### PR TITLE
Simplify passing sensitive configuration to application in PAAS

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -96,10 +96,6 @@ In addition to the `TFSTATE-CONTAINER-ACCESS-KEY` secret, `PAAS-USER` and `PAAS-
 
 ### Application secrets
 
-Any secrets in the Key Vault prefixed with 'APP--' will be passed through to the application via environment variables (with the 'APP--' prefix removed).
-In addition, since Key Vault does not support the '\__' delimiter expected by the .NET Configuration system, '--' should be used as a delimiter.
-Any '--' delimiters will be swapped for '__' by Terraform.
+Application config is stored in a JSON-encoded Key Vault secret named 'APP-CONFIG'.
 
-#### Example
-
-A secret named 'APP--ApiClients--client1--ApiKey' is exposed to the app as an environment variable 'ApiClient__client1__ApiKey' and can be retrieved in the app using `Configuration["ApiClients:client1:ApiKey"]`.
+Our `AddJsonEnvironmentVariable` configuration extension is used to read the environment variable, decode its contents then set configuration keys appropriately.

--- a/src/DqtApi/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/DqtApi/Configuration/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.Extensions.Configuration;
+
+namespace DqtApi.Configuration
+{
+    public static class ConfigurationBuilderExtensions
+    {
+        public static IConfigurationBuilder AddJsonEnvironmentVariable(
+            this IConfigurationBuilder builder,
+            string environmentVariableName,
+            string configurationKeyPrefix = null)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (string.IsNullOrEmpty(environmentVariableName))
+            {
+                throw new ArgumentException("Environment variable name must be specified.", nameof(environmentVariableName));
+            }
+
+            return builder.Add(new EnvironmentVariableJsonConfigurationSource()
+            {
+                EnvironmentVariableName = environmentVariableName,
+                ConfigurationKeyPrefix = configurationKeyPrefix
+            });
+        }
+    }
+}

--- a/src/DqtApi/Configuration/EnvironmentVariableJsonConfigurationSource.cs
+++ b/src/DqtApi/Configuration/EnvironmentVariableJsonConfigurationSource.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+
+namespace DqtApi.Configuration
+{
+    /// <summary>
+    /// Represents an environment variable with JSON contents as an <see cref="IConfigurationSource"/>.
+    /// </summary>
+    public class EnvironmentVariableJsonConfigurationSource : IConfigurationSource
+    {
+        /// <summary>
+        /// The prefix to add to configuration keys.
+        /// </summary>
+        public string ConfigurationKeyPrefix { get; set; }
+
+        /// <summary>
+        /// The environment variable to read JSON from.
+        /// </summary>
+        public string EnvironmentVariableName { get; set; }
+
+        /// <inheritdoc/>
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            if (string.IsNullOrEmpty(EnvironmentVariableName))
+            {
+                throw new Exception($"{nameof(EnvironmentVariableName)} must be specified.");
+            }
+
+            return new WrapperSource(this).Build(builder);
+        }
+
+        private class WrapperSource : JsonStreamConfigurationSource
+        {
+            public WrapperSource(EnvironmentVariableJsonConfigurationSource source)
+            {
+                var envVar = Environment.GetEnvironmentVariable(source.EnvironmentVariableName) ?? string.Empty;
+                var envVarBytes = Encoding.ASCII.GetBytes(envVar);
+                Stream = new MemoryStream(envVarBytes);
+
+                ConfigurationKeyPrefix = source.ConfigurationKeyPrefix?.TrimEnd(':');  // ':' == ConfigurationPath.KeyDelimiter
+            }
+
+            public string ConfigurationKeyPrefix { get; }
+
+            public override IConfigurationProvider Build(IConfigurationBuilder builder) => new WrapperProvider(this);
+        }
+
+        private class WrapperProvider : JsonStreamConfigurationProvider
+        {
+            private readonly WrapperSource _source;
+
+            public WrapperProvider(WrapperSource source) : base(source)
+            {
+                _source = source;
+            }
+
+            public override void Load()
+            {
+                base.Load();
+
+                if (!string.IsNullOrEmpty(_source.ConfigurationKeyPrefix))
+                {
+                    foreach (var key in Data.Keys.ToArray())
+                    {
+                        var prefixedKey = $"{_source.ConfigurationKeyPrefix}:{key}";
+                        Data[prefixedKey] = Data[key];
+                        Data.Remove(key);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using DqtApi.Configuration;
 using DqtApi.Security;
 using FluentValidation.AspNetCore;
 using MediatR;
@@ -19,6 +20,12 @@ namespace DqtApi
         public static void Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
+
+            if (builder.Environment.IsProduction())
+            {
+                builder.Configuration.AddJsonEnvironmentVariable("AppConfig");
+            }
+
             var services = builder.Services;
             var env = builder.Environment;
             var configuration = builder.Configuration;

--- a/terraform/api-app.tf
+++ b/terraform/api-app.tf
@@ -1,10 +1,6 @@
 locals {
-  # Any Key Vault secret prefixed 'APP--' gets exposed to the app as an environment variable.
-  # The ASP.NET Core configuration system expects keys with '__' separators but Key Vault doesn't support that
-  # so we use '--' instead in the secret name.
   api_app_config = {
-    for k, v in data.azurerm_key_vault_secret.secrets :
-    replace(substr(k, length("APP--"), -1), "--", "__") => v.value if substr(k, 0, length("APP--")) == "APP--"
+    AppConfig = data.azurerm_key_vault_secret.secrets["APP-CONFIG"].value
   }
 }
 


### PR DESCRIPTION
# Description

Use a single JSON-encoded Key Vault secret for storing application config.

This removes the need for some complex Terraform gymnastics mapping multiple Key Vault secrets through to the app by convention. It should also prevent a mass of secrets accumulating in Key Vault and make them simpler to manage.

## Link to Trello Card

https://trello.com/c/evDyTEmq/94-use-a-single-key-vault-secret-for-app-config
