### PR TITLE
Ensure OWASP scan can authenticate against API

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -21,6 +21,9 @@ outputs:
   environment_url:
     description: 'The base URL for the deployed environment'
     value: ${{ steps.terraform.outputs.url }}
+  test_user_api_key:
+    description: 'An API key of a client for running tests'
+    value: ${{ steps.get_secrets.outputs.TEST-API-KEY }}
 
 runs:
   using: composite
@@ -50,7 +53,7 @@ runs:
       id: get_secrets
       with:
         keyvault: ${{ steps.keyvault.outputs.name }}
-        secrets: 'TFSTATE-CONTAINER-ACCESS-KEY'
+        secrets: 'TFSTATE-CONTAINER-ACCESS-KEY,TEST-API-KEY'
 
     - uses: hashicorp/setup-terraform@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,9 +135,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Create config file
+      run: |
+        echo "replacer.full_list(0).description=auth1" >> options.prop
+        echo "replacer.full_list(0).enabled=true" >> options.prop
+        echo "replacer.full_list(0).matchtype=REQ_HEADER" >> options.prop
+        echo "replacer.full_list(0).matchstr=Authorization" >> options.prop
+        echo "replacer.full_list(0).regex=false" >> options.prop
+        echo "replacer.full_list(0).replacement=Bearer ${{ needs.deploy_dev.outputs.test_user_api_key }}" >> options.prop
+
     - uses: zaproxy/action-api-scan@v0.1.0
       with:
-        target: ${{ needs.deploy_dev.outputs.environment_url}}swagger/v1/swagger.json
+        target: ${{ needs.deploy_dev.outputs.environment_url }}swagger/v1/swagger.json
         format: openapi
         allow_issue_writing: false
         fail_action: true
+        cmd_options: '-z "-configFile /zap/wrk/options.prop"'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,3 +140,4 @@ jobs:
         target: ${{ needs.deploy_dev.outputs.environment_url}}swagger/v1/swagger.json
         format: openapi
         allow_issue_writing: false
+        fail_action: true


### PR DESCRIPTION
# Description

Give the OWASP scan valid API credentials so it can do more thorough checking.

## Link to Trello Card

https://trello.com/c/94Sj3Sta/80-add-owasp-api-test-to-ci-pipeline