### PR TITLE
Add production deployment to pipeline

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -16,6 +16,8 @@ inputs:
   terraform_backend_vars:
     description: 'Path to the backend tfvars file for the environment'
     required: true
+  skip_functional_tests:
+    default: false
 
 outputs:
   environment_url:
@@ -60,7 +62,7 @@ runs:
       id: get_secrets
       with:
         keyvault: ${{ steps.config.outputs.key_vault_name }}
-        secrets: 'TFSTATE-CONTAINER-ACCESS-KEY,TEST-API-KEY,FUNCTIONAL-TESTS-CONFIG,PAAS-USER,PAAS-PASSWORD'
+        secrets: 'TFSTATE-CONTAINER-ACCESS-KEY,TEST-API-KEY,PAAS-USER,PAAS-PASSWORD'
 
     - uses: hashicorp/setup-terraform@v1
       with:
@@ -96,24 +98,10 @@ runs:
       shell: bash
       working-directory: terraform
 
-    - uses: actions/setup-dotnet@v1
+    - uses: ./.github/workflows/actions/functional-tests
+      if: inputs.skip_functional_tests != 'true'
       with:
-        dotnet-version: '6.0.x'
-
-    - name: Functional tests
-      id: functional_tests
-      run: |
-        dotnet test tests/DqtApi.FunctionalTests --configuration Release --logger trx --settings tests/DqtApi.FunctionalTests/ci.runsettings || true
-      env:
-        FunctionalTestsConfig: ${{ steps.get_secrets.outputs.FUNCTIONAL-TESTS-CONFIG }}
-        BaseUrl: ${{ steps.terraform.outputs.url }}
-      shell: bash
-
-    - name: Test report
-      uses: dorny/test-reporter@v1
-      if: steps.functional_tests.outcome != 'skipped'
-      with:
-        name: ${{ inputs.environment_name }} functional test results
-        path: "**/*.trx"
-        reporter: dotnet-trx
-        fail-on-error: false
+        environment_name: ${{ inputs.environment_name }}
+        azure_credentials: ${{ inputs.azure_credentials }}
+        base_url: ${{ steps.terraform.outputs.url }}
+        key_vault_name: ${{ steps.config.outputs.key_vault_name }}

--- a/.github/workflows/actions/functional-tests/action.yml
+++ b/.github/workflows/actions/functional-tests/action.yml
@@ -1,0 +1,46 @@
+name: Run functional tests against PAAS environment
+
+inputs:
+  environment_name:
+    description: 'The name of the environment'
+    required: true
+  azure_credentials:
+    description: 'JSON object containing a service principal that can read from Azure Key Vault'
+    required: true
+  base_url:
+    description: 'The base URL of the API to run tests against'
+    required: true
+  key_vault_name:
+    description: 'The name of the Azure Key Vault'
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+
+    - uses: Azure/get-keyvault-secrets@v1
+      id: get_test_secrets
+      with:
+        keyvault: ${{ inputs.key_vault_name }}
+        secrets: 'FUNCTIONAL-TESTS-CONFIG'
+
+    - name: Functional tests
+      id: functional_tests
+      run: |
+        dotnet test tests/DqtApi.FunctionalTests --configuration Release --logger trx --settings tests/DqtApi.FunctionalTests/ci.runsettings
+      env:
+        FunctionalTestsConfig: ${{ steps.get_test_secrets.outputs.FUNCTIONAL-TESTS-CONFIG }}
+        BaseUrl: ${{ inputs.base_url }}
+      shell: bash
+
+    - name: Test report
+      uses: dorny/test-reporter@v1
+      if: steps.functional_tests.outcome != 'skipped'
+      with:
+        name: ${{ inputs.environment_name }} functional test results
+        path: "**/*.trx"
+        reporter: dotnet-trx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,3 +207,29 @@ jobs:
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
         terraform_vars: test.tfvars.json
         terraform_backend_vars: test.backend.tfvars
+
+  deploy_prod:
+    name: Deploy to production environment
+    needs: [build, deploy_test]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.environment_url }}
+    concurrency: deploy_prod
+
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: ./.github/workflows/actions/deploy-environment
+      id: deploy
+      with:
+        environment_name: production
+        docker_image: ${{ needs.build.outputs.docker_image }}
+        azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        terraform_vars: prod.tfvars.json
+        terraform_backend_vars: prod.backend.tfvars
+        skip_functional_tests: true

--- a/azure/azuredeploy.prod.parameters.json
+++ b/azure/azuredeploy.prod.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "keyVaultName": {
+      "value": "s165p01-kv"
+    },
+    "storageAccountName": {
+      "value": "s165p01tfstate"
+    }
+  }
+}

--- a/terraform/prod.backend.tfvars
+++ b/terraform/prod.backend.tfvars
@@ -1,0 +1,2 @@
+storage_account_name = "s165p01tfstate"
+key                  = "prod.tfstate"

--- a/terraform/prod.tfvars.json
+++ b/terraform/prod.tfvars.json
@@ -1,0 +1,8 @@
+{
+  "key_vault_name": "s165p01-kv",
+  "resource_group_name": "s165p01-rg",
+  "api_app_name": "qualified-teachers-api-prod",
+  "api_instances": 2,
+  "paas_space": "tra-production",
+  "postgres_database_name": "qualified-teachers-api-prod-pg-svc"
+}


### PR DESCRIPTION
# Description

Adds production environment deployment to CI/CD pipeline after the test environment has been deployed.

Also splits out the functional test running so it can be more easily skipped (which we do for production - we don't have stable test data to run tests with currently).

## Link to Trello Card

https://trello.com/c/ttA2o9jD/144-provision-production-environment