### PR TITLE
Extract API specs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,31 @@ jobs:
         terraform_vars: dev.tfvars.json
         terraform_backend_vars: dev.backend.tfvars
 
+  sync_api_specs:
+    name: Sync API specs
+    needs: deploy_dev
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout PR
+      run: gh pr checkout ${{ github.event.pull_request.number }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: fregante/setup-git-user@v1
+
+    - name: Generate specs
+      shell: pwsh
+      run: ./Sync-ApiSpecs.ps1 ${{ needs.deploy_dev.outputs.environment_url }}
+
+    - name: Commit specs
+      run: |
+        git add docs/api-specs
+        git diff --cached --quiet docs/api-specs || (git commit -m "Sync API specs" && git push)
+
   zap_scan:
     name: OWASP ZAP API scan
     needs: deploy_dev

--- a/Sync-ApiSpecs.ps1
+++ b/Sync-ApiSpecs.ps1
@@ -6,6 +6,8 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$BaseUrl = $BaseUrl.TrimEnd("/")
+
 $versions = @("v1", "v2")
 $output = Join-Path $PSScriptRoot "docs" "api-specs"
 

--- a/Sync-ApiSpecs.ps1
+++ b/Sync-ApiSpecs.ps1
@@ -1,0 +1,16 @@
+[CmdletBinding()]
+param(
+    [Parameter(Position = 1)]
+    [String]$BaseUrl = "http://localhost:30473"
+)
+
+$ErrorActionPreference = "Stop"
+
+$versions = @("v1", "v2")
+$output = Join-Path $PSScriptRoot "docs" "api-specs"
+
+New-Item $output -ItemType Directory -ErrorAction SilentlyContinue
+
+foreach ($version in $versions) {
+    Invoke-WebRequest -Uri "${BaseUrl}/swagger/${version}/swagger.json" -OutFile (Join-Path $output "${version}.json")
+}

--- a/docs/api-specs/v1.json
+++ b/docs/api-specs/v1.json
@@ -1,0 +1,339 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "DQT API",
+    "version": "v1"
+  },
+  "paths": {
+    "/v1/teachers/{trn}": {
+      "get": {
+        "tags": [
+          "Teachers"
+        ],
+        "summary": "Teacher",
+        "description": "Get an individual teacher by their TRN",
+        "parameters": [
+          {
+            "name": "trn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "birthdate",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "nino",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTeacherResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ContactState": {
+        "enum": [
+          "Active",
+          "Inactive"
+        ],
+        "type": "string"
+      },
+      "GetTeacherResponse": {
+        "type": "object",
+        "properties": {
+          "trn": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "ni_number": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "qualified_teacher_status": {
+            "$ref": "#/components/schemas/QualifiedTeacherStatus"
+          },
+          "induction": {
+            "$ref": "#/components/schemas/Induction"
+          },
+          "initial_teacher_training": {
+            "$ref": "#/components/schemas/InitialTeacherTraining"
+          },
+          "qualifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Qualification"
+            },
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "dob": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
+          },
+          "active_alert": {
+            "type": "boolean",
+            "nullable": true,
+            "readOnly": true
+          },
+          "state": {
+            "$ref": "#/components/schemas/ContactState"
+          },
+          "state_name": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Induction": {
+        "type": "object",
+        "properties": {
+          "start_date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
+          },
+          "completion_date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "state": {
+            "$ref": "#/components/schemas/InductionState"
+          },
+          "state_name": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InductionState": {
+        "enum": [
+          "Active",
+          "Inactive"
+        ],
+        "type": "string"
+      },
+      "InitialTeacherTraining": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/InitialteachertrainingState"
+          },
+          "state_code": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "programme_start_date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
+          },
+          "programme_end_date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
+          },
+          "programme_type": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "result": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subject1": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subject2": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subject3": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "qualification": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subject1_code": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subject2_code": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subject3_code": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InitialteachertrainingState": {
+        "enum": [
+          "Active",
+          "Inactive"
+        ],
+        "type": "string"
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
+      "QtsregistrationState": {
+        "enum": [
+          "Active",
+          "Inactive"
+        ],
+        "type": "string"
+      },
+      "Qualification": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "date_awarded": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualifiedTeacherStatus": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "state": {
+            "$ref": "#/components/schemas/QtsregistrationState"
+          },
+          "state_name": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "qts_date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "http",
+        "scheme": "Bearer"
+      }
+    }
+  },
+  "security": [
+    {
+      "Bearer": [ ]
+    }
+  ]
+}

