### PR TITLE
Add status endpoint and include Postgres & CRM checks

### DIFF
--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
     <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
     <PackageReference Include="HybridModelBinding" Version="0.18.0" />


### PR DESCRIPTION
### Context

https://trello.com/c/FoAsQBD8/82-add-production-api-to-teacher-services-status-site

### Changes proposed in this pull request

Adds a `/status` endpoint which runs checks against Postgres & CRM and returns either 200 or 503 based on whether all checks have passed or any have failed.

N.B. this is a different endpoint to `/health`, which is used by PAAS to decide whether a specific app instance is healthy. Since this check includes external components (which should *not* trigger PAAS to restart app nodes) it's a different endpoint.

### Guidance to review

- Run the app, browse to `/status` and observe successful status check response.
- Stop local Postgres instance, browse to `/status` and observe failed status check response.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
