### PR TITLE
Model binding and Swagger improvements

### DIFF
--- a/src/DqtApi/CamelCaseErrorKeysProblemDetailsFactory.cs
+++ b/src/DqtApi/CamelCaseErrorKeysProblemDetailsFactory.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace DqtApi
+{
+    public class CamelCaseErrorKeysProblemDetailsFactory : ProblemDetailsFactory
+    {
+        private readonly ProblemDetailsFactory _innerFactory;
+
+        public CamelCaseErrorKeysProblemDetailsFactory(ProblemDetailsFactory innerFactory)
+        {
+            _innerFactory = innerFactory;
+        }
+
+        public override ProblemDetails CreateProblemDetails(
+            HttpContext httpContext,
+            int? statusCode = null,
+            string title = null,
+            string type = null,
+            string detail = null,
+            string instance = null)
+        {
+            return _innerFactory.CreateProblemDetails(httpContext, statusCode, title, type, detail, instance);
+        }
+
+        public override ValidationProblemDetails CreateValidationProblemDetails(
+            HttpContext httpContext,
+            ModelStateDictionary modelStateDictionary,
+            int? statusCode = null,
+            string title = null,
+            string type = null,
+            string detail = null,
+            string instance = null)
+        {
+            var problemDetails = _innerFactory.CreateValidationProblemDetails(httpContext, modelStateDictionary, statusCode, title, type, detail, instance);
+
+            // All our property names are camel cased; ensure error keys are camel cased too
+
+            foreach (var errorKey in problemDetails.Errors.Keys.ToArray())
+            {
+                var errors = problemDetails.Errors[errorKey];
+                problemDetails.Errors.Remove(errorKey);
+
+                var camelCasedKey = System.Text.Json.JsonNamingPolicy.CamelCase.ConvertName(errorKey);
+                problemDetails.Errors.Add(camelCasedKey, errors);
+            }
+
+            return problemDetails;
+        }
+    }
+}

--- a/src/DqtApi/DataStore/Crm/Models/GetTeacherRequest.cs
+++ b/src/DqtApi/DataStore/Crm/Models/GetTeacherRequest.cs
@@ -12,7 +12,7 @@ namespace DqtApi.DataStore.Crm.Models
         [FromRoute(Name = "trn")]
         public string TRN { get; set; }
 
-        [FromQuery(Name = "birthdate"), SwaggerParameter(Required = true), SwaggerSchema(Format = "date"), ModelBinder(typeof(ModelBinders.DateTimeReverseOrderBinder))]
+        [FromQuery(Name = "birthdate"), SwaggerParameter(Required = true), SwaggerSchema(Format = "date"), ModelBinder(typeof(ModelBinding.DateTimeReverseOrderBinder))]
         public DateTime? BirthDate { get; set; }
 
         [FromQuery(Name = "nino")]

--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="0.5.17" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.2" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.2" />
+    <PackageReference Include="Scrutor" Version="3.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />

--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
     <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
-    <PackageReference Include="HybridModelBinding" Version="0.18.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">

--- a/src/DqtApi/Json/DateOnlyConverter.cs
+++ b/src/DqtApi/Json/DateOnlyConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DqtApi.ModelBinding;
+
+namespace DqtApi.Json
+{
+    public class DateOnlyConverter : JsonConverter<DateOnly>
+    {
+        public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new InvalidOperationException($"Cannot get the value of a token type '{reader.TokenType}' as a string.");
+            }
+
+            var asString = reader.GetString();
+            if (!DateOnly.TryParseExact(asString, Constants.DateFormat, out var value))
+            {
+                throw new FormatException("The JSON value is not in a supported DateOnly format.");
+            }
+
+            return value;
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+        {
+            var asString = value.ToString(Constants.DateFormat);
+            writer.WriteStringValue(asString);
+        }
+    }
+}

--- a/src/DqtApi/ModelBinding/Constants.cs
+++ b/src/DqtApi/ModelBinding/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace DqtApi.ModelBinding
+{
+    public static class Constants
+    {
+        public static string DateFormat = "yyyy-MM-dd";
+    }
+}

--- a/src/DqtApi/ModelBinding/DateTimeReverseOrderBinder.cs
+++ b/src/DqtApi/ModelBinding/DateTimeReverseOrderBinder.cs
@@ -31,7 +31,7 @@ namespace DqtApi.ModelBinding
                 return Task.CompletedTask;
             }
 
