### PR TITLE
Move CRM and SQL types under a root-level Models namespace

### DIFF
--- a/GenerateCrmModels.ps1
+++ b/GenerateCrmModels.ps1
@@ -27,8 +27,8 @@ $connectionString = "AuthType=ClientSecret;url=${crmUrl};ClientId=${crmClientId}
 
 $coreToolsFolder = (Join-Path $PSScriptRoot tools coretools)
 
-$namespace = "DqtApi.Models"
-$entitiesOutput = Join-Path -Path $PSScriptRoot -ChildPath src DqtApi Models GeneratedCode.cs
+$namespace = "DqtApi.DataStore.Crm.Models"
+$entitiesOutput = Join-Path -Path $PSScriptRoot -ChildPath src DqtApi DataStore Crm Models GeneratedCode.cs
 mkdir (Split-Path $entitiesOutput) -Force | Out-Null
 
 # entities
@@ -46,8 +46,7 @@ $crmSvcUtil = Join-Path -Path $coreToolsFolder -ChildPath "CrmSvcUtil.exe"
     /metadataproviderservice:"DLaB.CrmSvcUtilExtensions.Entity.MetadataProviderService,DLaB.CrmSvcUtilExtensions"
 
 # option sets
-$optionSetsOutput = Join-Path -Path $PSScriptRoot -ChildPath src DqtApi Models GeneratedOptionSets.cs
-$crmSvcUtil = Join-Path -Path $coreToolsFolder -ChildPath "CrmSvcUtil.exe"
+$optionSetsOutput = Join-Path -Path $PSScriptRoot -ChildPath src DqtApi DataStore Crm Models GeneratedOptionSets.cs
 & $crmSvcUtil `
     /connectionstring:${connectionString} `
     /out:${optionSetsOutput} `
@@ -57,4 +56,4 @@ $crmSvcUtil = Join-Path -Path $coreToolsFolder -ChildPath "CrmSvcUtil.exe"
     /codegenerationservice:"DLaB.CrmSvcUtilExtensions.OptionSet.CustomCodeGenerationService,DLaB.CrmSvcUtilExtensions" `
     /codewriterfilter:"DLaB.CrmSvcUtilExtensions.OptionSet.CodeWriterFilterService,DLaB.CrmSvcUtilExtensions" `
     /namingservice:"DLaB.CrmSvcUtilExtensions.NamingService,DLaB.CrmSvcUtilExtensions" `
-    /metadataproviderservice:"DLaB.CrmSvcUtilExtensions.BaseMetadataProviderService,DLaB.CrmSvcUtilExtensions" 
+    /metadataproviderservice:"DLaB.CrmSvcUtilExtensions.BaseMetadataProviderService,DLaB.CrmSvcUtilExtensions"

--- a/src/DqtApi/DataStore/Crm/DataCollectionExtensions.cs
+++ b/src/DqtApi/DataStore/Crm/DataCollectionExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xrm.Sdk;
 
