### PR TITLE
Expose PAAS service configuration to app

### DIFF
--- a/src/DqtApi/Configuration/EnvironmentVariableJsonConfigurationSource.cs
+++ b/src/DqtApi/Configuration/EnvironmentVariableJsonConfigurationSource.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+
+namespace DqtApi.Configuration
+{
+    /// <summary>
+    /// Represents an environment variable with JSON contents as an <see cref="IConfigurationSource"/>.
+    /// </summary>
+    public class EnvironmentVariableJsonConfigurationSource : IConfigurationSource
+    {
+        /// <summary>
+        /// The prefix to add to configuration keys.
+        /// </summary>
+        public string ConfigurationKeyPrefix { get; set; }
+
+        /// <summary>
+        /// The environment variable to read JSON from.
+        /// </summary>
+        public string EnvironmentVariableName { get; set; }
+
+        /// <inheritdoc/>
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            if (string.IsNullOrEmpty(EnvironmentVariableName))
+            {
+                throw new Exception($"{nameof(EnvironmentVariableName)} must be specified.");
+            }
+
+            return new WrapperSource(this).Build(builder);
+        }
+
+        private class WrapperSource : JsonStreamConfigurationSource
+        {
+            public WrapperSource(EnvironmentVariableJsonConfigurationSource source)
+            {
+                var envVar = Environment.GetEnvironmentVariable(source.EnvironmentVariableName) ?? string.Empty;
+                var envVarBytes = Encoding.ASCII.GetBytes(envVar);
+                Stream = new MemoryStream(envVarBytes);
+
+                ConfigurationKeyPrefix = source.ConfigurationKeyPrefix?.TrimEnd(':');  // ':' == ConfigurationPath.KeyDelimiter
+            }
+
+            public string ConfigurationKeyPrefix { get; }
+
+            public EnvironmentVariableJsonConfigurationSource Source { get; }
+
+            public override IConfigurationProvider Build(IConfigurationBuilder builder) => new WrapperProvider(this);
+        }
+
+        private class WrapperProvider : JsonStreamConfigurationProvider
+        {
+            private readonly WrapperSource _source;
+
+            public WrapperProvider(WrapperSource source) : base(source)
+            {
+                _source = source;
+            }
+
+            public override void Load()
+            {
+                base.Load();
+
+                if (!string.IsNullOrEmpty(_source.ConfigurationKeyPrefix))
+                {
+                    foreach (var key in Data.Keys.ToArray())
+                    {
+                        var prefixedKey = $"{_source.ConfigurationKeyPrefix}:{key}";
+                        Data[prefixedKey] = Data[key];
+                        Data.Remove(key);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using DqtApi.Configuration;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace DqtApi
 {
@@ -18,6 +13,14 @@ namespace DqtApi
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(config =>
+                {
+                    config.Add(new EnvironmentVariableJsonConfigurationSource()
+                    {
+                        ConfigurationKeyPrefix = "PaasServices",
+                        EnvironmentVariableName = "VCAP_SERVICES"
+                    });
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();


### PR DESCRIPTION
# Description

PAAS exposes information about connected services in a JSON-encoded environment variable - VCAP_SERVICES. This change makes the configuration within that variable available under the PaasServices configuration key within the same `IConfiguration` abstraction we use for existing configuration.

## Link to Trello Card

## How should a reviewer approach the PR? (optional)
