### PR TITLE
Fix running tests locally when relying on User Secrets

### DIFF
--- a/tests/DqtApi.Tests/ApiFixture.cs
+++ b/tests/DqtApi.Tests/ApiFixture.cs
@@ -29,7 +29,9 @@ namespace DqtApi.Tests
         {
             builder.UseEnvironment("Testing");
 
-            builder.ConfigureAppConfiguration(config => config.AddUserSecrets<ApiFixture>(optional: true));
+            // N.B. Don't use builder.ConfigureAppConfiguration here since it runs *after* the entry point
+            // i.e. Program.cs and that has a dependency on IConfiguration
+            builder.UseConfiguration(GetTestConfiguration());
 
             builder.ConfigureServices(services =>
             {
@@ -48,5 +50,8 @@ namespace DqtApi.Tests
         }
 
         Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
+
+        private static IConfiguration GetTestConfiguration() =>
+            new ConfigurationBuilder().AddUserSecrets<ApiFixture>(optional: true).Build();
     }
 }


### PR DESCRIPTION
60271d9491e376e292a68c3544243fa1dca9b7c2 made a change that required
connection strings be resolvable from our API entry point (i.e.
Program.cs) but our user secrets config source was being added *after*
the entry point ran (so any config set there isn't available to the
entry point). This change eagerly gets IConfiguration from user secrets
and ensures it's available to the entry point.

### Context

Fixing something I broke here 60271d9491e376e292a68c3544243fa1dca9b7c2

### Changes proposed in this pull request

Adjusts when user-secret-derived config is retrieve so it happens *before* the entry point is hit.

### Checklist

-   [ ] Attach to Trello card - N/A
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
