### PR TITLE
DB conventions & testing helpers

### DIFF
--- a/src/DqtApi/DataStore/Sql/DbContextTransactionExtensions.cs
+++ b/src/DqtApi/DataStore/Sql/DbContextTransactionExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace DqtApi.DataStore.Sql
+{
+    public static class DbContextTransactionExtensions
+    {
+        public static async Task AcquireAdvisoryLock(this IDbContextTransaction transaction, long key)
+        {
+            if (transaction is null)
+            {
+                throw new ArgumentNullException(nameof(transaction));
+            }
+
+            var dbTransaction = transaction.GetDbTransaction();
+
+            using (var command = dbTransaction.Connection.CreateCommand())
+            {
+                command.Transaction = dbTransaction;
+                command.CommandText = "SELECT pg_advisory_xact_lock(@id);";
+
+                var idParameter = command.CreateParameter();
+                idParameter.ParameterName = "id";
+                idParameter.Value = key;
+
+                command.Parameters.Add(idParameter);
+
+                await command.ExecuteNonQueryAsync();
+            }
+        }
+
+        public static Task AcquireAdvisoryLock(this IDbContextTransaction transaction, params object[] keys)
+        {
+            if (transaction is null)
+            {
+                throw new ArgumentNullException(nameof(transaction));
+            }
+
+            if (keys.Length == 0)
+            {
+                throw new ArgumentException("At least one key must be specified.", nameof(keys));
+            }
+
+            var hashCode = new HashCode();
+
+            foreach (var key in keys)
+            {
+                hashCode.Add(key.GetHashCode());
+            }
+
+            var combinedKey = hashCode.ToHashCode();
+
+            return AcquireAdvisoryLock(transaction, combinedKey);
+        }
+    }
+}

--- a/src/DqtApi/DataStore/Sql/DqtContext.cs
+++ b/src/DqtApi/DataStore/Sql/DqtContext.cs
@@ -16,8 +16,16 @@ namespace DqtApi.DataStore.Sql
 
         public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString)
         {
+            if (connectionString != null)
+            {
+                optionsBuilder.UseNpgsql(connectionString);
+            }
+            else
+            {
+                optionsBuilder.UseNpgsql();
+            }
+
             optionsBuilder
-                .UseNpgsql(connectionString)
                 .UseSnakeCaseNamingConvention();
         }
 

--- a/src/DqtApi/DataStore/Sql/DqtContext.cs
+++ b/src/DqtApi/DataStore/Sql/DqtContext.cs
@@ -19,6 +19,11 @@ namespace DqtApi.DataStore.Sql
             optionsBuilder.UseNpgsql(connectionString);
         }
 
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(DqtContext).Assembly);
+        }
+
         private static DbContextOptions<DqtContext> CreateOptions(string connectionString)
         {
             var optionsBuilder = new DbContextOptionsBuilder<DqtContext>();

--- a/src/DqtApi/DataStore/Sql/DqtContext.cs
+++ b/src/DqtApi/DataStore/Sql/DqtContext.cs
@@ -16,7 +16,9 @@ namespace DqtApi.DataStore.Sql
 
         public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString)
         {
-            optionsBuilder.UseNpgsql(connectionString);
+            optionsBuilder
+                .UseNpgsql(connectionString)
+                .UseSnakeCaseNamingConvention();
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/DqtApi/DataStore/Sql/DqtDesignTimeDbContextFactory.cs
+++ b/src/DqtApi/DataStore/Sql/DqtDesignTimeDbContextFactory.cs
@@ -9,6 +9,7 @@ namespace DqtApi.DataStore.Sql
         {
             var options = new DbContextOptionsBuilder<DqtContext>()
                 .UseNpgsql()
+                .UseSnakeCaseNamingConvention()
                 .Options;
 
             return new DqtContext(options);

--- a/src/DqtApi/DataStore/Sql/DqtDesignTimeDbContextFactory.cs
+++ b/src/DqtApi/DataStore/Sql/DqtDesignTimeDbContextFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
 
 namespace DqtApi.DataStore.Sql
 {
@@ -7,12 +8,16 @@ namespace DqtApi.DataStore.Sql
     {
         public DqtContext CreateDbContext(string[] args)
         {
-            var options = new DbContextOptionsBuilder<DqtContext>()
-                .UseNpgsql()
-                .UseSnakeCaseNamingConvention()
-                .Options;
+            var configuration = new ConfigurationBuilder()
+                .AddUserSecrets<DqtDesignTimeDbContextFactory>(optional: true)  // Optional for CI
+                .Build();
 
-            return new DqtContext(options);
+            var connectionString = configuration.GetConnectionString("DefaultConnection");
+
+            var optionsBuilder = new DbContextOptionsBuilder<DqtContext>();
+            DqtContext.ConfigureOptions(optionsBuilder, connectionString);
+
+            return new DqtContext(optionsBuilder.Options);
         }
     }
 }

--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
     <PackageReference Include="HybridModelBinding" Version="0.18.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />

--- a/tests/DqtApi.Tests/ApiTestBase.cs
+++ b/tests/DqtApi.Tests/ApiTestBase.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using DqtApi.DataStore.Sql;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace DqtApi.Tests
@@ -29,5 +31,19 @@ namespace DqtApi.Tests
         public virtual Task DisposeAsync() => Task.CompletedTask;
 
         public virtual Task InitializeAsync() => ApiFixture.DbHelper.ClearData();
+
+        public virtual async Task<T> WithDbContext<T>(Func<DqtContext, Task<T>> action)
+        {
+            await using var scope = ApiFixture.Services.GetRequiredService<IServiceScopeFactory>().CreateAsyncScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<DqtContext>();
+            return await action(dbContext);
+        }
+
+        public virtual Task WithDbContext(Func<DqtContext, Task> action) =>
+            WithDbContext(async dbContext =>
+            {
+                await action(dbContext);
+                return 0;
+            });
     }
 }

--- a/tests/DqtApi.Tests/DbHelper.cs
+++ b/tests/DqtApi.Tests/DbHelper.cs
@@ -27,7 +27,6 @@ namespace DqtApi.Tests
         {
             using var dbContext = new DqtContext(_connectionString);
             await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
             await dbContext.Database.MigrateAsync();
 
             CreateCheckpoint();


### PR DESCRIPTION
Adds a few helper methods for:
- getting a Postgres advisory lock;
- working with `DbContext` in tests (e.g. for adding test data).

Applies a snake case naming convention to generated database objects.

Apply fluent entity configurations via discovery.

Also fixes design-time DbContext creation (so that generating migrations works correctly).