### PR TITLE
Add pre-production environment to pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,9 +208,34 @@ jobs:
         terraform_vars: test.tfvars.json
         terraform_backend_vars: test.backend.tfvars
 
+  deploy_preprod:
+    name: Deploy to pre-production environment
+    needs: [build, deploy_test]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: pre-production
+      url: ${{ steps.deploy.outputs.environment_url }}
+    concurrency: deploy_preprod
+
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: ./.github/workflows/actions/deploy-environment
+      id: deploy
+      with:
+        environment_name: pre-production
+        docker_image: ${{ needs.build.outputs.docker_image }}
+        azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        terraform_vars: preprod.tfvars.json
+        terraform_backend_vars: preprod.backend.tfvars
+
   deploy_prod:
     name: Deploy to production environment
-    needs: [build, deploy_test]
+    needs: [build, deploy_preprod]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     environment:

--- a/azure/azuredeploy.preprod.parameters.json
+++ b/azure/azuredeploy.preprod.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "keyVaultName": {
+      "value": "s165t01-preprod-kv"
+    },
+    "storageAccountName": {
+      "value": "s165t01preprodtfstate"
+    }
+  }
+}

--- a/terraform/api-app.tf
+++ b/terraform/api-app.tf
@@ -13,7 +13,7 @@ resource "cloudfoundry_route" "api_public" {
 }
 
 resource "cloudfoundry_user_provided_service" "logging" {
-  name             = "logit-ssl-drain"
+  name             = var.logging_service_name
   space            = data.cloudfoundry_space.space.id
   syslog_drain_url = "syslog-tls://${local.logstash_endpoint}"
 }

--- a/terraform/dev.tfvars.json
+++ b/terraform/dev.tfvars.json
@@ -2,6 +2,7 @@
   "key_vault_name": "s165d01-kv",
   "resource_group_name": "s165d01-rg",
   "api_app_name": "qualified-teachers-api-dev",
+  "logging_service_name": "logit-ssl-drain-dev",
   "paas_space": "tra-dev",
   "postgres_database_name": "qualified-teachers-api-dev-pg-svc"
 }

--- a/terraform/preprod.backend.tfvars
+++ b/terraform/preprod.backend.tfvars
@@ -1,0 +1,2 @@
+storage_account_name = "s165t01preprodtfstate"
+key                  = "preprod.tfstate"

--- a/terraform/preprod.tfvars.json
+++ b/terraform/preprod.tfvars.json
@@ -1,0 +1,8 @@
+{
+  "key_vault_name": "s165t01-preprod-kv",
+  "resource_group_name": "s165t01-preprod-rg",
+  "api_app_name": "qualified-teachers-api-preprod",
+  "logging_service_name": "logit-ssl-drain-preprod",
+  "paas_space": "tra-test",
+  "postgres_database_name": "qualified-teachers-api-preprod-pg-svc"
+}

--- a/terraform/prod.tfvars.json
+++ b/terraform/prod.tfvars.json
@@ -3,6 +3,7 @@
   "resource_group_name": "s165p01-rg",
   "api_app_name": "qualified-teachers-api-prod",
   "api_instances": 2,
+  "logging_service_name": "logit-ssl-drain-prod",
   "paas_space": "tra-production",
   "postgres_database_name": "qualified-teachers-api-prod-pg-svc"
 }

--- a/terraform/test.tfvars.json
+++ b/terraform/test.tfvars.json
@@ -2,6 +2,7 @@
   "key_vault_name": "s165t01-kv",
   "resource_group_name": "s165t01-rg",
   "api_app_name": "qualified-teachers-api-test",
+  "logging_service_name": "logit-ssl-drain-test",
   "paas_space": "tra-test",
   "postgres_database_name": "qualified-teachers-api-test-pg-svc"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,10 @@ variable "api_disk_quota" {
   default = "1024"
 }
 
+variable "logging_service_name" {
+  type = string
+}
+
 variable "postgres_database_name" {
   type = string
 }


### PR DESCRIPTION
# Description

Adds pre-production environment deployment to CI/CD pipeline between the test and production environments.

Also amends the `logging` user-defined service to give it an environment-specific name, since pre-prod's resource live in the same PAAS space as the test environment.

## Link to Trello Card

https://trello.com/c/wCvn2TBm/145-provision-pre-production-environment
