### PR TITLE
Ensure integration test runs happen one at a time on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: Build & test
     runs-on: ubuntu-latest
+    concurrency: build
 
     outputs:
       docker_image: ${{ steps.image.outputs.tag }}


### PR DESCRIPTION
When builds are running concurrently we're seeing intermittent test failures due to multiple instances of the integration tests running at the same time. This change ensures that only one will run at once.