### PR TITLE
Add an exception filter to map CRM service protection errors to a 429 response

### DIFF
--- a/src/DqtApi/Filters/CrmServiceProtectionFaultExceptionFilter.cs
+++ b/src/DqtApi/Filters/CrmServiceProtectionFaultExceptionFilter.cs
@@ -1,0 +1,35 @@
+﻿using System.ServiceModel;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+
+namespace DqtApi.Filters
+{
+    public class CrmServiceProtectionFaultExceptionFilter : IExceptionFilter
+    {
+        public void OnException(ExceptionContext context)
+        {
+            if (context.Exception is FaultException<OrganizationServiceFault> fault)
+            {
+                // https://docs.microsoft.com/en-us/powerapps/developer/data-platform/api-limits#service-protection-api-limit-errors-returned
+
+                switch (fault.Detail.ErrorCode)
+                {
+                    case -2147015902:  // Number of requests
+                    case -2147015903:  // Execution time
+                    case -2147015898:  // Concurrent requests
+                        context.Result = new StatusCodeResult(StatusCodes.Status429TooManyRequests);
+                        context.ExceptionHandled = true;
+
+                        var logger = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger<CrmServiceProtectionFaultExceptionFilter>();
+                        logger.LogWarning("Hit CRM service limits; error code: {ErrorCode}", fault.Detail.ErrorCode);
+
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -63,6 +63,7 @@ namespace DqtApi
                 {
                     options.Filters.Add(new AuthorizeFilter());
                     options.Filters.Add(new ProducesJsonOrProblemAttribute());
+                    options.Filters.Add(new CrmServiceProtectionFaultExceptionFilter());
                 })
                 .AddFluentValidation(fv =>
                 {

--- a/tests/DqtApi.Tests/ApiFixture.cs
+++ b/tests/DqtApi.Tests/ApiFixture.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using DqtApi.DAL;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,6 +35,9 @@ namespace DqtApi.Tests
 
             builder.ConfigureServices(services =>
             {
+                // Add controllers defined in this test assembly
+                services.AddMvc().AddApplicationPart(typeof(ApiFixture).Assembly);
+
                 services.AddSingleton(OrganizationService.Object);
                 services.AddSingleton<IDataverseAdaptor, DataverseAdaptor>();
 

--- a/tests/DqtApi.Tests/Filters/CrmServiceProtectionFaultExceptionFilterTests.cs
+++ b/tests/DqtApi.Tests/Filters/CrmServiceProtectionFaultExceptionFilterTests.cs
@@ -1,0 +1,58 @@
+﻿using System.ServiceModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Xrm.Sdk;
+using Xunit;
+
+namespace DqtApi.Tests.Filters
+{
+    public class CrmServiceProtectionFaultExceptionFilterTests : ApiTestBase
+    {
+        public CrmServiceProtectionFaultExceptionFilterTests(ApiFixture apiFixture) : base(apiFixture)
+        {
+        }
+
+        [Theory]
+        [InlineData("number_of_requests")]
+        [InlineData("execution_time")]
+        [InlineData("concurrent_requests")]
+        public async Task Given_a_service_protection_fault_is_thrown_return_a_429_response(string testEndpoint)
+        {
+            var response = await HttpClient.GetAsync($"CrmServiceProtectionFaultExceptionFilterTests/{testEndpoint}");
+
+            Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+        }
+    }
+
+    [Route("CrmServiceProtectionFaultExceptionFilterTests")]
+    public class CrmServiceProtectionFaultExceptionFilterTestsController : Controller
+    {
+        [HttpGet("number_of_requests")]
+        public IActionResult ThrowsNumberOfRequestsError()
+        {
+            throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault()
+            {
+                ErrorCode = -2147015902
+            });
+        }
+
+        [HttpGet("execution_time")]
+        public IActionResult ThrowsExecutionTimeError()
+        {
+            throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault()
+            {
+                ErrorCode = -2147015903
+            });
+        }
+
+        [HttpGet("concurrent_requests")]
+        public IActionResult ConcurrentRequests()
+        {
+            throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault()
+            {
+                ErrorCode = -2147015898
+            });
+        }
+    }
+}


### PR DESCRIPTION
Forward any API limit-related errors to our API consumers

https://docs.microsoft.com/en-us/powerapps/developer/data-platform/api-limits#service-protection-api-limit-errors-returned