--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -1,0 +1,465 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "DQT API",
+    "version": "v2"
+  },
+  "paths": {
+    "/v2/itt-providers": {
+      "get": {
+        "tags": [
+          "IttProviders"
+        ],
+        "summary": "Gets a list of all ITT Providers",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetIttProvidersResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/trn-requests/{requestId}": {
+      "get": {
+        "tags": [
+          "TrnRequests"
+        ],
+        "summary": "Retrieves a TRN request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "The unique ID the TRN request was created with.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrnRequestInfo"
+                },
+                "example": {"requestId":"72888c5d-db14-4222-829b-7db9c2ec0dc3","status":"Completed","trn":"1234567"}
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "TrnRequests"
+        ],
+        "summary": "Creates a request for a TRN",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "A unique ID that represents this request. If a request has already been created with this ID then that existing record's result is returned.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetOrCreateTrnRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetOrCreateTrnRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetOrCreateTrnRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrnRequestInfo"
+                },
+                "example": {"requestId":"72888c5d-db14-4222-829b-7db9c2ec0dc3","status":"Completed","trn":"1234567"}
+              }
+            }
+          },
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrnRequestInfo"
+                },
+                "example": {"requestId":"72888c5d-db14-4222-829b-7db9c2ec0dc3","status":"Completed","trn":"1234567"}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/unlock-teacher/{teacherId}": {
+      "put": {
+        "tags": [
+          "UnlockTeacher"
+        ],
+        "description": "Unlocks the teacher record allowing the teacher to sign in to the portals",
+        "parameters": [
+          {
+            "name": "teacherId",
+            "in": "path",
+            "description": "The ID of the teacher record to unlock",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ClassDivision": {
+        "enum": [
+          "FirstClassHonours",
+          "UpperSecondClassHonours",
+          "LowerSecondClassHonours",
+          "UndividedSecondClassHonours",
+          "ThirdClassHonours",
+          "FourthClassHonours",
+          "UnclassifiedHonours",
+          "Aegrotat",
+          "PassFollowingAnHonoursCourse",
+          "Ordinary",
+          "GeneralDegree",
+          "Distinction",
+          "Merit",
+          "Pass",
+          "Notapplicable",
+          "NotKnown",
+          "HigherDegree"
+        ],
+        "type": "string"
+      },
+      "Gender": {
+        "enum": [
+          "Male",
+          "Female",
+          "Other"
+        ],
+        "type": "string"
+      },
+      "GetIttProvidersResponse": {
+        "type": "object",
+        "properties": {
+          "ittProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IttProviderInfo"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetOrCreateTrnRequest": {
+        "required": [
+          "birthDate",
+          "emailAddress",
+          "firstName",
+          "genderCode",
+          "initialTeacherTraining",
+          "lastName",
+          "middleName",
+          "qualification"
+        ],
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string"
+          },
+          "middleName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "birthDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "emailAddress": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/GetOrCreateTrnRequestAddress"
+          },
+          "genderCode": {
+            "$ref": "#/components/schemas/Gender"
+          },
+          "initialTeacherTraining": {
+            "$ref": "#/components/schemas/GetOrCreateTrnRequestInitialTeacherTraining"
+          },
+          "qualification": {
+            "$ref": "#/components/schemas/GetOrCreateTrnRequestQualification"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetOrCreateTrnRequestAddress": {
+        "type": "object",
+        "properties": {
+          "addressLine1": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine3": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetOrCreateTrnRequestInitialTeacherTraining": {
+        "required": [
+          "programmeEndDate",
+          "programmeStartDate",
+          "programmeType",
+          "providerUkprn",
+          "result",
+          "subject1",
+          "subject2"
+        ],
+        "type": "object",
+        "properties": {
+          "providerUkprn": {
+            "type": "string"
+          },
+          "programmeStartDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "programmeEndDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "programmeType": {
+            "$ref": "#/components/schemas/IttProgrammeType"
+          },
+          "subject1": {
+            "type": "string"
+          },
+          "subject2": {
+            "type": "string"
+          },
+          "result": {
+            "$ref": "#/components/schemas/IttResult"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetOrCreateTrnRequestQualification": {
+        "required": [
+          "class",
+          "countryCode",
+          "date",
+          "providerUkprn",
+          "subject"
+        ],
+        "type": "object",
+        "properties": {
+          "providerUkprn": {
+            "type": "string"
+          },
+          "countryCode": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "class": {
+            "$ref": "#/components/schemas/ClassDivision"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IttProgrammeType": {
+        "enum": [
+          "Core",
+          "HEI",
+          "SchoolDirectTrainingProgrammeSelfFunded",
+          "SchoolDirectTrainingProgrammeSalaried",
+          "SchoolDirectTrainingProgramme",
+          "TeachFirstProgrammeCC",
+          "TeachFirstProgramme",
+          "OverseasTrainedTeacherProgramme",
+          "RegisteredTeacherProgramme",
+          "GraduateTeacherProgramme",
+          "AssessmentOnlyRoute",
+          "CoreFlexible",
+          "LicensedTeacherProgramme",
+          "UndergraduateOptIn",
+          "EYITTAssessmentOnly",
+          "EYITTGraduateEntry",
+          "EYITTGraduateEmploymentBased",
+          "EYITTUndergraduate",
+          "EYITTSchoolDirectEarlyYears",
+          "Apprenticeship",
+          "FutureTeachingScholars"
+        ],
+        "type": "string"
+      },
+      "IttProviderInfo": {
+        "type": "object",
+        "properties": {
+          "ukprn": {
+            "type": "string"
+          },
+          "providerName": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IttResult": {
+        "enum": [
+          "Pass",
+          "Fail",
+          "Withdrawn",
+          "InTraining",
+          "Approved",
+          "Deferred",
+          "DeferredforSkillsTests",
+          "UnderAssessment",
+          "ApplicationReceived",
+          "ApplicationUnsuccessful",
+          "Info",
+          "NoResultSubmitted"
+        ],
+        "type": "string"
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
+      "TrnRequestInfo": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TrnRequestStatus"
+          },
+          "trn": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TrnRequestStatus": {
+        "enum": [
+          "Pending",
+          "Completed"
+        ],
+        "type": "string"
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "http",
+        "scheme": "Bearer"
+      }
+    }
+  },
+  "security": [
+    {
+      "Bearer": [ ]
+    }
+  ]
+}


### PR DESCRIPTION
### Context

Adds a script to extract Swagger docs from a running instance of the API and amends the build process to sync Swagger docs on PR builds, if required.

https://trello.com/c/6lyWqai7/130-create-tech-docs-space-and-pull-guidance-across-from-confluence-etc

### Changes proposed in this pull request

- Powershell script to generate Swagger docs.
- CI pipeline addition for PR builds

### Guidance to review


### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
