### PR TITLE
Add dependabot config for the app itself and GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  — package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: 'daily'
+
+  — package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
# Description

Sets up dependabot for the API and for GitHub actions.

By updating dependencies regularly we stay on top of security updates and reduce the chance of pain that comes with larger, less frequent dependency updates.

List any dependencies that are required for this change.

## Link to Trello Card

N/A