-namespace DqtApi.DAL
+namespace DqtApi.DataStore.Crm
 {
     internal static class DataCollectionExtensions
     {

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -4,19 +4,19 @@ using System.Linq;
 using System.Net;
 using System.ServiceModel;
 using System.Threading.Tasks;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.PowerPlatform.Dataverse.Client.Utils;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 
-namespace DqtApi.DAL
+namespace DqtApi.DataStore.Crm
 {
-    public class DataverseAdaptor : IDataverseAdaptor
+    public class DataverseAdapter : IDataverseAdapter
     {
         private readonly IOrganizationServiceAsync _service;
 
-        public DataverseAdaptor(IOrganizationServiceAsync organizationServiceAsync)
+        public DataverseAdapter(IOrganizationServiceAsync organizationServiceAsync)
         {
             _service = organizationServiceAsync;
         }

--- a/src/DqtApi/DataStore/Crm/FormattedValueCollectionExtensions.cs
+++ b/src/DqtApi/DataStore/Crm/FormattedValueCollectionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Xrm.Sdk;
 
-namespace DqtApi.DAL
+namespace DqtApi.DataStore.Crm
 {
     internal static class FormattedValueCollectionExtensions
     {

--- a/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 
-namespace DqtApi.DAL
+namespace DqtApi.DataStore.Crm
 {
-    public interface IDataverseAdaptor
+    public interface IDataverseAdapter
     {
         Task<IEnumerable<Account>> GetIttProviders();
 

--- a/src/DqtApi/DataStore/Crm/Models/GeneratedCode.cs
+++ b/src/DqtApi/DataStore/Crm/Models/GeneratedCode.cs
@@ -12,7 +12,7 @@
 [assembly: Microsoft.Xrm.Sdk.Client.ProxyTypesAssemblyAttribute()]
 [assembly: System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.95")]
 
-namespace DqtApi.Models
+namespace DqtApi.DataStore.Crm.Models
 {
 	
 	
@@ -161,7 +161,7 @@ namespace DqtApi.Models
 		/// Status of the account.
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
-		public System.Nullable<DqtApi.Models.AccountState> StateCode
+		public System.Nullable<DqtApi.DataStore.Crm.Models.AccountState> StateCode
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
@@ -169,7 +169,7 @@ namespace DqtApi.Models
 				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
 				if ((optionSet != null))
 				{
-					return ((DqtApi.Models.AccountState)(System.Enum.ToObject(typeof(DqtApi.Models.AccountState), optionSet.Value)));
+					return ((DqtApi.DataStore.Crm.Models.AccountState)(System.Enum.ToObject(typeof(DqtApi.DataStore.Crm.Models.AccountState), optionSet.Value)));
 				}
 				else
 				{
@@ -196,18 +196,18 @@ namespace DqtApi.Models
 		/// 1:N account_master_account
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.Account> Referencedaccount_master_account
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.Account> Referencedaccount_master_account
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.Account>("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referenced);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.Account>("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referenced);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencedaccount_master_account");
-				this.SetRelatedEntities<DqtApi.Models.Account>("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.Account>("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
 				this.OnPropertyChanged("Referencedaccount_master_account");
 			}
 		}
@@ -216,18 +216,18 @@ namespace DqtApi.Models
 		/// 1:N account_parent_account
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.Account> Referencedaccount_parent_account
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.Account> Referencedaccount_parent_account
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.Account>("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referenced);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.Account>("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referenced);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencedaccount_parent_account");
-				this.SetRelatedEntities<DqtApi.Models.Account>("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.Account>("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
 				this.OnPropertyChanged("Referencedaccount_parent_account");
 			}
 		}
@@ -236,18 +236,18 @@ namespace DqtApi.Models
 		/// 1:N contact_customer_accounts
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("contact_customer_accounts")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.Contact> contact_customer_accounts
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.Contact> contact_customer_accounts
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.Contact>("contact_customer_accounts", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("contact_customer_accounts", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("contact_customer_accounts");
-				this.SetRelatedEntities<DqtApi.Models.Contact>("contact_customer_accounts", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("contact_customer_accounts", null, value);
 				this.OnPropertyChanged("contact_customer_accounts");
 			}
 		}
@@ -256,18 +256,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_account_dfeta_initialteachertraining
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_account_dfeta_initialteachertraining")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_initialteachertraining> dfeta_account_dfeta_initialteachertraining
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining> dfeta_account_dfeta_initialteachertraining
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_account_dfeta_initialteachertraining", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_account_dfeta_initialteachertraining", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_account_dfeta_initialteachertraining");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_account_dfeta_initialteachertraining", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_account_dfeta_initialteachertraining", null, value);
 				this.OnPropertyChanged("dfeta_account_dfeta_initialteachertraining");
 			}
 		}
@@ -276,18 +276,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_account_dfeta_qualification_he
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_account_dfeta_qualification_he")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_qualification> dfeta_account_dfeta_qualification_he
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_qualification> dfeta_account_dfeta_qualification_he
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_qualification>("dfeta_account_dfeta_qualification_he", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qualification>("dfeta_account_dfeta_qualification_he", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_account_dfeta_qualification_he");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_qualification>("dfeta_account_dfeta_qualification_he", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qualification>("dfeta_account_dfeta_qualification_he", null, value);
 				this.OnPropertyChanged("dfeta_account_dfeta_qualification_he");
 			}
 		}
@@ -297,18 +297,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("masterid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
-		public DqtApi.Models.Account Referencingaccount_master_account
+		public DqtApi.DataStore.Crm.Models.Account Referencingaccount_master_account
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Account>("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referencing);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referencing);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencingaccount_master_account");
-				this.SetRelatedEntity<DqtApi.Models.Account>("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("account_master_account", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
 				this.OnPropertyChanged("Referencingaccount_master_account");
 			}
 		}
@@ -318,18 +318,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("parentaccountid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
-		public DqtApi.Models.Account Referencingaccount_parent_account
+		public DqtApi.DataStore.Crm.Models.Account Referencingaccount_parent_account
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Account>("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referencing);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referencing);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencingaccount_parent_account");
-				this.SetRelatedEntity<DqtApi.Models.Account>("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("account_parent_account", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
 				this.OnPropertyChanged("Referencingaccount_parent_account");
 			}
 		}
@@ -339,18 +339,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("primarycontactid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("account_primary_contact")]
-		public DqtApi.Models.Contact account_primary_contact
+		public DqtApi.DataStore.Crm.Models.Contact account_primary_contact
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("account_primary_contact", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("account_primary_contact", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("account_primary_contact");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("account_primary_contact", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("account_primary_contact", null, value);
 				this.OnPropertyChanged("account_primary_contact");
 			}
 		}
@@ -635,7 +635,7 @@ namespace DqtApi.Models
 		/// Status of the contact.
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
-		public System.Nullable<DqtApi.Models.ContactState> StateCode
+		public System.Nullable<DqtApi.DataStore.Crm.Models.ContactState> StateCode
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
@@ -643,7 +643,7 @@ namespace DqtApi.Models
 				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
 				if ((optionSet != null))
 				{
-					return ((DqtApi.Models.ContactState)(System.Enum.ToObject(typeof(DqtApi.Models.ContactState), optionSet.Value)));
+					return ((DqtApi.DataStore.Crm.Models.ContactState)(System.Enum.ToObject(typeof(DqtApi.DataStore.Crm.Models.ContactState), optionSet.Value)));
 				}
 				else
 				{
@@ -670,18 +670,18 @@ namespace DqtApi.Models
 		/// 1:N account_primary_contact
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("account_primary_contact")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.Account> account_primary_contact
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.Account> account_primary_contact
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.Account>("account_primary_contact", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.Account>("account_primary_contact", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("account_primary_contact");
-				this.SetRelatedEntities<DqtApi.Models.Account>("account_primary_contact", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.Account>("account_primary_contact", null, value);
 				this.OnPropertyChanged("account_primary_contact");
 			}
 		}
@@ -690,18 +690,18 @@ namespace DqtApi.Models
 		/// 1:N contact_customer_contacts
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.Contact> Referencedcontact_customer_contacts
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.Contact> Referencedcontact_customer_contacts
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.Contact>("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referenced);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referenced);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencedcontact_customer_contacts");
-				this.SetRelatedEntities<DqtApi.Models.Contact>("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
 				this.OnPropertyChanged("Referencedcontact_customer_contacts");
 			}
 		}
@@ -710,18 +710,18 @@ namespace DqtApi.Models
 		/// 1:N contact_master_contact
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.Contact> Referencedcontact_master_contact
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.Contact> Referencedcontact_master_contact
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.Contact>("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencedcontact_master_contact");
-				this.SetRelatedEntities<DqtApi.Models.Contact>("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
 				this.OnPropertyChanged("Referencedcontact_master_contact");
 			}
 		}
@@ -730,18 +730,18 @@ namespace DqtApi.Models
 		/// 1:N contact_parent_contact
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.Contact> Referencedcontact_parent_contact
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.Contact> Referencedcontact_parent_contact
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.Contact>("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencedcontact_parent_contact");
-				this.SetRelatedEntities<DqtApi.Models.Contact>("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
 				this.OnPropertyChanged("Referencedcontact_parent_contact");
 			}
 		}
@@ -750,18 +750,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_contact_dfeta_induction
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_induction")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_induction> dfeta_contact_dfeta_induction
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_induction> dfeta_contact_dfeta_induction
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_induction>("dfeta_contact_dfeta_induction", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_induction>("dfeta_contact_dfeta_induction", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_induction");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_induction>("dfeta_contact_dfeta_induction", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_induction>("dfeta_contact_dfeta_induction", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_induction");
 			}
 		}
@@ -770,18 +770,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_contact_dfeta_induction1
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_induction1")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_induction> dfeta_contact_dfeta_induction1
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_induction> dfeta_contact_dfeta_induction1
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_induction>("dfeta_contact_dfeta_induction1", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_induction>("dfeta_contact_dfeta_induction1", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_induction1");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_induction>("dfeta_contact_dfeta_induction1", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_induction>("dfeta_contact_dfeta_induction1", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_induction1");
 			}
 		}
@@ -790,18 +790,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_contact_dfeta_initialteachertraining
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_initialteachertraining")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_initialteachertraining> dfeta_contact_dfeta_initialteachertraining
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining> dfeta_contact_dfeta_initialteachertraining
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_contact_dfeta_initialteachertraining", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_contact_dfeta_initialteachertraining", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_initialteachertraining");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_contact_dfeta_initialteachertraining", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_contact_dfeta_initialteachertraining", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_initialteachertraining");
 			}
 		}
@@ -810,18 +810,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_contact_dfeta_initialteachertraining1
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_initialteachertraining1")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_initialteachertraining> dfeta_contact_dfeta_initialteachertraining1
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining> dfeta_contact_dfeta_initialteachertraining1
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_contact_dfeta_initialteachertraining1", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_contact_dfeta_initialteachertraining1", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_initialteachertraining1");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_contact_dfeta_initialteachertraining1", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_contact_dfeta_initialteachertraining1", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_initialteachertraining1");
 			}
 		}
@@ -830,18 +830,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_contact_dfeta_qtsregistration
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_qtsregistration")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_qtsregistration> dfeta_contact_dfeta_qtsregistration
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration> dfeta_contact_dfeta_qtsregistration
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_qtsregistration>("dfeta_contact_dfeta_qtsregistration", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration>("dfeta_contact_dfeta_qtsregistration", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_qtsregistration");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_qtsregistration>("dfeta_contact_dfeta_qtsregistration", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration>("dfeta_contact_dfeta_qtsregistration", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_qtsregistration");
 			}
 		}
@@ -850,18 +850,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_contact_dfeta_qtsregistration1
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_qtsregistration1")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_qtsregistration> dfeta_contact_dfeta_qtsregistration1
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration> dfeta_contact_dfeta_qtsregistration1
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_qtsregistration>("dfeta_contact_dfeta_qtsregistration1", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration>("dfeta_contact_dfeta_qtsregistration1", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_qtsregistration1");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_qtsregistration>("dfeta_contact_dfeta_qtsregistration1", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration>("dfeta_contact_dfeta_qtsregistration1", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_qtsregistration1");
 			}
 		}