-            if (!DateTime.TryParseExact(value, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out DateTime result))
+            if (!DateTime.TryParseExact(value, Constants.DateFormat, null, System.Globalization.DateTimeStyles.None, out DateTime result))
             {
                 bindingContext.ModelState.TryAddModelError(modelName, Properties.StringResources.ErrorMessages_InvalidBirthDate);
 

--- a/src/DqtApi/ModelBinding/DateTimeReverseOrderBinder.cs
+++ b/src/DqtApi/ModelBinding/DateTimeReverseOrderBinder.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
-namespace DqtApi.ModelBinders
+namespace DqtApi.ModelBinding
 {
     public class DateTimeReverseOrderBinder : IModelBinder
     {       

--- a/src/DqtApi/ModelBinding/HybridBodyApiDescriptionProvider.cs
+++ b/src/DqtApi/ModelBinding/HybridBodyApiDescriptionProvider.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace DqtApi.ModelBinding
+{
+    public class HybridBodyApiDescriptionProvider : IApiDescriptionProvider
+    {
+        private readonly IModelMetadataProvider _modelMetadataProvider;
+
+        public HybridBodyApiDescriptionProvider(IModelMetadataProvider modelMetadataProvider)
+        {
+            _modelMetadataProvider = modelMetadataProvider;
+        }
+
+        public int Order => 0;
+
+        public void OnProvidersExecuted(ApiDescriptionProviderContext context)
+        {
+            foreach (var apiDescription in context.Results)
+            {
+                foreach (var parameterDescription in apiDescription.ParameterDescriptions.ToArray())
+                {
+                    if (parameterDescription.BindingInfo?.BindingSource == BindingSource.Body)
+                    {
+                        var bodyParameterType = parameterDescription.Type;
+
+                        foreach (var property in bodyParameterType.GetProperties())
+                        {
+                            var fromQueryAttribute = property.GetCustomAttribute<FromQueryAttribute>();
+                            var fromRouteAttribute = property.GetCustomAttribute<FromRouteAttribute>();
+
+                            if (fromQueryAttribute != null || fromRouteAttribute != null)
+                            {
+                                var modelMetadata = _modelMetadataProvider.GetMetadataForProperty(bodyParameterType, property.Name);
+                                var bindingInfo = BindingInfo.GetBindingInfo(property.GetCustomAttributes(), modelMetadata);
+
+                                var name = ModelNames.CreatePropertyModelName(
+                                    prefix: string.Empty,
+                                    propertyName: !string.IsNullOrEmpty(modelMetadata.BinderModelName) ? modelMetadata.BinderModelName : modelMetadata.PropertyName);
+
+                                if (fromRouteAttribute != null)
+                                {
+                                    // We should have an existing parameter for this property (that comes from the route template).
+                                    // If so, enrich it rather than replacing it
+
+                                    var existingRouteParameter = apiDescription.ParameterDescriptions
+                                        .SingleOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && p.Source == BindingSource.Path);
+
+                                    if (existingRouteParameter != null)
+                                    {
+                                        existingRouteParameter.ModelMetadata = modelMetadata;
+                                        existingRouteParameter.Type = modelMetadata.ModelType;
+
+                                        continue;
+                                    }
+                                }
+
+                                apiDescription.ParameterDescriptions.Add(new ApiParameterDescription()
+                                {
+                                    BindingInfo = bindingInfo,
+                                    Name = name,
+                                    Source = modelMetadata.BindingSource,
+                                    Type = modelMetadata.ModelType,
+                                    ModelMetadata = modelMetadata
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void OnProvidersExecuting(ApiDescriptionProviderContext context)
+        {
+        }
+    }
+}

--- a/src/DqtApi/ModelBinding/HybridBodyModelBinderProvider.cs
+++ b/src/DqtApi/ModelBinding/HybridBodyModelBinderProvider.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+namespace DqtApi.ModelBinding
+{
+    public class HybridBodyModelBinderProvider : IModelBinderProvider
+    {
+        private readonly BodyModelBinderProvider _innerProvider;
+
+        public HybridBodyModelBinderProvider(BodyModelBinderProvider innerProvider)
+        {
+            _innerProvider = innerProvider;
+        }
+
+        public IModelBinder GetBinder(ModelBinderProviderContext context)
+        {
+            var modelBinder = _innerProvider.GetBinder(context);
+
+            if (modelBinder == null || context.BindingInfo.BindingSource != BindingSource.Body)
+            {
+                return modelBinder;
+            }
+
+            var propertyBinders = new Dictionary<ModelMetadata, IModelBinder>();
+            foreach (var property in context.Metadata.Properties)
+            {
+                var createPropertyBinder = property.BindingSource == BindingSource.Path ||
+                    property.BindingSource == BindingSource.Query;
+
+                if (createPropertyBinder)
+                {
+                    propertyBinders.Add(property, context.CreateBinder(property));
+                }
+            }
+
+            return new HybridBodyModelBinder(modelBinder, propertyBinders);
+        }
+
+        private class HybridBodyModelBinder : IModelBinder
+        {
+            private readonly IModelBinder _innerModelBinder;
+            private readonly Dictionary<ModelMetadata, IModelBinder> _propertyBinders;
+
+            public HybridBodyModelBinder(IModelBinder innerModelBinder, Dictionary<ModelMetadata, IModelBinder> propertyBinders)
+            {
+                _innerModelBinder = innerModelBinder;
+                _propertyBinders = propertyBinders;
+            }
+
+            public async Task BindModelAsync(ModelBindingContext bindingContext)
+            {
+                await _innerModelBinder.BindModelAsync(bindingContext);
+
+                if (bindingContext.Result.IsModelSet)
+                {
+                    foreach (var (property, propertyBinder) in _propertyBinders)
+                    {
+                        var fieldName = property.PropertyName;
+                        var modelName = ModelNames.CreatePropertyModelName(bindingContext.ModelName, fieldName);
+
+                        ModelBindingResult result;
+                        using (bindingContext.EnterNestedScope(property, fieldName, modelName, model: null))
+                        {
+                            await propertyBinder.BindModelAsync(bindingContext);
+                            result = bindingContext.Result;
+                        }
+
+                        property.PropertySetter(
+                            bindingContext.Result.Model,
+                            result.IsModelSet ? result.Model : CreateDefaultValue(property.ModelType));
+                    }
+                }
+
+                static object CreateDefaultValue(Type type) => type.IsValueType ? Activator.CreateInstance(type) : null;
+            }
+        }
+    }
+}

--- a/src/DqtApi/ModelBinding/MvcOptionsExtensions.cs
+++ b/src/DqtApi/ModelBinding/MvcOptionsExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+namespace DqtApi.ModelBinding
+{
+    public static class MvcOptionsExtensions
+    {
+        public static void AddHybridBodyModelBinderProvider(this MvcOptions options)
+        {
+            var bodyModelBinderProvider = options.ModelBinderProviders.OfType<BodyModelBinderProvider>().Single();
+            var hybridBodyModelBinderProvider = new HybridBodyModelBinderProvider(bodyModelBinderProvider);
+            options.ModelBinderProviders[options.ModelBinderProviders.IndexOf(bodyModelBinderProvider)] = hybridBodyModelBinderProvider;
+        }
+    }
+}

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -6,12 +6,14 @@ using DqtApi.Configuration;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Sql;
 using DqtApi.Filters;
+using DqtApi.ModelBinding;
 using DqtApi.Security;
 using DqtApi.Swagger;
 using FluentValidation.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -65,6 +67,8 @@ namespace DqtApi
             services
                 .AddMvc(options =>
                 {
+                    options.AddHybridBodyModelBinderProvider();
+
                     options.Filters.Add(new AuthorizeFilter());
                     options.Filters.Add(new ProducesJsonOrProblemAttribute());
                     options.Filters.Add(new CrmServiceProtectionFaultExceptionFilter());
@@ -78,11 +82,9 @@ namespace DqtApi
                 .AddFluentValidation(fv =>
                 {
                     fv.RegisterValidatorsFromAssemblyContaining(typeof(Program));
-                })
-                .AddHybridModelBinder(options =>
-                {
-                    options.FallbackBindingOrder = new[] { HybridModelBinding.Source.Body };
                 });
+
+            services.AddTransient<IApiDescriptionProvider, HybridBodyApiDescriptionProvider>();
 
             services.AddControllers()
                 .AddJsonOptions(options =>

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -97,6 +97,8 @@ namespace DqtApi
                     options.JsonSerializerOptions.Converters.Add(new DateOnlyConverter());
                 });
 
+            services.Decorate<Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory, CamelCaseErrorKeysProblemDetailsFactory>();
+
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo() { Title = "DQT API", Version = "v1" });

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -6,6 +6,7 @@ using DqtApi.Configuration;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Sql;
 using DqtApi.Filters;
+using DqtApi.Json;
 using DqtApi.ModelBinding;
 using DqtApi.Security;
 using DqtApi.Swagger;
@@ -13,6 +14,7 @@ using FluentValidation.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
@@ -20,6 +22,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Npgsql;
@@ -27,6 +30,7 @@ using Prometheus;
 using Serilog;
 using Serilog.Context;
 using Swashbuckle.AspNetCore.Filters;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace DqtApi
 {
@@ -90,6 +94,7 @@ namespace DqtApi
                 .AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                    options.JsonSerializerOptions.Converters.Add(new DateOnlyConverter());
                 });
 
             services.AddSwaggerGen(c =>
@@ -148,6 +153,11 @@ namespace DqtApi
             services.AddSingleton<IApiClientRepository, ConfigurationApiClientRepository>();
             services.AddSingleton<ICurrentClientProvider, ClaimsPrincipalCurrentClientProvider>();
             services.AddSwaggerExamplesFromAssemblyOf<Program>();
+            services.AddTransient<ISerializerDataContractResolver>(sp =>
+            {
+                var serializerOptions = sp.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions;
+                return new Swagger.JsonSerializerDataContractResolver(serializerOptions);
+            });
 
             services.AddDbContext<DqtContext>(options =>
             {

--- a/src/DqtApi/Swagger/JsonSerializerDataContractResolver.cs
+++ b/src/DqtApi/Swagger/JsonSerializerDataContractResolver.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.Json;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using WrappedResolver = Swashbuckle.AspNetCore.SwaggerGen.JsonSerializerDataContractResolver;
+
+namespace DqtApi.Swagger
+{
+    // Decorates Swashbuckle's built-in JsonSerializerDataContractResolver to add in support for additional types e.g. DateOnly
+    // see https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/f6dc5f872d6d065324c21b37852a1bdf8858420e/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+    public class JsonSerializerDataContractResolver : ISerializerDataContractResolver
+    {
+        private readonly WrappedResolver _innerResolver;
+        private readonly JsonSerializerOptions _serializerOptions;
+
+        public JsonSerializerDataContractResolver(JsonSerializerOptions serializerOptions)
+        {
+            _innerResolver = new WrappedResolver(serializerOptions);
+            _serializerOptions = serializerOptions;
+        }
+
+        public DataContract GetDataContractForType(Type type)
+        {
+            if (type == typeof(DateOnly))
+            {
+                return DataContract.ForPrimitive(
+                    underlyingType: type,
+                    dataType: DataType.String,
+                    dataFormat: "date",
+                    jsonConverter: value => JsonSerializer.Serialize(value, _serializerOptions));
+            }
+
+            return _innerResolver.GetDataContractForType(type);
+        }
+    }
+}

--- a/src/DqtApi/V2/Controllers/TrnRequestsController.cs
+++ b/src/DqtApi/V2/Controllers/TrnRequestsController.cs
@@ -23,7 +23,7 @@ namespace DqtApi.V2.Controllers
         [SwaggerOperation(summary: "Retrieves a TRN request")]
         [ProducesResponseType(typeof(TrnRequestInfo), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> GetTrnRequest([FromRoute] GetTrnRequest request)
+        public async Task<IActionResult> GetTrnRequest(GetTrnRequest request)
         {
             var response = await _mediator.Send(request);
             return response != null ? Ok(response) : NotFound();

--- a/src/DqtApi/V2/Requests/GetTrnRequest.cs
+++ b/src/DqtApi/V2/Requests/GetTrnRequest.cs
@@ -1,11 +1,13 @@
 ﻿using DqtApi.V2.Responses;
 using MediatR;
+using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace DqtApi.V2.Requests
 {
     public class GetTrnRequest : IRequest<TrnRequestInfo>
     {
+        [FromRoute]
         [SwaggerParameter(description: "The unique ID the TRN request was created with.")]
         public string RequestId { get; set; }
     }


### PR DESCRIPTION
### Context

This PR contains some of the model binding tweaks extracted from the PR for the 'Put TRN request'.

Pre-requisite for https://trello.com/c/FJHFPAxn/155-register-api-create-put-request

### Changes proposed in this pull request

There are three changes here:

#### Adds a `HybridBodyModelBinderProvider` which allows binding individual properties on a model from the route with the rest coming from the request body.
The previous intention was to use [HybridModelBinding](https://github.com/billbogaiv/hybrid-model-binding) but it doesn't play nicely with Swashbuckle so the generated Swagger doc is incorrect. This implementation is based on what HybridModelBinding does but trimmed down and with support for generating a correct Swagger doc.

Having a single object for the entire request is desirable as it works better with MediatR and FluentValidation, both of which expect a single request object.

#### Adds support for `DateOnly` to the JSON serializer
`System.Text.Json` doesn't yet support `DateOnly` so we add it here ourselves.

#### Camel case property names in error responses

When we generate a validation error the error keys are sometimes pascal-cased. This fixes that to always camel-case error keys.

### Guidance to review

Review commit-by-commit.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
