### PR TITLE
Add rate limiting to API

### DIFF
--- a/docs/api-specs/v1.json
+++ b/docs/api-specs/v1.json
@@ -61,6 +61,16 @@
           },
           "404": {
             "description": "Not Found"
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }

--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -21,6 +21,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -56,6 +66,16 @@
           },
           "404": {
             "description": "Not Found"
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       },
@@ -126,6 +146,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -154,6 +184,16 @@
           },
           "404": {
             "description": "Not Found"
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }

--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="6.0.1" />
+    <PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />

--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="6.0.1" />
     <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
@@ -15,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.1" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.17" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="0.5.17" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.2" />

--- a/src/DqtApi/Security/ApiClientResolveContributor.cs
+++ b/src/DqtApi/Security/ApiClientResolveContributor.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using AspNetCoreRateLimit;
+using Microsoft.AspNetCore.Http;
+
+namespace DqtApi.Security
+{
+    public class ApiClientResolveContributor : IClientResolveContributor
+    {
+        public Task<string> ResolveClientAsync(HttpContext httpContext)
+        {
+            var clientId = ClaimsPrincipalCurrentClientProvider.GetCurrentClientIdFromHttpContext(httpContext);
+            return Task.FromResult(clientId);
+        }
+    }
+}

--- a/src/DqtApi/Security/ClaimsPrincipalCurrentClientProvider.cs
+++ b/src/DqtApi/Security/ClaimsPrincipalCurrentClientProvider.cs
@@ -12,11 +12,16 @@ namespace DqtApi.Security
             _httpContextAccessor = httpContextAccessor;
         }
 
+        public static string GetCurrentClientIdFromHttpContext(HttpContext httpContext)
+        {
+            var principal = httpContext?.User;
+            return principal?.FindFirst(ClaimTypes.Name)?.Value;
+        }
+
         public string GetCurrentClientId()
         {
             var httpContext = _httpContextAccessor.HttpContext;
-            var principal = httpContext?.User;
-            return principal?.FindFirst(ClaimTypes.Name)?.Value;
+            return GetCurrentClientIdFromHttpContext(httpContext);
         }
     }
 }

--- a/src/DqtApi/Security/RateLimitConfiguration.cs
+++ b/src/DqtApi/Security/RateLimitConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using AspNetCoreRateLimit;
+using Microsoft.Extensions.Options;
+using BaseRateLimitConfiguration = AspNetCoreRateLimit.RateLimitConfiguration;
+
+namespace DqtApi.Security
+{
+    public class RateLimitConfiguration : BaseRateLimitConfiguration
+    {
+        public RateLimitConfiguration(
+            IOptions<IpRateLimitOptions> ipOptions,
+            IOptions<ClientRateLimitOptions> clientOptions)
+            : base(ipOptions, clientOptions)
+        {
+        }
+
+        public override void RegisterResolvers()
+        {
+            base.RegisterResolvers();
+
+            this.ClientResolvers.Add(new ApiClientResolveContributor());
+        }
+    }
+}

--- a/src/DqtApi/Security/RateLimitMiddleware.cs
+++ b/src/DqtApi/Security/RateLimitMiddleware.cs
@@ -1,0 +1,57 @@
+﻿using AspNetCoreRateLimit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DqtApi.Security
+{
+    public class RateLimitMiddleware : ClientRateLimitMiddleware
+    {
+        private readonly ClientRateLimitOptions _options;
+
+        public RateLimitMiddleware(
+            RequestDelegate next,
+            IProcessingStrategy processingStrategy,
+            IOptions<ClientRateLimitOptions> options,
+            IRateLimitCounterStore counterStore,
+            IClientPolicyStore policyStore,
+            IRateLimitConfiguration config,
+            ILogger<ClientRateLimitMiddleware> logger)
+            : base(next, processingStrategy, options, counterStore, policyStore, config, logger)
+        {
+            _options = options.Value;
+        }
+
+        public override Task ReturnQuotaExceededResponse(HttpContext httpContext, RateLimitRule rule, string retryAfter)
+        {
+            if (rule.QuotaExceededResponse != null)
+            {
+                _options.QuotaExceededResponse = rule.QuotaExceededResponse;
+            }
+
+            var message = string.Format(
+                _options.QuotaExceededResponse?.Content ??
+                _options.QuotaExceededMessage ??
+                "A maximum of {0} calls per {1} are permitted.", rule.Limit, rule.Period, retryAfter);
+
+            if (!_options.DisableRateLimitHeaders)
+            {
+                httpContext.Response.Headers["Retry-After"] = retryAfter;
+            }
+
+            var statusCode = _options.QuotaExceededResponse?.StatusCode ?? _options.HttpStatusCode;
+
+            var problemDetails = new ProblemDetails()
+            {
+                Title = "API calls quota exceeded",
+                Detail = message,
+                Status = statusCode
+            };
+
+            httpContext.Response.StatusCode = statusCode;
+
+            return httpContext.Response.WriteAsJsonAsync(problemDetails, type: typeof(ProblemDetails), options: null, contentType: "application/problem+json");
+        }
+    }
+}