@@ -870,18 +870,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_contact_dfeta_qualification
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_qualification")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_qualification> dfeta_contact_dfeta_qualification
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_qualification> dfeta_contact_dfeta_qualification
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_qualification>("dfeta_contact_dfeta_qualification", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qualification>("dfeta_contact_dfeta_qualification", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_qualification");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_qualification>("dfeta_contact_dfeta_qualification", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qualification>("dfeta_contact_dfeta_qualification", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_qualification");
 			}
 		}
@@ -891,18 +891,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("parentcustomerid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("contact_customer_accounts")]
-		public DqtApi.Models.Account contact_customer_accounts
+		public DqtApi.DataStore.Crm.Models.Account contact_customer_accounts
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Account>("contact_customer_accounts", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("contact_customer_accounts", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("contact_customer_accounts");
-				this.SetRelatedEntity<DqtApi.Models.Account>("contact_customer_accounts", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("contact_customer_accounts", null, value);
 				this.OnPropertyChanged("contact_customer_accounts");
 			}
 		}
@@ -912,18 +912,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("parentcustomerid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
-		public DqtApi.Models.Contact Referencingcontact_customer_contacts
+		public DqtApi.DataStore.Crm.Models.Contact Referencingcontact_customer_contacts
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referencing);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referencing);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencingcontact_customer_contacts");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("contact_customer_contacts", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
 				this.OnPropertyChanged("Referencingcontact_customer_contacts");
 			}
 		}
@@ -933,18 +933,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("masterid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
-		public DqtApi.Models.Contact Referencingcontact_master_contact
+		public DqtApi.DataStore.Crm.Models.Contact Referencingcontact_master_contact
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencingcontact_master_contact");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("contact_master_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
 				this.OnPropertyChanged("Referencingcontact_master_contact");
 			}
 		}
@@ -954,18 +954,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("parent_contactid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
-		public DqtApi.Models.Contact Referencingcontact_parent_contact
+		public DqtApi.DataStore.Crm.Models.Contact Referencingcontact_parent_contact
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("Referencingcontact_parent_contact");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("contact_parent_contact", Microsoft.Xrm.Sdk.EntityRole.Referencing, value);
 				this.OnPropertyChanged("Referencingcontact_parent_contact");
 			}
 		}
@@ -975,18 +975,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_qtsregistrationid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_qtsregistration_contact")]
-		public DqtApi.Models.dfeta_qtsregistration dfeta_dfeta_qtsregistration_contact
+		public DqtApi.DataStore.Crm.Models.dfeta_qtsregistration dfeta_dfeta_qtsregistration_contact
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.dfeta_qtsregistration>("dfeta_dfeta_qtsregistration_contact", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration>("dfeta_dfeta_qtsregistration_contact", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_qtsregistration_contact");
-				this.SetRelatedEntity<DqtApi.Models.dfeta_qtsregistration>("dfeta_dfeta_qtsregistration_contact", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration>("dfeta_dfeta_qtsregistration_contact", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_qtsregistration_contact");
 			}
 		}
@@ -1153,7 +1153,7 @@ namespace DqtApi.Models
 		/// Status of the Induction
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
-		public System.Nullable<DqtApi.Models.dfeta_inductionState> StateCode
+		public System.Nullable<DqtApi.DataStore.Crm.Models.dfeta_inductionState> StateCode
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
@@ -1161,7 +1161,7 @@ namespace DqtApi.Models
 				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
 				if ((optionSet != null))
 				{
-					return ((DqtApi.Models.dfeta_inductionState)(System.Enum.ToObject(typeof(DqtApi.Models.dfeta_inductionState), optionSet.Value)));
+					return ((DqtApi.DataStore.Crm.Models.dfeta_inductionState)(System.Enum.ToObject(typeof(DqtApi.DataStore.Crm.Models.dfeta_inductionState), optionSet.Value)));
 				}
 				else
 				{
@@ -1188,18 +1188,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_dfeta_induction_dfeta_qtsregistration
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_induction_dfeta_qtsregistration")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_qtsregistration> dfeta_dfeta_induction_dfeta_qtsregistration
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration> dfeta_dfeta_induction_dfeta_qtsregistration
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_qtsregistration>("dfeta_dfeta_induction_dfeta_qtsregistration", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration>("dfeta_dfeta_induction_dfeta_qtsregistration", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_induction_dfeta_qtsregistration");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_qtsregistration>("dfeta_dfeta_induction_dfeta_qtsregistration", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_qtsregistration>("dfeta_dfeta_induction_dfeta_qtsregistration", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_induction_dfeta_qtsregistration");
 			}
 		}
@@ -1209,18 +1209,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_personid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_induction")]
-		public DqtApi.Models.Contact dfeta_contact_dfeta_induction
+		public DqtApi.DataStore.Crm.Models.Contact dfeta_contact_dfeta_induction
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_induction", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_induction", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_induction");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_induction", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_induction", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_induction");
 			}
 		}
@@ -1230,18 +1230,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_requestedbyid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_induction1")]
-		public DqtApi.Models.Contact dfeta_contact_dfeta_induction1
+		public DqtApi.DataStore.Crm.Models.Contact dfeta_contact_dfeta_induction1
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_induction1", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_induction1", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_induction1");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_induction1", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_induction1", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_induction1");
 			}
 		}
@@ -1516,7 +1516,7 @@ namespace DqtApi.Models
 		/// Status of the Initial Teacher Training
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
-		public System.Nullable<DqtApi.Models.dfeta_initialteachertrainingState> StateCode
+		public System.Nullable<DqtApi.DataStore.Crm.Models.dfeta_initialteachertrainingState> StateCode
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
@@ -1524,7 +1524,7 @@ namespace DqtApi.Models
 				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
 				if ((optionSet != null))
 				{
-					return ((DqtApi.Models.dfeta_initialteachertrainingState)(System.Enum.ToObject(typeof(DqtApi.Models.dfeta_initialteachertrainingState), optionSet.Value)));
+					return ((DqtApi.DataStore.Crm.Models.dfeta_initialteachertrainingState)(System.Enum.ToObject(typeof(DqtApi.DataStore.Crm.Models.dfeta_initialteachertrainingState), optionSet.Value)));
 				}
 				else
 				{
@@ -1552,18 +1552,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_establishmentid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_account_dfeta_initialteachertraining")]
-		public DqtApi.Models.Account dfeta_account_dfeta_initialteachertraining
+		public DqtApi.DataStore.Crm.Models.Account dfeta_account_dfeta_initialteachertraining
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Account>("dfeta_account_dfeta_initialteachertraining", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("dfeta_account_dfeta_initialteachertraining", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_account_dfeta_initialteachertraining");
-				this.SetRelatedEntity<DqtApi.Models.Account>("dfeta_account_dfeta_initialteachertraining", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("dfeta_account_dfeta_initialteachertraining", null, value);
 				this.OnPropertyChanged("dfeta_account_dfeta_initialteachertraining");
 			}
 		}
@@ -1573,18 +1573,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_personid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_initialteachertraining")]
-		public DqtApi.Models.Contact dfeta_contact_dfeta_initialteachertraining
+		public DqtApi.DataStore.Crm.Models.Contact dfeta_contact_dfeta_initialteachertraining
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_initialteachertraining", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_initialteachertraining", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_initialteachertraining");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_initialteachertraining", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_initialteachertraining", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_initialteachertraining");
 			}
 		}
