### PR TITLE
Add PAAS environment details to Prometheus metrics

### DIFF
--- a/src/DqtApi/Configuration/MetricLabels.cs
+++ b/src/DqtApi/Configuration/MetricLabels.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Configuration;
+using Prometheus;
+
+namespace DqtApi.Configuration
+{
+    public static class MetricLabels
+    {
+        public static void ConfigureLabels(IConfiguration configuration)
+        {
+            if (configuration["CF_INSTANCE_INDEX"] != null)
+            {
+                Metrics.DefaultRegistry.SetStaticLabels(new()
+                {
+                    { "app", configuration["VCAP_APPLICATION:application_name"] },
+                    { "organisation", configuration["VCAP_APPLICATION:organization_name"] },
+                    { "space", configuration["VCAP_APPLICATION:space_name"] },
+                    { "instance", configuration["CF_INSTANCE_INDEX"] }
+                });
+            }
+        }
+    }
+}

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -39,7 +39,8 @@ namespace DqtApi
             {
                 builder.Configuration
                     .AddJsonEnvironmentVariable("AppConfig")
-                    .AddJsonEnvironmentVariable("VCAP_SERVICES", configurationKeyPrefix: "VCAP_SERVICES");
+                    .AddJsonEnvironmentVariable("VCAP_SERVICES", configurationKeyPrefix: "VCAP_SERVICES")
+                    .AddJsonEnvironmentVariable("VCAP_APPLICATION", configurationKeyPrefix: "VCAP_APPLICATION");
             }
 
             var services = builder.Services;
@@ -166,7 +167,9 @@ namespace DqtApi
                 services.AddSingleton<IOrganizationServiceAsync>(GetCrmServiceClient());
                 services.AddSingleton<IDataverseAdaptor, DataverseAdaptor>();
             }
-         
+
+            MetricLabels.ConfigureLabels(builder.Configuration);
+
             var app = builder.Build();            
 
             app.Use((ctx, next) =>

--- a/tests/DqtApi.FunctionalTests/DqtApi.FunctionalTests.csproj
+++ b/tests/DqtApi.FunctionalTests/DqtApi.FunctionalTests.csproj
@@ -38,7 +38,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../../src/DqtApi/Configuration/**/*.cs">
+    <Compile Include="../../src/DqtApi/Configuration/ConfigurationBuilderExtensions.cs">
+      <Link>\Configuration\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="../../src/DqtApi/Configuration/EnvironmentVariableJsonConfigurationSource.cs">
       <Link>\Configuration\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>


### PR DESCRIPTION
# Description

Defines labels for all Prometheus metrics for the PAAS app name, org, space and app instance.

## Link to Trello Card

https://trello.com/c/mlmPAocF/111-set-up-prometheus-for-tra-services
