### PR TITLE
Improve CRM integration tests performance

### DIFF
--- a/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -7,13 +6,14 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
+    [Collection(nameof(ExclusiveCrmTestCollection))]
     public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLifetime
     {
         private readonly CreateTeacherFixture _createTeacherFixture;
         private readonly CrmClientFixture _crmClientFixture;
         private readonly DataverseAdapter _dataverseAdapter;
         private readonly ServiceClient _serviceClient;
+        private readonly EntityCleanupHelper _entityCleanupHelper;
 
         public CreateTeacherTests(CreateTeacherFixture createTeacherFixture, CrmClientFixture crmClientFixture)
         {
@@ -21,11 +21,12 @@ namespace DqtApi.Tests.DataverseIntegration
             _crmClientFixture = crmClientFixture;
             _dataverseAdapter = crmClientFixture.CreateDataverseAdapter();
             _serviceClient = crmClientFixture.ServiceClient;
+            _entityCleanupHelper = crmClientFixture.CreateEntityCleanupHelper();
         }
 
         public Task InitializeAsync() => Task.CompletedTask;
 
-        public Task DisposeAsync() => _crmClientFixture.CleanupEntities();
+        public Task DisposeAsync() => _entityCleanupHelper.CleanupEntities();
 
         [Fact]
         public async Task Given_valid_request_creates_required_entities()
@@ -34,7 +35,7 @@ namespace DqtApi.Tests.DataverseIntegration
 
             // Act
             var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command);
-            _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, result.TeacherId);
+            _entityCleanupHelper.RegisterForCleanup(Contact.EntityLogicalName, result.TeacherId);
 
             // Assert
             Assert.True(result.Succeeded);
@@ -56,7 +57,7 @@ namespace DqtApi.Tests.DataverseIntegration
 
             // Act
             var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command, findExistingTeacher);
-            _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, result.TeacherId);
+            _entityCleanupHelper.RegisterForCleanup(Contact.EntityLogicalName, result.TeacherId);
 
             // Assert
             Assert.True(result.Succeeded);
@@ -105,8 +106,8 @@ namespace DqtApi.Tests.DataverseIntegration
 
             // Act
             var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command, findExistingTeacher);
-            _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, result.TeacherId);
-            _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, existingTeacherId);
+            _entityCleanupHelper.RegisterForCleanup(Contact.EntityLogicalName, result.TeacherId);
+            _entityCleanupHelper.RegisterForCleanup(Contact.EntityLogicalName, existingTeacherId);
 
             // Assert
             Assert.True(result.Succeeded);
@@ -282,7 +283,7 @@ namespace DqtApi.Tests.DataverseIntegration
                 LastName = matchOnSurname ? command.LastName : "Oli",
                 BirthDate = matchOnDateOfBirth ? command.BirthDate : new(1945, 2, 3)
             });
-            _crmClientFixture.RegisterForCleanup(Contact.EntityLogicalName, existingTeacherId);
+            _entityCleanupHelper.RegisterForCleanup(Contact.EntityLogicalName, existingTeacherId);
 
             var helper = new DataverseAdapter.CreateTeacherHelper(_dataverseAdapter, command);
 