@@ -1594,18 +1594,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_requestedbyid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_initialteachertraining1")]
-		public DqtApi.Models.Contact dfeta_contact_dfeta_initialteachertraining1
+		public DqtApi.DataStore.Crm.Models.Contact dfeta_contact_dfeta_initialteachertraining1
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_initialteachertraining1", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_initialteachertraining1", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_initialteachertraining1");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_initialteachertraining1", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_initialteachertraining1", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_initialteachertraining1");
 			}
 		}
@@ -1615,18 +1615,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_subject1id")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_ittsubject1_dfeta_initialteachertra")]
-		public DqtApi.Models.dfeta_ittsubject dfeta_dfeta_ittsubject1_dfeta_initialteachertra
+		public DqtApi.DataStore.Crm.Models.dfeta_ittsubject dfeta_dfeta_ittsubject1_dfeta_initialteachertra
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject1_dfeta_initialteachertra", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject1_dfeta_initialteachertra", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_ittsubject1_dfeta_initialteachertra");
-				this.SetRelatedEntity<DqtApi.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject1_dfeta_initialteachertra", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject1_dfeta_initialteachertra", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_ittsubject1_dfeta_initialteachertra");
 			}
 		}
@@ -1636,18 +1636,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_subject2id")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_ittsubject2_dfeta_initialteachertra")]
-		public DqtApi.Models.dfeta_ittsubject dfeta_dfeta_ittsubject2_dfeta_initialteachertra
+		public DqtApi.DataStore.Crm.Models.dfeta_ittsubject dfeta_dfeta_ittsubject2_dfeta_initialteachertra
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject2_dfeta_initialteachertra", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject2_dfeta_initialteachertra", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_ittsubject2_dfeta_initialteachertra");
-				this.SetRelatedEntity<DqtApi.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject2_dfeta_initialteachertra", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject2_dfeta_initialteachertra", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_ittsubject2_dfeta_initialteachertra");
 			}
 		}
@@ -1657,18 +1657,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_subject3id")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_ittsubject3_dfeta_initialteachertra")]
-		public DqtApi.Models.dfeta_ittsubject dfeta_dfeta_ittsubject3_dfeta_initialteachertra
+		public DqtApi.DataStore.Crm.Models.dfeta_ittsubject dfeta_dfeta_ittsubject3_dfeta_initialteachertra
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject3_dfeta_initialteachertra", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject3_dfeta_initialteachertra", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_ittsubject3_dfeta_initialteachertra");
-				this.SetRelatedEntity<DqtApi.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject3_dfeta_initialteachertra", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_ittsubject>("dfeta_dfeta_ittsubject3_dfeta_initialteachertra", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_ittsubject3_dfeta_initialteachertra");
 			}
 		}
@@ -1772,7 +1772,7 @@ namespace DqtApi.Models
 		/// Status of the ITT Subject
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
-		public System.Nullable<DqtApi.Models.dfeta_ittsubjectState> StateCode
+		public System.Nullable<DqtApi.DataStore.Crm.Models.dfeta_ittsubjectState> StateCode
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
@@ -1780,7 +1780,7 @@ namespace DqtApi.Models
 				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
 				if ((optionSet != null))
 				{
-					return ((DqtApi.Models.dfeta_ittsubjectState)(System.Enum.ToObject(typeof(DqtApi.Models.dfeta_ittsubjectState), optionSet.Value)));
+					return ((DqtApi.DataStore.Crm.Models.dfeta_ittsubjectState)(System.Enum.ToObject(typeof(DqtApi.DataStore.Crm.Models.dfeta_ittsubjectState), optionSet.Value)));
 				}
 				else
 				{
@@ -1807,18 +1807,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_dfeta_ittsubject1_dfeta_initialteachertra
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_ittsubject1_dfeta_initialteachertra")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_initialteachertraining> dfeta_dfeta_ittsubject1_dfeta_initialteachertra
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining> dfeta_dfeta_ittsubject1_dfeta_initialteachertra
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject1_dfeta_initialteachertra", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject1_dfeta_initialteachertra", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_ittsubject1_dfeta_initialteachertra");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject1_dfeta_initialteachertra", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject1_dfeta_initialteachertra", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_ittsubject1_dfeta_initialteachertra");
 			}
 		}
@@ -1827,18 +1827,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_dfeta_ittsubject2_dfeta_initialteachertra
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_ittsubject2_dfeta_initialteachertra")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_initialteachertraining> dfeta_dfeta_ittsubject2_dfeta_initialteachertra
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining> dfeta_dfeta_ittsubject2_dfeta_initialteachertra
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject2_dfeta_initialteachertra", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject2_dfeta_initialteachertra", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_ittsubject2_dfeta_initialteachertra");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject2_dfeta_initialteachertra", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject2_dfeta_initialteachertra", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_ittsubject2_dfeta_initialteachertra");
 			}
 		}
@@ -1847,18 +1847,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_dfeta_ittsubject3_dfeta_initialteachertra
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_ittsubject3_dfeta_initialteachertra")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.dfeta_initialteachertraining> dfeta_dfeta_ittsubject3_dfeta_initialteachertra
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining> dfeta_dfeta_ittsubject3_dfeta_initialteachertra
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject3_dfeta_initialteachertra", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject3_dfeta_initialteachertra", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_ittsubject3_dfeta_initialteachertra");
-				this.SetRelatedEntities<DqtApi.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject3_dfeta_initialteachertra", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.dfeta_initialteachertraining>("dfeta_dfeta_ittsubject3_dfeta_initialteachertra", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_ittsubject3_dfeta_initialteachertra");
 			}
 		}
@@ -2005,7 +2005,7 @@ namespace DqtApi.Models
 		/// Status of the QTS Registration
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
-		public System.Nullable<DqtApi.Models.dfeta_qtsregistrationState> StateCode
+		public System.Nullable<DqtApi.DataStore.Crm.Models.dfeta_qtsregistrationState> StateCode
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
@@ -2013,7 +2013,7 @@ namespace DqtApi.Models
 				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
 				if ((optionSet != null))
 				{
-					return ((DqtApi.Models.dfeta_qtsregistrationState)(System.Enum.ToObject(typeof(DqtApi.Models.dfeta_qtsregistrationState), optionSet.Value)));
+					return ((DqtApi.DataStore.Crm.Models.dfeta_qtsregistrationState)(System.Enum.ToObject(typeof(DqtApi.DataStore.Crm.Models.dfeta_qtsregistrationState), optionSet.Value)));
 				}
 				else
 				{
@@ -2040,18 +2040,18 @@ namespace DqtApi.Models
 		/// 1:N dfeta_dfeta_qtsregistration_contact
 		/// </summary>
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_qtsregistration_contact")]
-		public System.Collections.Generic.IEnumerable<DqtApi.Models.Contact> dfeta_dfeta_qtsregistration_contact
+		public System.Collections.Generic.IEnumerable<DqtApi.DataStore.Crm.Models.Contact> dfeta_dfeta_qtsregistration_contact
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntities<DqtApi.Models.Contact>("dfeta_dfeta_qtsregistration_contact", null);
+				return this.GetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("dfeta_dfeta_qtsregistration_contact", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_qtsregistration_contact");
-				this.SetRelatedEntities<DqtApi.Models.Contact>("dfeta_dfeta_qtsregistration_contact", null, value);
+				this.SetRelatedEntities<DqtApi.DataStore.Crm.Models.Contact>("dfeta_dfeta_qtsregistration_contact", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_qtsregistration_contact");
 			}
 		}
@@ -2061,18 +2061,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_personid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_qtsregistration")]
-		public DqtApi.Models.Contact dfeta_contact_dfeta_qtsregistration
+		public DqtApi.DataStore.Crm.Models.Contact dfeta_contact_dfeta_qtsregistration
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_qtsregistration", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_qtsregistration", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_qtsregistration");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_qtsregistration", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_qtsregistration", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_qtsregistration");
 			}
 		}
