### PR TITLE
Move functional tests docs into docs folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
     - main
+    paths-ignore:
+    - 'docs/**'
+    - 'README.md'
+    - 'LICENSE'
   pull_request:
     branches:
     - main
+    paths-ignore:
+    - 'docs/**'
+    - 'README.md'
+    - 'LICENSE'
 
 jobs:
   build:
@@ -51,7 +59,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - name: Docker build & push
       uses: docker/build-push-action@v2
       with:

--- a/README.md
+++ b/README.md
@@ -3,17 +3,3 @@
 [![Build](https://github.com/DFE-Digital/qualified-teachers-api/actions/workflows/build.yml/badge.svg)](https://github.com/DFE-Digital/qualified-teachers-api/actions/workflows/build.yml)
 
 Provides a restful API for integrating with the Database of Qualified Teacher CRM
-
-## Running functional tests
-
-The functional test project is at `tests/DqtApi.FunctionalTests/`.
-
-When run in development mode (e.g. from Visual Studio) the project will launch the main API project (`src/DqtApi/`) and use that instance as the target for the tests i.e. `http://localhost:5000`.
-
-Secrets and test data come from [User Secrets](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-5.0&tabs=windows) with ID `DqtApiFunctionalTests`. Ask a developer for a copy of the secrets.
-
-### Running tests against the EAPIM implementation
-
-There is a PowerShell script that will run a subset of the functional tests against the legacy API implementation hosted on EAPIM. The script is at `tests/DqtApi.FunctionalTests/TestApim.ps1`.
-
-The script requires endpoints and test data from User Secrets with ID `DqtApiApimIntegrationTests`. Ask a developer for a copy of the secrets.

--- a/docs/running-functional-tests.md
+++ b/docs/running-functional-tests.md
@@ -1,0 +1,13 @@
+# Running functional tests
+
+The functional test project is at `tests/DqtApi.FunctionalTests/`.
+
+When run in development mode (e.g. from Visual Studio) the project will launch the main API project (`src/DqtApi/`) and use that instance as the target for the tests i.e. `http://localhost:5000`.
+
+Secrets and test data come from [User Secrets](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-5.0&tabs=windows) with ID `DqtApiFunctionalTests`. Ask a developer for a copy of the secrets.
+
+## Running tests against the EAPIM implementation
+
+There is a PowerShell script that will run a subset of the functional tests against the legacy API implementation hosted on EAPIM. The script is at `tests/DqtApi.FunctionalTests/TestApim.ps1`.
+
+The script requires endpoints and test data from User Secrets with ID `DqtApiApimIntegrationTests`. Ask a developer for a copy of the secrets.


### PR DESCRIPTION
# Description

Moves the docs on running the functional tests into the docs folder so it will be available in the tech docs site.

Also amends the build pipeline so it will not be triggered when only the docs have changed.

## Link to Trello Card

N/A