--- a/src/DqtApi/Swagger/RateLimitOperationFilter.cs
+++ b/src/DqtApi/Swagger/RateLimitOperationFilter.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace DqtApi.Swagger
+{
+    public class RateLimitOperationFilter : IOperationFilter
+    {
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var problemDetailsSchema = context.SchemaGenerator.GenerateSchema(modelType: typeof(ProblemDetails), context.SchemaRepository);
+
+            operation.Responses.Add("429", new OpenApiResponse()
+            {
+                Content =
+                {
+                    { "application/problem+json", new OpenApiMediaType() { Schema = problemDetailsSchema } }
+                },
+                Description = ReasonPhrases.GetReasonPhrase(429)
+            });
+        }
+    }
+}

--- a/src/DqtApi/appsettings.Production.json
+++ b/src/DqtApi/appsettings.Production.json
@@ -1,4 +1,19 @@
 {
+  "ClientRateLimiting": {
+    "EnableEndpointRateLimiting": false,
+    "EndpointWhitelist": [
+      "*:/health",
+      "*:/status",
+      "*:/swagger/*"
+    ],
+    "GeneralRules": [
+      {
+        "Endpoint": "*",
+        "Period": "60s",
+        "Limit": 300
+      }
+    ]
+  },
   "Serilog": {
     "WriteTo": [
       {

--- a/terraform/api-app.tf
+++ b/terraform/api-app.tf
@@ -38,6 +38,12 @@ resource "null_resource" "migrations" {
   ]
 }
 
+resource "cloudfoundry_service_instance" "redis" {
+  name         = var.redis_name
+  space        = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_service_plan]
+}
+
 resource "cloudfoundry_app" "api" {
   name                       = var.api_app_name
   space                      = data.cloudfoundry_space.space.id
@@ -60,6 +66,10 @@ resource "cloudfoundry_app" "api" {
 
   service_binding {
     service_instance = cloudfoundry_service_instance.postgres.id
+  }
+
+  service_binding {
+    service_instance = cloudfoundry_service_instance.redis.id
   }
 
   depends_on = [

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -25,3 +25,7 @@ data "cloudfoundry_domain" "cloudapps" {
 data "cloudfoundry_service" "postgres" {
   name = "postgres"
 }
+
+data "cloudfoundry_service" "redis" {
+  name = "redis"
+}

--- a/terraform/dev.tfvars.json
+++ b/terraform/dev.tfvars.json
@@ -5,5 +5,6 @@
   "logging_service_name": "logit-ssl-drain-dev",
   "paas_space": "tra-dev",
   "postgres_database_name": "qualified-teachers-api-dev-pg-svc",
+  "redis_name": "qualified-teachers-api-dev-redis-svc",
   "statuscake_alerts": {}
 }

--- a/terraform/preprod.tfvars.json
+++ b/terraform/preprod.tfvars.json
@@ -5,6 +5,7 @@
   "logging_service_name": "logit-ssl-drain-preprod",
   "paas_space": "tra-test",
   "postgres_database_name": "qualified-teachers-api-preprod-pg-svc",
+  "redis_name": "qualified-teachers-api-preprod-redis-svc",
   "statuscake_alerts": {
     "tra-preprod": {
       "website_name": "qualified-teachers-api-preprod",

--- a/terraform/prod.tfvars.json
+++ b/terraform/prod.tfvars.json
@@ -6,6 +6,8 @@
   "logging_service_name": "logit-ssl-drain-prod",
   "paas_space": "tra-production",
   "postgres_database_name": "qualified-teachers-api-prod-pg-svc",
+  "redis_name": "qualified-teachers-api-prod-redis-svc",
+  "redis_service_plan": "tiny-ha-6_x",
   "statuscake_alerts": {
     "tra-prod": {
       "website_name": "qualified-teachers-api-prod",

--- a/terraform/test.tfvars.json
+++ b/terraform/test.tfvars.json
@@ -5,6 +5,7 @@
   "logging_service_name": "logit-ssl-drain-test",
   "paas_space": "tra-test",
   "postgres_database_name": "qualified-teachers-api-test-pg-svc",
+  "redis_name": "qualified-teachers-api-test-redis-svc",
   "statuscake_alerts": {
     "tra-test": {
       "website_name": "qualified-teachers-api-test",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -56,6 +56,15 @@ variable "postgres_database_service_plan" {
   default = "small-13"
 }
 
+variable "redis_name" {
+  type = string
+}
+
+variable "redis_service_plan" {
+  type    = string
+  default = "tiny-6_x"
+}
+
 variable "migrations_file" {
   type = string
 }


### PR DESCRIPTION
### Context

https://trello.com/c/OE5G3TVw/181-add-rate-limiting-to-api

### Changes proposed in this pull request

- Adds a Redis service to every environment.
- Adds API rate limiting (300 requests per minute, mirroring EAPIM API implementation)

### Guidance to review

Verify Terraform changes meet Teacher Services standards.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