@@ -2082,18 +2082,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_requestedbyid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_qtsregistration1")]
-		public DqtApi.Models.Contact dfeta_contact_dfeta_qtsregistration1
+		public DqtApi.DataStore.Crm.Models.Contact dfeta_contact_dfeta_qtsregistration1
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_qtsregistration1", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_qtsregistration1", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_qtsregistration1");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_qtsregistration1", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_qtsregistration1", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_qtsregistration1");
 			}
 		}
@@ -2103,18 +2103,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_inductionid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_dfeta_induction_dfeta_qtsregistration")]
-		public DqtApi.Models.dfeta_induction dfeta_dfeta_induction_dfeta_qtsregistration
+		public DqtApi.DataStore.Crm.Models.dfeta_induction dfeta_dfeta_induction_dfeta_qtsregistration
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.dfeta_induction>("dfeta_dfeta_induction_dfeta_qtsregistration", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_induction>("dfeta_dfeta_induction_dfeta_qtsregistration", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_dfeta_induction_dfeta_qtsregistration");
-				this.SetRelatedEntity<DqtApi.Models.dfeta_induction>("dfeta_dfeta_induction_dfeta_qtsregistration", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.dfeta_induction>("dfeta_dfeta_induction_dfeta_qtsregistration", null, value);
 				this.OnPropertyChanged("dfeta_dfeta_induction_dfeta_qtsregistration");
 			}
 		}
@@ -2259,18 +2259,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_he_establishmentid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_account_dfeta_qualification_he")]
-		public DqtApi.Models.Account dfeta_account_dfeta_qualification_he
+		public DqtApi.DataStore.Crm.Models.Account dfeta_account_dfeta_qualification_he
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Account>("dfeta_account_dfeta_qualification_he", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("dfeta_account_dfeta_qualification_he", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_account_dfeta_qualification_he");
-				this.SetRelatedEntity<DqtApi.Models.Account>("dfeta_account_dfeta_qualification_he", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Account>("dfeta_account_dfeta_qualification_he", null, value);
 				this.OnPropertyChanged("dfeta_account_dfeta_qualification_he");
 			}
 		}
@@ -2280,18 +2280,18 @@ namespace DqtApi.Models
 		/// </summary>
 		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_personid")]
 		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("dfeta_contact_dfeta_qualification")]
-		public DqtApi.Models.Contact dfeta_contact_dfeta_qualification
+		public DqtApi.DataStore.Crm.Models.Contact dfeta_contact_dfeta_qualification
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]
 			get
 			{
-				return this.GetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_qualification", null);
+				return this.GetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_qualification", null);
 			}
 			[System.Diagnostics.DebuggerNonUserCode()]
 			set
 			{
 				this.OnPropertyChanging("dfeta_contact_dfeta_qualification");
-				this.SetRelatedEntity<DqtApi.Models.Contact>("dfeta_contact_dfeta_qualification", null, value);
+				this.SetRelatedEntity<DqtApi.DataStore.Crm.Models.Contact>("dfeta_contact_dfeta_qualification", null, value);
 				this.OnPropertyChanged("dfeta_contact_dfeta_qualification");
 			}
 		}

--- a/src/DqtApi/DataStore/Crm/Models/GeneratedOptionSets.cs
+++ b/src/DqtApi/DataStore/Crm/Models/GeneratedOptionSets.cs
@@ -9,7 +9,7 @@
 
 //------------------------------------------------------------------------------
 
