### PR TITLE
Fix error running tests against helper library

### DIFF
--- a/tests/DqtApi.TestCommon/DqtApi.TestCommon.csproj
+++ b/tests/DqtApi.TestCommon/DqtApi.TestCommon.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ensure `TestCommon` project isn't treated as a test project.