### PR TITLE
Add a V2 API spec and separate operations by namespace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,9 @@ jobs:
     needs: deploy_dev
     runs-on: ubuntu-latest
     concurrency: deploy_dev
+    strategy:
+      matrix:
+        version: [v1, v2]
 
     steps:
     - name: Create config file
@@ -177,7 +180,7 @@ jobs:
 
     - uses: zaproxy/action-api-scan@v0.1.0
       with:
-        target: ${{ needs.deploy_dev.outputs.environment_url }}swagger/v1/swagger.json
+        target: ${{ needs.deploy_dev.outputs.environment_url }}swagger/${{ matrix.version }}/swagger.json
         format: openapi
         allow_issue_writing: false
         fail_action: true

--- a/src/DqtApi/ApiVersionConvention.cs
+++ b/src/DqtApi/ApiVersionConvention.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace DqtApi
+{
+    public class ApiVersionConvention : IControllerModelConvention
+    {
+        public void Apply(ControllerModel controller)
+        {
+            var controllerNamespace = controller.ControllerType.Namespace;
+            var namespaceVersion = controllerNamespace.Split('.')[1];
+
+            if (namespaceVersion[0] == 'V' && int.TryParse(namespaceVersion.TrimStart('V'), out var version))
+            {
+                ApplyGroupName();
+                ApplyRoutePrefix();
+
+                // Group name is used to partition the operations by version into different swagger docs
+                void ApplyGroupName() => controller.ApiExplorer.GroupName = $"v{version}";
+
+                // A V1 operation gets a /v1 route prefix, V2 operation a /v2 route prefix etc.
+                void ApplyRoutePrefix()
+                {
+                    var routePrefix = new AttributeRouteModel(new RouteAttribute($"v{version}"));
+
+                    foreach (var selector in controller.Selectors)
+                    {
+                        selector.AttributeRouteModel = selector.AttributeRouteModel != null ?
+                            AttributeRouteModel.CombineAttributeRouteModel(routePrefix, selector.AttributeRouteModel) :
+                            routePrefix;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -64,6 +64,8 @@ namespace DqtApi
                     options.Filters.Add(new AuthorizeFilter());
                     options.Filters.Add(new ProducesJsonOrProblemAttribute());
                     options.Filters.Add(new CrmServiceProtectionFaultExceptionFilter());
+
+                    options.Conventions.Add(new ApiVersionConvention());
                 })
                 .AddFluentValidation(fv =>
                 {
@@ -77,6 +79,9 @@ namespace DqtApi
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo() { Title = "DQT API", Version = "v1" });
+                c.SwaggerDoc("v2", new OpenApiInfo() { Title = "DQT API", Version = "v2" });
+
+                c.DocInclusionPredicate((docName, api) => docName.Equals(api.GroupName, StringComparison.OrdinalIgnoreCase));
                 c.EnableAnnotations();
                 c.OperationFilter<ResponseContentTypeOperationFilter>();
 
@@ -200,7 +205,8 @@ namespace DqtApi
             {
                 app.UseSwaggerUI(c =>
                 {
-                    c.SwaggerEndpoint("v1/swagger.json", "DQT API");
+                    c.SwaggerEndpoint("v1/swagger.json", "DQT API v1");
+                    c.SwaggerEndpoint("v2/swagger.json", "DQT API v2");
                     c.EnablePersistAuthorization();
                 });
 

--- a/src/DqtApi/V1/Controllers/TeachersController.cs
+++ b/src/DqtApi/V1/Controllers/TeachersController.cs
@@ -2,15 +2,15 @@ using System.Linq;
 using System.Threading.Tasks;
 using DqtApi.DAL;
 using DqtApi.Models;
-using DqtApi.Responses;
+using DqtApi.V1.Responses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
-namespace DqtApi
+namespace DqtApi.V1.Controllers
 {
     [ApiController]
-    [Route("v1/teachers")]
+    [Route("teachers")]
     public class TeachersController : ControllerBase
     {
         private readonly IDataverseAdaptor _dataverseAdaptor;
@@ -27,7 +27,7 @@ namespace DqtApi
         [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> GetTeacher([FromRoute]GetTeacherRequest request)           
+        public async Task<IActionResult> GetTeacher([FromRoute] GetTeacherRequest request)           
         {            
             if (!request.BirthDate.HasValue)
             {

--- a/src/DqtApi/V1/Responses/EntityExtensions.cs
+++ b/src/DqtApi/V1/Responses/EntityExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using DqtApi.DAL;
 using Microsoft.Xrm.Sdk;
 
-namespace DqtApi.Responses
+namespace DqtApi.V1.Responses
 {
     public static class EntityExtensions
     {

--- a/src/DqtApi/V1/Responses/GetTeacherResponse.cs
+++ b/src/DqtApi/V1/Responses/GetTeacherResponse.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using DqtApi.Models;
 
-namespace DqtApi.Responses
+namespace DqtApi.V1.Responses
 {
     public class GetTeacherResponse
     {

--- a/src/DqtApi/V1/Responses/Induction.cs
+++ b/src/DqtApi/V1/Responses/Induction.cs
@@ -2,7 +2,7 @@
 using System.Text.Json.Serialization;
 using DqtApi.Models;
 
-namespace DqtApi.Responses
+namespace DqtApi.V1.Responses
 {
     public class Induction : LinkedEntity<dfeta_induction>
     {

--- a/src/DqtApi/V1/Responses/InitialTeacherTraining.cs
+++ b/src/DqtApi/V1/Responses/InitialTeacherTraining.cs
@@ -4,7 +4,7 @@ using DqtApi.DAL;
 using DqtApi.Models;
 using Microsoft.Xrm.Sdk;
 
-namespace DqtApi.Responses
+namespace DqtApi.V1.Responses
 {
     public class InitialTeacherTraining : LinkedEntity<dfeta_initialteachertraining>
     {

--- a/src/DqtApi/V1/Responses/LinkedEntity.cs
+++ b/src/DqtApi/V1/Responses/LinkedEntity.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using Microsoft.Xrm.Sdk;
 
-namespace DqtApi.Responses
+namespace DqtApi.V1.Responses
 {
     public abstract class LinkedEntity<T> where T : Entity, new()
     {

--- a/src/DqtApi/V1/Responses/Qualification.cs
+++ b/src/DqtApi/V1/Responses/Qualification.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 using DqtApi.DAL;
 using DqtApi.Models;
 
-namespace DqtApi.Responses
+namespace DqtApi.V1.Responses
 {
     public class Qualification
     {

--- a/src/DqtApi/V1/Responses/QualifiedTeacherStatus.cs
+++ b/src/DqtApi/V1/Responses/QualifiedTeacherStatus.cs
@@ -2,7 +2,7 @@
 using System.Text.Json.Serialization;
 using DqtApi.Models;
 
-namespace DqtApi.Responses
+namespace DqtApi.V1.Responses
 {
     public class QualifiedTeacherStatus : LinkedEntity<dfeta_qtsregistration>
     {

--- a/src/DqtApi/V1/Responses/Subject.cs
+++ b/src/DqtApi/V1/Responses/Subject.cs
@@ -1,6 +1,6 @@
 ﻿using DqtApi.Models;
 
-namespace DqtApi.Responses
+namespace DqtApi.V1.Responses
 {
     public class Subject : LinkedEntity<dfeta_ittsubject>
     {

--- a/src/DqtApi/V1/Validators/GetTeacherRequestValidator.cs
+++ b/src/DqtApi/V1/Validators/GetTeacherRequestValidator.cs
@@ -1,7 +1,7 @@
 ﻿using DqtApi.Models;
 using FluentValidation;
 
-namespace DqtApi.Validators
+namespace DqtApi.V1.Validators
 {
     public class GetTeacherRequestValidator : AbstractValidator<GetTeacherRequest>
     {

--- a/tests/DqtApi.FunctionalTests/Endpoints/SwaggerTests.cs
+++ b/tests/DqtApi.FunctionalTests/Endpoints/SwaggerTests.cs
@@ -16,10 +16,12 @@ namespace DqtApi.FunctionalTests.Endpoints
 
         public HttpClient HttpClient { get; }
 
-        [Fact]
-        public async Task GetSwaggerDoc()
+        [Theory]
+        [InlineData("v1")]
+        [InlineData("v2")]
+        public async Task GetSwaggerDoc(string version)
         {
-            var response = await HttpClient.GetAsync("swagger/v1/swagger.json");
+            var response = await HttpClient.GetAsync($"swagger/{version}/swagger.json");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);

--- a/tests/DqtApi.FunctionalTests/Endpoints/V1/GetTeacherTests.cs
+++ b/tests/DqtApi.FunctionalTests/Endpoints/V1/GetTeacherTests.cs
@@ -6,7 +6,7 @@ using DqtApi.TestCommon;
 using Xunit;
 using Xunit.Extensions.AssemblyFixture;
 
-namespace DqtApi.FunctionalTests.Endpoints
+namespace DqtApi.FunctionalTests.Endpoints.V1
 {
     public class GetTeacherTests : IAssemblyFixture<ApiFixture>
     {

--- a/tests/DqtApi.Tests/V1/Operations/GetTeacherTests.cs
+++ b/tests/DqtApi.Tests/V1/Operations/GetTeacherTests.cs
@@ -4,7 +4,7 @@ using DqtApi.Properties;
 using DqtApi.TestCommon;
 using Xunit;
 
-namespace DqtApi.Tests
+namespace DqtApi.Tests.V1.Operations
 {
     public class GetTeacherTests : ApiTestBase
     {

--- a/tests/DqtApi.Tests/V1/UnitTests/GetTeacherRequest.cs
+++ b/tests/DqtApi.Tests/V1/UnitTests/GetTeacherRequest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using DqtApi.Models;
 using Xunit;
 
-namespace DqtApi.Tests.UnitTests
+namespace DqtApi.Tests.V1.UnitTests
 {
     public class GetTeacherRequest
     {

--- a/tests/DqtApi.Tests/V1/UnitTests/GetTeacherResponse.cs
+++ b/tests/DqtApi.Tests/V1/UnitTests/GetTeacherResponse.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using DqtApi.Models;
 using Microsoft.Xrm.Sdk;
 using Xunit;
 
-namespace DqtApi.Tests.UnitTests
+namespace DqtApi.Tests.V1.UnitTests
 {
     public class GetTeacherResponse
     {
@@ -30,7 +28,7 @@ namespace DqtApi.Tests.UnitTests
 
             contact.FormattedValues.Add(Contact.Fields.StateCode, ContactState.Active.ToString());
 
-            var response = new Responses.GetTeacherResponse(contact);
+            var response = new DqtApi.V1.Responses.GetTeacherResponse(contact);
 
             Assert.True(response.ActiveAlert);
             Assert.Equal(birthDate, response.DateOfBirth);
@@ -66,7 +64,7 @@ namespace DqtApi.Tests.UnitTests
 
             contact.FormattedValues.Add($"{prefix}.{dfeta_qtsregistration.Fields.StateCode}", dfeta_qtsregistrationState.Active.ToString());
 
-            var response = new Responses.GetTeacherResponse(contact);
+            var response = new DqtApi.V1.Responses.GetTeacherResponse(contact);
 
             var qualifiedTeacherStatus = response.QualifiedTeacherStatus;
 
@@ -104,7 +102,7 @@ namespace DqtApi.Tests.UnitTests
             contact.FormattedValues.Add($"{prefix}.{dfeta_induction.Fields.dfeta_InductionStatus}", inductionStatusName);
             contact.FormattedValues.Add($"{prefix}.{dfeta_induction.Fields.StateCode}", dfeta_inductionState.Active.ToString());
 
-            var response = new Responses.GetTeacherResponse(contact);
+            var response = new DqtApi.V1.Responses.GetTeacherResponse(contact);
 
             var induction = response.Induction;
 
@@ -164,7 +162,7 @@ namespace DqtApi.Tests.UnitTests
             contact.FormattedValues.Add($"{prefix}.{dfeta_initialteachertraining.Fields.dfeta_Subject3Id}", subject3);
             contact.FormattedValues.Add($"{prefix}.{dfeta_initialteachertraining.Fields.StateCode}", dfeta_initialteachertrainingState.Active.ToString());
 
-            var response = new Responses.GetTeacherResponse(contact);
+            var response = new DqtApi.V1.Responses.GetTeacherResponse(contact);
 
             var initialTeacherTraining = response.InitialTeacherTraining;
 
@@ -202,7 +200,7 @@ namespace DqtApi.Tests.UnitTests
                 })
             };
 
-            var response = new Responses.GetTeacherResponse(contact);
+            var response = new DqtApi.V1.Responses.GetTeacherResponse(contact);
 
             var qualifications = response.Qualifications;
 

--- a/tests/DqtApi.Tests/V1/UnitTests/TeachersController.cs
+++ b/tests/DqtApi.Tests/V1/UnitTests/TeachersController.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using DqtApi.DAL;
 using DqtApi.Models;
-using DqtApi.Responses;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
 
-namespace DqtApi.Tests.UnitTests
+namespace DqtApi.Tests.V1.UnitTests
 {
     public class TeachersController
     {
@@ -26,7 +25,7 @@ namespace DqtApi.Tests.UnitTests
         {
             _adaptor.Setup(a => a.GetMatchingTeachersAsync(It.IsAny<Models.GetTeacherRequest>())).ReturnsAsync(new List<Contact>());
 
-            var result = await new DqtApi.TeachersController(_adaptor.Object).GetTeacher(new Models.GetTeacherRequest{ TRN = trn, BirthDate = birthDate });
+            var result = await new DqtApi.V1.Controllers.TeachersController(_adaptor.Object).GetTeacher(new Models.GetTeacherRequest { TRN = trn, BirthDate = birthDate });
 
             Assert.IsType<NotFoundResult>(result);
         }
@@ -36,7 +35,7 @@ namespace DqtApi.Tests.UnitTests
         {
             _adaptor.Setup(a => a.GetMatchingTeachersAsync(It.IsAny<Models.GetTeacherRequest>())).ReturnsAsync(new[] { new Contact{ dfeta_TRN = trn } });
 
-            var result = await new DqtApi.TeachersController(_adaptor.Object).GetTeacher(new Models.GetTeacherRequest { TRN = trn, BirthDate = birthDate });
+            var result = await new DqtApi.V1.Controllers.TeachersController(_adaptor.Object).GetTeacher(new Models.GetTeacherRequest { TRN = trn, BirthDate = birthDate });
 
             Assert.IsType<OkObjectResult>(result);
         }


### PR DESCRIPTION
# Description

Adds a convention for separating endpoints into API versions by namespace e.g. controllers in the `DqtApi.V1` namespace go into the V1 API, `DqtApi.V21 into the V2 API etc.

Updates the OWASP scan to crawl both the V1 and V2 API specs.

## Link to Trello Card

Pre-requisite for https://trello.com/c/EgaTYdhB/146-decommission-dttp