-namespace DqtApi.Models
+namespace DqtApi.DataStore.Crm.Models
 {
 	
 	

--- a/src/DqtApi/DataStore/Crm/Models/GetTeacherRequest.cs
+++ b/src/DqtApi/DataStore/Crm/Models/GetTeacherRequest.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Xrm.Sdk.Query;
 using Swashbuckle.AspNetCore.Annotations;
 
-namespace DqtApi.Models
+namespace DqtApi.DataStore.Crm.Models
 {
     public class GetTeacherRequest
     {

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using System.Text.Json.Serialization;
 using DqtApi.Configuration;
-using DqtApi.DAL;
+using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Sql;
 using DqtApi.Filters;
 using DqtApi.Security;
@@ -159,7 +159,7 @@ namespace DqtApi
                 var crmServiceClient = GetCrmServiceClient();
 
                 services.AddSingleton<IOrganizationServiceAsync>(crmServiceClient);
-                services.AddSingleton<IDataverseAdaptor, DataverseAdaptor>();
+                services.AddSingleton<IDataverseAdapter, DataverseAdapter>();
 
                 healthCheckBuilder.AddCheck("CRM", () => crmServiceClient.IsReady ? HealthCheckResult.Healthy() : HealthCheckResult.Degraded());
             }

--- a/src/DqtApi/V1/Controllers/TeachersController.cs
+++ b/src/DqtApi/V1/Controllers/TeachersController.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
-using DqtApi.DAL;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 using DqtApi.V1.Responses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,11 +13,11 @@ namespace DqtApi.V1.Controllers
     [Route("teachers")]
     public class TeachersController : ControllerBase
     {
-        private readonly IDataverseAdaptor _dataverseAdaptor;
+        private readonly IDataverseAdapter _dataverseAdapter;
 
-        public TeachersController(IDataverseAdaptor dataverseAdaptor)
+        public TeachersController(IDataverseAdapter dataverseAdapter)
         {
-            _dataverseAdaptor = dataverseAdaptor;
+            _dataverseAdapter = dataverseAdapter;
         }
 
         [HttpGet("{trn}")]
@@ -34,7 +34,7 @@ namespace DqtApi.V1.Controllers
                 return NotFound();
             }
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             var teacher = request.SelectMatch(matchingTeachers);
 
@@ -44,7 +44,7 @@ namespace DqtApi.V1.Controllers
             }
             else
             {
-                var qualifications = await _dataverseAdaptor.GetQualificationsAsync(teacher.Id);
+                var qualifications = await _dataverseAdapter.GetQualificationsAsync(teacher.Id);
 
                 if (qualifications.Any())
                 {

--- a/src/DqtApi/V1/Responses/EntityExtensions.cs
+++ b/src/DqtApi/V1/Responses/EntityExtensions.cs
@@ -1,4 +1,4 @@
-﻿using DqtApi.DAL;
+﻿using DqtApi.DataStore.Crm;
 using Microsoft.Xrm.Sdk;
 
 namespace DqtApi.V1.Responses

--- a/src/DqtApi/V1/Responses/GetTeacherResponse.cs
+++ b/src/DqtApi/V1/Responses/GetTeacherResponse.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 
 namespace DqtApi.V1.Responses
 {

--- a/src/DqtApi/V1/Responses/Induction.cs
+++ b/src/DqtApi/V1/Responses/Induction.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 
 namespace DqtApi.V1.Responses
 {

--- a/src/DqtApi/V1/Responses/InitialTeacherTraining.cs
+++ b/src/DqtApi/V1/Responses/InitialTeacherTraining.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.Json.Serialization;
-using DqtApi.DAL;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.Xrm.Sdk;
 
 namespace DqtApi.V1.Responses

--- a/src/DqtApi/V1/Responses/Qualification.cs
+++ b/src/DqtApi/V1/Responses/Qualification.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.Json.Serialization;
-using DqtApi.DAL;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 
 namespace DqtApi.V1.Responses
 {

--- a/src/DqtApi/V1/Responses/QualifiedTeacherStatus.cs
+++ b/src/DqtApi/V1/Responses/QualifiedTeacherStatus.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text.Json.Serialization;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 
 namespace DqtApi.V1.Responses
 {

--- a/src/DqtApi/V1/Responses/Subject.cs
+++ b/src/DqtApi/V1/Responses/Subject.cs
@@ -1,4 +1,4 @@
-﻿using DqtApi.Models;
+﻿using DqtApi.DataStore.Crm.Models;
 
 namespace DqtApi.V1.Responses
 {

--- a/src/DqtApi/V1/Validators/GetTeacherRequestValidator.cs
+++ b/src/DqtApi/V1/Validators/GetTeacherRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿using DqtApi.Models;
+﻿using DqtApi.DataStore.Crm.Models;
 using FluentValidation;
 
 namespace DqtApi.V1.Validators

--- a/src/DqtApi/V2/Handlers/GetIttProvidersHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetIttProvidersHandler.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DqtApi.DAL;
+using DqtApi.DataStore.Crm;
 using DqtApi.V2.Requests;
 using DqtApi.V2.Responses;
 using MediatR;
@@ -10,16 +10,16 @@ namespace DqtApi.V2.Handlers
 {
     public class GetIttProvidersHandler : IRequestHandler<GetIttProvidersRequest, GetIttProvidersResponse>
     {
-        private readonly IDataverseAdaptor _dataverseAdaptor;
+        private readonly IDataverseAdapter _dataverseAdapter;
 
-        public GetIttProvidersHandler(IDataverseAdaptor dataverseAdaptor)
+        public GetIttProvidersHandler(IDataverseAdapter dataverseAdapter)
         {
-            _dataverseAdaptor = dataverseAdaptor;
+            _dataverseAdapter = dataverseAdapter;
         }
 
         public async Task<GetIttProvidersResponse> Handle(GetIttProvidersRequest request, CancellationToken cancellationToken)
         {
-            var ittProviders = await _dataverseAdaptor.GetIttProviders();
+            var ittProviders = await _dataverseAdapter.GetIttProviders();
 
             return new GetIttProvidersResponse()
             {

--- a/src/DqtApi/V2/Handlers/GetTrnRequestHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetTrnRequestHandler.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using DqtApi.DAL;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 using DqtApi.DataStore.Sql;
-using DqtApi.Models;
 using DqtApi.Security;
 using DqtApi.V2.Requests;
 using DqtApi.V2.Responses;
@@ -14,16 +14,16 @@ namespace DqtApi.V2.Handlers
     public class GetTrnRequestHandler : IRequestHandler<GetTrnRequest, TrnRequestInfo>
     {
         private readonly DqtContext _dqtContext;
-        private readonly IDataverseAdaptor _dataverseAdaptor;
+        private readonly IDataverseAdapter _dataverseAdapter;
         private readonly ICurrentClientProvider _currentClientProvider;
 
         public GetTrnRequestHandler(
             DqtContext dqtContext,
-            IDataverseAdaptor dataverseAdaptor,
+            IDataverseAdapter dataverseAdapter,
             ICurrentClientProvider currentClientProvider)
         {
             _dqtContext = dqtContext;
-            _dataverseAdaptor = dataverseAdaptor;
+            _dataverseAdapter = dataverseAdapter;
             _currentClientProvider = currentClientProvider;
         }
 
@@ -43,7 +43,7 @@ namespace DqtApi.V2.Handlers
 
             if (trnRequest.TeacherId.HasValue)
             {
-                var teacher = await _dataverseAdaptor.GetTeacherAsync(trnRequest.TeacherId.Value, columnNames: Contact.Fields.dfeta_TRN);
+                var teacher = await _dataverseAdapter.GetTeacherAsync(trnRequest.TeacherId.Value, columnNames: Contact.Fields.dfeta_TRN);
                 trn = teacher.dfeta_TRN;
             }
 

--- a/src/DqtApi/V2/Handlers/UnlockTeacherHandler.cs
+++ b/src/DqtApi/V2/Handlers/UnlockTeacherHandler.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using DqtApi.DAL;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 using DqtApi.V2.Requests;
 using MediatR;
 
@@ -9,16 +9,16 @@ namespace DqtApi.V2.Handlers
 {
     public class UnlockTeacherHandler : IRequestHandler<UnlockTeacherRequest>
     {
-        private readonly IDataverseAdaptor _dataverseAdaptor;
+        private readonly IDataverseAdapter _dataverseAdapter;
 
-        public UnlockTeacherHandler(IDataverseAdaptor dataverseAdaptor)
+        public UnlockTeacherHandler(IDataverseAdapter dataverseAdapter)
         {
-            _dataverseAdaptor = dataverseAdaptor;
+            _dataverseAdapter = dataverseAdapter;
         }
 
         public async Task<Unit> Handle(UnlockTeacherRequest request, CancellationToken cancellationToken)
         {
-            var found = await _dataverseAdaptor.UnlockTeacherRecordAsync(request.TeacherId);
+            var found = await _dataverseAdapter.UnlockTeacherRecordAsync(request.TeacherId);
 
             if (!found)
             {

--- a/tests/DqtApi.Tests/ApiFixture.cs
+++ b/tests/DqtApi.Tests/ApiFixture.cs
@@ -1,5 +1,5 @@
 using System.Threading.Tasks;
-using DqtApi.DAL;
+using DqtApi.DataStore.Crm;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
@@ -13,7 +13,7 @@ namespace DqtApi.Tests
     {
         public DbHelper DbHelper => Services.GetRequiredService<DbHelper>();
 
-        public Mock<IDataverseAdaptor> DataverseAdaptor { get; } = new Mock<IDataverseAdaptor>();
+        public Mock<IDataverseAdapter> DataverseAdapter { get; } = new Mock<IDataverseAdapter>();
 
         public async Task InitializeAsync()
         {
@@ -22,7 +22,7 @@ namespace DqtApi.Tests
 
         public void ResetMocks()
         {
-            DataverseAdaptor.Reset();
+            DataverseAdapter.Reset();
         }
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -38,7 +38,7 @@ namespace DqtApi.Tests
                 // Add controllers defined in this test assembly
                 services.AddMvc().AddApplicationPart(typeof(ApiFixture).Assembly);
 
-                services.AddSingleton(DataverseAdaptor.Object);
+                services.AddSingleton(DataverseAdapter.Object);
 
                 services.AddSingleton(sp =>
                 {

--- a/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using DqtApi.DAL;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.Configuration;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -27,7 +27,7 @@ namespace DqtApi.Tests.DataverseIntegration
 
         public ServiceClient ServiceClient { get; }
 
-        public DataverseAdaptor CreateDataverseAdaptor() => new(ServiceClient);
+        public DataverseAdapter CreateDataverseAdapter() => new(ServiceClient);
 
         public Task InitializeAsync() => Task.CompletedTask;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetIttProvidersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetIttProvidersTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using DqtApi.DAL;
+using DqtApi.DataStore.Crm;
 using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
@@ -7,11 +7,11 @@ namespace DqtApi.Tests.DataverseIntegration
     [Collection(nameof(DataverseTestCollection))]
     public class GetIttProvidersTests : IClassFixture<CrmClientFixture>
     {
-        private readonly DataverseAdaptor _dataverseAdaptor;
+        private readonly DataverseAdapter _dataverseAdapter;
 
         public GetIttProvidersTests(CrmClientFixture crmClientFixture)
         {
-            _dataverseAdaptor = crmClientFixture.CreateDataverseAdaptor();
+            _dataverseAdapter = crmClientFixture.CreateDataverseAdapter();
         }
 
         [Fact]
@@ -20,7 +20,7 @@ namespace DqtApi.Tests.DataverseIntegration
             // Arrange
 
             // Act
-            var result = await _dataverseAdaptor.GetIttProviders();
+            var result = await _dataverseAdapter.GetIttProviders();
 
             // Assert
             Assert.NotEmpty(result);

--- a/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersFixture.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk.Query;
 using Xunit;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using DqtApi.DAL;
+using DqtApi.DataStore.Crm;
 using Xunit;
 using static DqtApi.Tests.DataverseIntegration.GetMatchingTeachersFixture.MatchFixture;
 
@@ -9,12 +9,12 @@ namespace DqtApi.Tests.DataverseIntegration
     public class GetMatchingTeachersTests : IClassFixture<GetMatchingTeachersFixture>
     {
         private readonly GetMatchingTeachersFixture _fixture;
-        private readonly IDataverseAdaptor _dataverseAdaptor;
+        private readonly IDataverseAdapter _dataverseAdapter;
 
         public GetMatchingTeachersTests(GetMatchingTeachersFixture fixture)
         {
             _fixture = fixture;
-            _dataverseAdaptor = new DataverseAdaptor(_fixture.Service);
+            _dataverseAdapter = new DataverseAdapter(_fixture.Service);
         }
 
         [Fact]
@@ -22,7 +22,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, true);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Single(matchingTeachers);
 
@@ -34,7 +34,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(None, true);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -44,7 +44,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, false);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -54,7 +54,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(None, false);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -64,7 +64,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, true, One);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Single(matchingTeachers);
 
@@ -76,7 +76,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, true, Two);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Collection(matchingTeachers,
                 firstTeacher => _fixture.AssertMatchesFixture(firstTeacher, 0),
@@ -89,7 +89,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(None, true, One);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Single(matchingTeachers);
 
@@ -101,7 +101,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, true, None);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Single(matchingTeachers);
 
@@ -113,7 +113,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(None, false, One);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -123,7 +123,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, false, None);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -133,7 +133,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, false, One);
 
-            var matchingTeachers = await _dataverseAdaptor.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
 
             Assert.Empty(matchingTeachers);
         }

--- a/tests/DqtApi.Tests/DataverseIntegration/GetTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetTeacherTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using DqtApi.DAL;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
@@ -13,13 +13,13 @@ namespace DqtApi.Tests.DataverseIntegration
     public class GetTeacherTests : IClassFixture<CrmClientFixture>
     {
         private readonly CrmClientFixture _crmClientFixture;
-        private readonly DataverseAdaptor _dataverseAdaptor;
+        private readonly DataverseAdapter _dataverseAdapter;
         private readonly ServiceClient _serviceClient;
 
         public GetTeacherTests(CrmClientFixture crmClientFixture)
         {
             _crmClientFixture = crmClientFixture;
-            _dataverseAdaptor = crmClientFixture.CreateDataverseAdaptor();
+            _dataverseAdapter = crmClientFixture.CreateDataverseAdapter();
             _serviceClient = crmClientFixture.ServiceClient;
         }
 
@@ -30,7 +30,7 @@ namespace DqtApi.Tests.DataverseIntegration
             var teacherId = Guid.NewGuid();
 
             // Act
-            var result = await _dataverseAdaptor.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
+            var result = await _dataverseAdapter.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
 
             // Assert
             Assert.Null(result);
@@ -44,7 +44,7 @@ namespace DqtApi.Tests.DataverseIntegration
             _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, teacherId);
 
             // Act
-            var result = await _dataverseAdaptor.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
+            var result = await _dataverseAdapter.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
 
             // Assert
             Assert.NotNull(result);
@@ -70,7 +70,7 @@ namespace DqtApi.Tests.DataverseIntegration
             _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, teacherId);
 
             // Act
-            var result = await _dataverseAdaptor.GetTeacherAsync(teacherId, resolveMerges: true, Contact.Fields.StateCode);
+            var result = await _dataverseAdapter.GetTeacherAsync(teacherId, resolveMerges: true, Contact.Fields.StateCode);
 
             // Assert
             Assert.NotNull(result);
@@ -96,7 +96,7 @@ namespace DqtApi.Tests.DataverseIntegration
             _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, teacherId);
 
             // Act
-            var result = await _dataverseAdaptor.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
+            var result = await _dataverseAdapter.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
 
             // Assert
             Assert.NotNull(result);

--- a/tests/DqtApi.Tests/DataverseIntegration/NationalInsuranceNumberGenerator.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/NationalInsuranceNumberGenerator.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/UnlockTeacherRecordTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/UnlockTeacherRecordTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using DqtApi.DAL;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk.Query;
 using Xunit;
@@ -12,13 +12,13 @@ namespace DqtApi.Tests.DataverseIntegration
     public class UnlockTeacherRecordTests : IClassFixture<CrmClientFixture>
     {
         private readonly CrmClientFixture _crmClientFixture;
-        private readonly DataverseAdaptor _dataverseAdaptor;
+        private readonly DataverseAdapter _dataverseAdapter;
         private readonly ServiceClient _serviceClient;
 
         public UnlockTeacherRecordTests(CrmClientFixture crmClientFixture)
         {
             _crmClientFixture = crmClientFixture;
-            _dataverseAdaptor = crmClientFixture.CreateDataverseAdaptor();
+            _dataverseAdapter = crmClientFixture.CreateDataverseAdapter();
             _serviceClient = crmClientFixture.ServiceClient;
         }
 
@@ -29,7 +29,7 @@ namespace DqtApi.Tests.DataverseIntegration
             var teacherId = Guid.NewGuid();
 
             // Act
-            var result = await _dataverseAdaptor.UnlockTeacherRecordAsync(teacherId);
+            var result = await _dataverseAdapter.UnlockTeacherRecordAsync(teacherId);
 
             // Assert
             Assert.False(result);
@@ -48,7 +48,7 @@ namespace DqtApi.Tests.DataverseIntegration
             _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, teacherId);
 
             // Act
-            var result = await _dataverseAdaptor.UnlockTeacherRecordAsync(teacherId);
+            var result = await _dataverseAdapter.UnlockTeacherRecordAsync(teacherId);
 
             // Assert
             Assert.True(result);

--- a/tests/DqtApi.Tests/V1/UnitTests/GetTeacherRequest.cs
+++ b/tests/DqtApi.Tests/V1/UnitTests/GetTeacherRequest.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 using Xunit;
 
 namespace DqtApi.Tests.V1.UnitTests
 {
-    public class GetTeacherRequest
+    public class GetTeacherRequestTests
     {
         private readonly string _trn = "1111111";
         private readonly string _nationalInsuranceNumber = "AA123456A";
@@ -14,7 +14,7 @@ namespace DqtApi.Tests.V1.UnitTests
         private readonly Contact _matchingNationalInsuranceNumber;
         private IEnumerable<Contact> _matches;
 
-        public GetTeacherRequest()
+        public GetTeacherRequestTests()
         {
             _matchingTrn = new() { dfeta_TRN = _trn, Id = Guid.NewGuid() };
             _matchingNationalInsuranceNumber = new() { dfeta_NINumber = _nationalInsuranceNumber, Id = Guid.NewGuid() };
@@ -24,7 +24,7 @@ namespace DqtApi.Tests.V1.UnitTests
         [Fact]
         public void Given_a_match_by_trn_return_contact()
         {
-            var request = new Models.GetTeacherRequest { TRN = _trn, NationalInsuranceNumber = "BB234567B" };
+            var request = new GetTeacherRequest { TRN = _trn, NationalInsuranceNumber = "BB234567B" };
             var match = request.SelectMatch(_matches);
             Assert.Equal(_matchingTrn.Id, match.Id);
         }
@@ -32,7 +32,7 @@ namespace DqtApi.Tests.V1.UnitTests
         [Fact]
         public void Given_no_match_by_trn_but_a_match_by_national_insurance_number_return_contact()
         {
-            var request = new Models.GetTeacherRequest { TRN = "2222222", NationalInsuranceNumber = _nationalInsuranceNumber };
+            var request = new GetTeacherRequest { TRN = "2222222", NationalInsuranceNumber = _nationalInsuranceNumber };
             var match = request.SelectMatch(_matches);
             Assert.Equal(_matchingNationalInsuranceNumber.Id, match.Id);
         }
@@ -40,7 +40,7 @@ namespace DqtApi.Tests.V1.UnitTests
         [Fact]
         public void Given_no_match_by_trn_or_national_insurance_number_return_null()
         {
-            var request = new Models.GetTeacherRequest { TRN = "2222222", NationalInsuranceNumber = "BB234567B" };
+            var request = new GetTeacherRequest { TRN = "2222222", NationalInsuranceNumber = "BB234567B" };
             var match = request.SelectMatch(_matches);
             Assert.Null(match);
         }

--- a/tests/DqtApi.Tests/V1/UnitTests/GetTeacherResponse.cs
+++ b/tests/DqtApi.Tests/V1/UnitTests/GetTeacherResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.Xrm.Sdk;
 using Xunit;
 

--- a/tests/DqtApi.Tests/V1/UnitTests/TeachersController.cs
+++ b/tests/DqtApi.Tests/V1/UnitTests/TeachersController.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using DqtApi.DAL;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
@@ -11,21 +11,21 @@ namespace DqtApi.Tests.V1.UnitTests
 {
     public class TeachersController
     {
-        private readonly Mock<IDataverseAdaptor> _adaptor;
+        private readonly Mock<IDataverseAdapter> _adapter;
         private readonly string trn = "1111111";
         private readonly DateTime birthDate = new DateTime(2000, 1, 1);
 
         public TeachersController()
         {
-            _adaptor = new Mock<IDataverseAdaptor>();            
+            _adapter = new Mock<IDataverseAdapter>();            
         }
 
         [Fact]
         public async Task Given_there_is_no_match_return_not_found()
         {
-            _adaptor.Setup(a => a.GetMatchingTeachersAsync(It.IsAny<Models.GetTeacherRequest>())).ReturnsAsync(new List<Contact>());
+            _adapter.Setup(a => a.GetMatchingTeachersAsync(It.IsAny<GetTeacherRequest>())).ReturnsAsync(new List<Contact>());
 
-            var result = await new DqtApi.V1.Controllers.TeachersController(_adaptor.Object).GetTeacher(new Models.GetTeacherRequest { TRN = trn, BirthDate = birthDate });
+            var result = await new DqtApi.V1.Controllers.TeachersController(_adapter.Object).GetTeacher(new GetTeacherRequest { TRN = trn, BirthDate = birthDate });
 
             Assert.IsType<NotFoundResult>(result);
         }
@@ -33,9 +33,9 @@ namespace DqtApi.Tests.V1.UnitTests
         [Fact]
         public async Task Given_there_is_a_match_return_ok()
         {
-            _adaptor.Setup(a => a.GetMatchingTeachersAsync(It.IsAny<Models.GetTeacherRequest>())).ReturnsAsync(new[] { new Contact{ dfeta_TRN = trn } });
+            _adapter.Setup(a => a.GetMatchingTeachersAsync(It.IsAny<GetTeacherRequest>())).ReturnsAsync(new[] { new Contact{ dfeta_TRN = trn } });
 
-            var result = await new DqtApi.V1.Controllers.TeachersController(_adaptor.Object).GetTeacher(new Models.GetTeacherRequest { TRN = trn, BirthDate = birthDate });
+            var result = await new DqtApi.V1.Controllers.TeachersController(_adapter.Object).GetTeacher(new GetTeacherRequest { TRN = trn, BirthDate = birthDate });
 
             Assert.IsType<OkObjectResult>(result);
         }

--- a/tests/DqtApi.Tests/V2/Operations/GetIttProvidersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/GetIttProvidersTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
-using DqtApi.Models;
+using DqtApi.DataStore.Crm.Models;
 using DqtApi.TestCommon;
 using Microsoft.AspNetCore.Http;
 using Moq;
@@ -30,7 +30,7 @@ namespace DqtApi.Tests.V2.Operations
                 dfeta_UKPRN = "2345678"
             };
 
-            ApiFixture.DataverseAdaptor
+            ApiFixture.DataverseAdapter
                 .Setup(mock => mock.GetIttProviders())
                 .ReturnsAsync(new[] { provider1, provider2 });
 

--- a/tests/DqtApi.Tests/V2/Operations/GetTrnRequestTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/GetTrnRequestTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Threading.Tasks;
+using DqtApi.DataStore.Crm.Models;
 using DqtApi.DataStore.Sql.Models;
 using DqtApi.TestCommon;
 using Microsoft.AspNetCore.Http;
@@ -96,9 +97,9 @@ namespace DqtApi.Tests.V2.Operations
             var teacherId = Guid.NewGuid();
             var trn = "1234567";
 
-            ApiFixture.DataverseAdaptor
+            ApiFixture.DataverseAdapter
                 .Setup(mock => mock.GetTeacherAsync(teacherId, /* resolveMerges: */ true, It.IsAny<string[]>()))
-                .ReturnsAsync(new Models.Contact()
+                .ReturnsAsync(new Contact()
                 {
                     Id = teacherId,
                     dfeta_TRN = trn

--- a/tests/DqtApi.Tests/V2/Operations/UnlockTeacherTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/UnlockTeacherTests.cs
@@ -19,7 +19,7 @@ namespace DqtApi.Tests.V2.Operations
             // Arrange
             var teacherId = Guid.NewGuid();
 
-            ApiFixture.DataverseAdaptor
+            ApiFixture.DataverseAdapter
                 .Setup(mock => mock.UnlockTeacherRecordAsync(teacherId))
                 .ReturnsAsync(false);
 
@@ -38,7 +38,7 @@ namespace DqtApi.Tests.V2.Operations
             // Arrange
             var teacherId = Guid.NewGuid();
 
-            ApiFixture.DataverseAdaptor
+            ApiFixture.DataverseAdapter
                 .Setup(mock => mock.UnlockTeacherRecordAsync(teacherId))
                 .ReturnsAsync(true)
                 .Verifiable();
@@ -50,7 +50,7 @@ namespace DqtApi.Tests.V2.Operations
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-            ApiFixture.DataverseAdaptor.Verify();
+            ApiFixture.DataverseAdapter.Verify();
         }
     }
 }


### PR DESCRIPTION
Consolidates namespaces to give some symmetry to CRM-related types and SQL-related types.

```
DqtApi
  DataStore
    Crm
      Models
    Sql
      Models
```