### PR TITLE
Tidy generated Swagger spec for Get Teacher operation

### DIFF
--- a/src/DqtApi/Models/GetTeacherRequest.cs
+++ b/src/DqtApi/Models/GetTeacherRequest.cs
@@ -11,7 +11,7 @@ namespace DqtApi.Models
     {        
         public string TRN { get; set; }
 
-        [FromQuery, SwaggerParameter(Required = true),ModelBinder(typeof(ModelBinders.DateTimeReverseOrderBinder))]
+        [FromQuery, SwaggerParameter(Required = true), SwaggerSchema(Format = "date"), ModelBinder(typeof(ModelBinders.DateTimeReverseOrderBinder))]
         public DateTime? BirthDate { get; set; }
 
         [FromQuery(Name = "nino")]

--- a/src/DqtApi/Models/GetTeacherRequest.cs
+++ b/src/DqtApi/Models/GetTeacherRequest.cs
@@ -8,10 +8,11 @@ using Swashbuckle.AspNetCore.Annotations;
 namespace DqtApi.Models
 {
     public class GetTeacherRequest
-    {        
+    {
+        [FromRoute(Name = "trn")]
         public string TRN { get; set; }
 
-        [FromQuery, SwaggerParameter(Required = true), SwaggerSchema(Format = "date"), ModelBinder(typeof(ModelBinders.DateTimeReverseOrderBinder))]
+        [FromQuery(Name = "birthdate"), SwaggerParameter(Required = true), SwaggerSchema(Format = "date"), ModelBinder(typeof(ModelBinders.DateTimeReverseOrderBinder))]
         public DateTime? BirthDate { get; set; }
 
         [FromQuery(Name = "nino")]

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -79,6 +79,20 @@ namespace DqtApi
                 c.EnableAnnotations();
                 c.OperationFilter<ResponseContentTypeOperationFilter>();
 
+                c.CustomSchemaIds(type =>
+                {
+                    // Generated CRM models for custom entities have a weird type name; fix that up here
+                    // e.g. for the 'dfeta_inductionState' type use 'InductionState' in the API spec
+
+                    if (type.Name.StartsWith("dfeta_"))
+                    {
+                        var prefixTrimmedTypeName = type.Name.Substring("dfeta_".Length);
+                        return prefixTrimmedTypeName[0..1].ToUpper() + prefixTrimmedTypeName[1..];
+                    }
+
+                    return type.Name;
+                });
+
                 c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme()
                 {
                     In = ParameterLocation.Header,

--- a/tests/DqtApi.Tests/Operations/GetTeacherTests.cs
+++ b/tests/DqtApi.Tests/Operations/GetTeacherTests.cs
@@ -24,7 +24,7 @@ namespace DqtApi.Tests
 
             var response = await HttpClient.SendAsync(request);
 
-            await AssertEx.ResponseIsProblemDetails(response, expectedError: StringResources.ErrorMessages_TRNMustBe7Digits, nameof(Models.GetTeacherRequest.TRN));
+            await AssertEx.ResponseIsProblemDetails(response, expectedError: StringResources.ErrorMessages_TRNMustBe7Digits, "trn");
         }
 
         [Theory]
@@ -36,7 +36,7 @@ namespace DqtApi.Tests
 
             var response = await HttpClient.SendAsync(request);
 
-            await AssertEx.ResponseIsProblemDetails(response, expectedError: StringResources.ErrorMessages_InvalidBirthDate, nameof(Models.GetTeacherRequest.BirthDate));
+            await AssertEx.ResponseIsProblemDetails(response, expectedError: StringResources.ErrorMessages_InvalidBirthDate, "birthdate");
         }
 
         //[Fact(Skip = "not implemented")]


### PR DESCRIPTION
# Description

Tweaks the generated API spec for the Get Teacher operation to tidy some schema names and to align parameter names with EAPIM API implementation.

## Link to Trello Card

https://trello.com/c/Lh8Sg0RN/113-build-the-get-teacher-operation-endpoint