--- a/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class CreateTeacherTests : IClassFixture<CrmClientFixture>, IAsyncLifetime
+    public class CreateTeacherTests : IAsyncLifetime
     {
         private readonly CrmClientFixture _crmClientFixture;
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using Microsoft.Crm.Sdk.Messages;
@@ -9,11 +10,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
-using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    public class CrmClientFixture : IDisposable, IAsyncLifetime
+    public sealed class CrmClientFixture : IAsyncDisposable
     {
         private readonly List<(string EntityName, Guid EntityId)> _createdEntities;
 
@@ -52,12 +52,11 @@ namespace DqtApi.Tests.DataverseIntegration
 
         public Task InitializeAsync() => Task.CompletedTask;
 
-        public virtual void Dispose()
+        public async ValueTask DisposeAsync()
         {
+            await CleanupEntities();
             ServiceClient.Dispose();
         }
-
-        public Task DisposeAsync() => CleanupEntities();
 
         public void RegisterForCleanup(Entity entity)
         {

--- a/tests/DqtApi.Tests/DataverseIntegration/DataverseTestCollection.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/DataverseTestCollection.cs
@@ -1,9 +1,0 @@
-﻿using Xunit;
-
-namespace DqtApi.Tests.DataverseIntegration
-{
-    [CollectionDefinition(nameof(DataverseTestCollection))]
-    public class DataverseTestCollection
-    {
-    }
-}

--- a/tests/DqtApi.Tests/DataverseIntegration/EntityCleanupHelper.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/EntityCleanupHelper.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+
+namespace DqtApi.Tests.DataverseIntegration
+{
+    public class EntityCleanupHelper
+    {
+        private readonly List<(string EntityName, Guid EntityId)> _createdEntities;
+        private readonly ServiceClient _serviceClient;
+
+        public EntityCleanupHelper(ServiceClient serviceClient)
+        {
+            _createdEntities = new();
+            _serviceClient = serviceClient;
+        }
+
+        public async Task CleanupEntities()
+        {
+            var multiRequest = new ExecuteMultipleRequest()
+            {
+                Requests = new(),
+                Settings = new ExecuteMultipleSettings()
+                {
+                    ContinueOnError = true
+                }
+            };
+
+            (string EntityName, Guid EntityId)[] toBeCleared;
+            lock (_createdEntities)
+            {
+                toBeCleared = _createdEntities.ToArray();
+                _createdEntities.Clear();
+            }
+
+            foreach (var (entityName, entityId) in toBeCleared)
+            {
+                multiRequest.Requests.Add(new SetStateRequest()
+                {
+                    EntityMoniker = new EntityReference(entityName, entityId),
+                    State = new OptionSetValue(1),  // Inactive
+                    Status = new OptionSetValue(2)
+                });
+            }
+
+            await _serviceClient.ExecuteAsync(multiRequest);
+        }
+
+        public void RegisterForCleanup(Entity entity)
+        {
+            lock (_createdEntities)
+            {
+                _createdEntities.Add((entity.LogicalName, entity.Id));
+            }
+        }
+
+        public void RegisterForCleanup(string entityName, Guid entityId)
+        {
+            if (entityId == Guid.Empty)
+            {
+                return;
+            }
+
+            lock (_createdEntities)
+            {
+                _createdEntities.Add((entityName, entityId));
+            }
+        }
+    }
+}

--- a/tests/DqtApi.Tests/DataverseIntegration/ExclusiveCrmTestCollection.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/ExclusiveCrmTestCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace DqtApi.Tests.DataverseIntegration
+{
+    [CollectionDefinition(nameof(ExclusiveCrmTestCollection))]
+    public class ExclusiveCrmTestCollection
+    {
+    }
+}

--- a/tests/DqtApi.Tests/DataverseIntegration/GetCountryTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetCountryTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetCountryTests : IClassFixture<CrmClientFixture>
+    public class GetCountryTests
     {
         private readonly DataverseAdapter _dataverseAdapter;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetCountryTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetCountryTests.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetCountryTests
     {
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetEarlyYearsStatusTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetEarlyYearsStatusTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetEarlyYearsStatusTests : IClassFixture<CrmClientFixture>
+    public class GetEarlyYearsStatusTests
     {
         private readonly DataverseAdapter _dataverseAdapter;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetEarlyYearsStatusTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetEarlyYearsStatusTests.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetEarlyYearsStatusTests
     {
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetHeQualificationByNameTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetHeQualificationByNameTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetHeQualificationByNameTests : IClassFixture<CrmClientFixture>
+    public class GetHeQualificationByNameTests
     {
         private readonly DataverseAdapter _dataverseAdapter;
         private readonly ServiceClient _serviceClient;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetHeQualificationByNameTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetHeQualificationByNameTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetHeQualificationByNameTests
     {
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetHeSubjectByNameTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetHeSubjectByNameTests.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetHeSubjectByNameTests
     {
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetHeSubjectByNameTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetHeSubjectByNameTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetHeSubjectByNameTests : IClassFixture<CrmClientFixture>
+    public class GetHeSubjectByNameTests
     {
         private readonly DataverseAdapter _dataverseAdapter;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetIttProvidersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetIttProvidersTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetIttProvidersTests : IClassFixture<CrmClientFixture>
+    public class GetIttProvidersTests
     {
         private readonly DataverseAdapter _dataverseAdapter;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetIttProvidersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetIttProvidersTests.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetIttProvidersTests
     {
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetIttSubjectByNameTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetIttSubjectByNameTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetIttSubjectByNameTests : IClassFixture<CrmClientFixture>
+    public class GetIttSubjectByNameTests
     {
         private readonly DataverseAdapter _dataverseAdapter;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetIttSubjectByNameTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetIttSubjectByNameTests.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetIttSubjectByNameTests
     {
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersFixture.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersFixture.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    public class GetMatchingTeachersFixture : CrmClientFixture
+    public class GetMatchingTeachersFixture : IDisposable
     {
         public struct Fixture
         {
@@ -17,7 +17,7 @@ namespace DqtApi.Tests.DataverseIntegration
             public Guid ID { get; set; }
         }
 
-        public IOrganizationServiceAsync Service => ServiceClient;
+        public IOrganizationServiceAsync Service { get; }
         private readonly string _nonmatchingNationalInsuranceNumber;
         private readonly string _nonmatchingTRN;
 
@@ -26,8 +26,10 @@ namespace DqtApi.Tests.DataverseIntegration
         private static DateTime MatchingBirthdate => new(2001, 1, 1);
         private static DateTime NonmatchingBirthdate => new(2002, 2, 2);
 
-        public GetMatchingTeachersFixture()
+        public GetMatchingTeachersFixture(CrmClientFixture crmClientFixture)
         {
+            Service = crmClientFixture.ServiceClient;
+
             var nationalInsuranceNumberGenerator = new NationalInsuranceNumberGenerator(Service);
 
             var nationalInsuranceNumber1 = nationalInsuranceNumberGenerator.GetNextAvailable();
@@ -101,15 +103,13 @@ namespace DqtApi.Tests.DataverseIntegration
             Assert.Equal(_fixtures[index].ID, teacher.Id);
         }
 
-        public override void Dispose()
+        public void Dispose()
         {
             // remove National Insurance Number from each fixture so it can be re-used
             Enumerable.Range(0, 2).ToList().ForEach(i =>
             {
                 Service.Update(new Contact { Id = _fixtures[i].ID, dfeta_NINumber = string.Empty });
             });
-
-            base.Dispose();
         }
     }
 }

--- a/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
@@ -7,7 +7,7 @@ using static DqtApi.Tests.DataverseIntegration.GetMatchingTeachersFixture.MatchF
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
+    [Collection(nameof(ExclusiveCrmTestCollection))]
     public class GetMatchingTeachersTests : IClassFixture<GetMatchingTeachersFixture>
     {
         private readonly GetMatchingTeachersFixture _fixture;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetOrganizationByUkprnTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetOrganizationByUkprnTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetOrganizationByUkprnTests
     {
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetOrganizationByUkprnTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetOrganizationByUkprnTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetOrganizationByUkprnTests : IClassFixture<CrmClientFixture>
+    public class GetOrganizationByUkprnTests
     {
         private readonly DataverseAdapter _dataverseAdapter;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetTeacherStatusTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetTeacherStatusTests.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetTeacherStatusTests
     {
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetTeacherStatusTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetTeacherStatusTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetTeacherStatusTests : IClassFixture<CrmClientFixture>
+    public class GetTeacherStatusTests
     {
         private readonly DataverseAdapter _dataverseAdapter;
 

--- a/tests/DqtApi.Tests/DataverseIntegration/GetTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetTeacherTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class GetTeacherTests
     {
         private readonly CrmClientFixture _crmClientFixture;

--- a/tests/DqtApi.Tests/DataverseIntegration/GetTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetTeacherTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class GetTeacherTests : IClassFixture<CrmClientFixture>
+    public class GetTeacherTests
     {
         private readonly CrmClientFixture _crmClientFixture;
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/UnlockTeacherRecordTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/UnlockTeacherRecordTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace DqtApi.Tests.DataverseIntegration
 {
     [Collection(nameof(DataverseTestCollection))]
-    public class UnlockTeacherRecordTests : IClassFixture<CrmClientFixture>
+    public class UnlockTeacherRecordTests
     {
         private readonly CrmClientFixture _crmClientFixture;
         private readonly DataverseAdapter _dataverseAdapter;

--- a/tests/DqtApi.Tests/DataverseIntegration/UnlockTeacherRecordTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/UnlockTeacherRecordTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(DataverseTestCollection))]
     public class UnlockTeacherRecordTests
     {
         private readonly CrmClientFixture _crmClientFixture;

--- a/tests/DqtApi.Tests/DqtApi.Tests.csproj
+++ b/tests/DqtApi.Tests/DqtApi.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Respawn" Version="5.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.DependencyInjection" Version="8.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/DqtApi.Tests/Startup.cs
+++ b/tests/DqtApi.Tests/Startup.cs
@@ -1,0 +1,13 @@
+﻿using DqtApi.Tests.DataverseIntegration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DqtApi.Tests
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<CrmClientFixture>();
+        }
+    }
+}


### PR DESCRIPTION
### Context

Split apart from one of the new APIs for Register - https://trello.com/c/ngFfEsOx/16-register-api-create-put-request-for-qts

### Changes proposed in this pull request

* Adds dependency injection support for tests
This allows us to have dependencies between fixtures, something that isn't possible with out-of-the-box xUnit. Specifically `CrmClientFixture` is now injected via DI and is singleton-scoped, meaning the CRM `ServiceClient` is now created and re-used across all tests. This is an enabler for the next change...

* Re-use some test data in a data-driven test
Lots of data permutations in `Given_details_that_do_not_match_existing_records_allocates_trn` previously meant that the same entity was getting created and cleaned up many times needlessly. This sets it up once, re-uses it for all test cases then cleans it up.

* Batch the cleanup requests to CRM.
Previously every cleaned up entity was done in its own API call, now they all go in a single call. We will likely need to batch this in future when the  number of entities goes over whatever the CRM API's batch request limit is.

* Run most tests in parallel
Apart from {Get|Create}Teacher-like operations we can safely run tests in parallel.

The perf improvement here isn't super impressive but it's a sizeable improvement for the forthcoming API addition.

### Guidance to review

Probably best reviewed commit-by-commit.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
