### PR TITLE
Add caching to reference data lookups for Teacher creation

### DIFF
--- a/src/DqtApi/CacheKeys.cs
+++ b/src/DqtApi/CacheKeys.cs
@@ -1,0 +1,15 @@
+﻿namespace DqtApi
+{
+    public static class CacheKeys
+    {
+        public static object GetCountryKey(string code) => $"country:{code}";
+
+        public static object GetEarlyYearsStatusKey(string code) => $"early_years_status:{code}";
+
+        public static object GetHeSubjectKey(string name) => $"he_subject:{name}";
+
+        public static object GetIttSubjectKey(string name) => $"itt_subject:{name}";
+
+        public static object GetOrganizationByUkprnKey(string ukprn) => $"organization:{ukprn}";
+    }
+}

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.ServiceModel;
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.PowerPlatform.Dataverse.Client.Utils;
 using Microsoft.Xrm.Sdk;
@@ -16,13 +17,16 @@ namespace DqtApi.DataStore.Crm
     {
         private readonly IOrganizationServiceAsync _service;
         private readonly IClock _clock;
+        private readonly IMemoryCache _cache;
 
         public DataverseAdapter(
             IOrganizationServiceAsync organizationServiceAsync,
-            IClock clock)
+            IClock clock,
+            IMemoryCache cache)
         {
             _service = organizationServiceAsync;
             _clock = clock;
+            _cache = cache;
         }
 
         public async Task<dfeta_country> GetCountry(string value)

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -159,6 +159,7 @@ namespace DqtApi
                 return new Swagger.JsonSerializerDataContractResolver(serializerOptions);
             });
             services.AddSingleton<IClock, Clock>();
+            services.AddMemoryCache();
 
             services.AddDbContext<DqtContext>(options =>
             {

--- a/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using Xunit;
@@ -46,7 +48,7 @@ namespace DqtApi.Tests.DataverseIntegration
             _createdEntities.Clear();
         }
 
-        public DataverseAdapter CreateDataverseAdapter() => new(ServiceClient, Clock);
+        public DataverseAdapter CreateDataverseAdapter() => new(ServiceClient, Clock, new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
 
         public Task InitializeAsync() => Task.CompletedTask;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
 using DqtApi.DataStore.Crm;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using Xunit;
 using static DqtApi.Tests.DataverseIntegration.GetMatchingTeachersFixture.MatchFixture;
 
@@ -14,7 +16,7 @@ namespace DqtApi.Tests.DataverseIntegration
         public GetMatchingTeachersTests(GetMatchingTeachersFixture fixture)
         {
             _fixture = fixture;
-            _dataverseAdapter = new DataverseAdapter(_fixture.Service, new TestableClock());
+            _dataverseAdapter = new DataverseAdapter(_fixture.Service, new TestableClock(), new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
         }
 
         [Fact]


### PR DESCRIPTION
### Context

https://trello.com/c/JFFRWNZ2/169-add-caching-to-reference-data-lookups-in-put-trn-request-operation

### Changes proposed in this pull request

Adds caching to reference data lookups performed when creating a teacher. This reference data is effectively static so we're not worried about having to expire cache entries here.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
