### PR TITLE
Sentry integration

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -54,6 +54,15 @@ runs:
         TFVARS: ${{ inputs.terraform_vars }}
       working-directory: terraform
 
+    - name: Extract version
+      id: get_version
+      run: |
+        API_VERSION=${DOCKER_IMAGE##*:}
+        echo ::set-output name=api_version::$API_VERSION
+      env:
+        DOCKER_IMAGE: ${{ inputs.docker_image }}
+      shell: bash
+
     - uses: Azure/login@v1
       with:
         creds: ${{ inputs.azure_credentials }}
@@ -95,6 +104,7 @@ runs:
         BACKEND_TFVARS: ${{ inputs.terraform_backend_vars }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
         TF_VAR_api_docker_image: ${{ inputs.docker_image }}
+        TF_VAR_api_app_version: ${{ steps.get_version.outputs.api_version }}
       shell: bash
       working-directory: terraform
 

--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.2" />
     <PackageReference Include="Scrutor" Version="4.0.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.13.0" />
+    <PackageReference Include="Sentry.Serilog" Version="3.13.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />

--- a/src/DqtApi/HttpRequestExtensions.cs
+++ b/src/DqtApi/HttpRequestExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using DqtApi.Logging;
+using Microsoft.AspNetCore.Http;
+
+namespace DqtApi
+{
+    public static class HttpRequestExtensions
+    {
+        public static string GetScrubbedRequestPathAndQuery(this HttpRequest httpRequest)
+        {
+            if (httpRequest is null)
+            {
+                throw new ArgumentNullException(nameof(httpRequest));
+            }
+
+            var httpContext = httpRequest.HttpContext;
+            var pathAndQuery = $"{httpContext.Request.Path}{httpContext.Request.QueryString}";
+
+            var redactedUrlParameters = httpContext.GetEndpoint()?.Metadata?.GetMetadata<RedactedUrlParameters>();
+
+            return redactedUrlParameters?.ScrubUrl(pathAndQuery) ?? pathAndQuery;
+        }
+
+        public static string GetScrubbedQueryString(this HttpRequest httpRequest)
+        {
+            if (httpRequest is null)
+            {
+                throw new ArgumentNullException(nameof(httpRequest));
+            }
+
+            var httpContext = httpRequest.HttpContext;
+            var queryString = httpContext.Request.QueryString.ToString();
+
+            var redactedUrlParameters = httpContext.GetEndpoint()?.Metadata?.GetMetadata<RedactedUrlParameters>();
+
+            return redactedUrlParameters?.ScrubQueryString(queryString) ?? queryString;
+        }
+    }
+}

--- a/src/DqtApi/Logging/ApplicationBuilderExtensions.cs
+++ b/src/DqtApi/Logging/ApplicationBuilderExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Serilog;
+using Serilog.Context;
+
+namespace DqtApi.Logging
+{
+    public static class ApplicationBuilderExtensions
+    {
+        public static IApplicationBuilder UseRequestLogging(this IApplicationBuilder app)
+        {
+            app.Use((ctx, next) =>
+            {
+                LogContext.Push(new RemoveRedactedUrlParametersEnricher(ctx));
+                LogContext.PushProperty("CorrelationId", ctx.TraceIdentifier);
+                return next();
+            });
+
+            app.UseSerilogRequestLogging();
+
+            return app;
+        }
+    }
+}

--- a/src/DqtApi/Logging/LogEventExtensions.cs
+++ b/src/DqtApi/Logging/LogEventExtensions.cs
@@ -1,0 +1,13 @@
+﻿using Serilog.Events;
+
+namespace DqtApi.Logging
+{
+    public static class LogEventExtensions
+    {
+        public static T GetScalarPropertyValue<T>(this LogEvent logEvent, string propertyKey)
+        {
+            var property = logEvent.Properties[propertyKey];
+            return (T)(((ScalarValue)property).Value);
+        }
+    }
+}

--- a/src/DqtApi/Logging/RedactQueryParamAttribute.cs
+++ b/src/DqtApi/Logging/RedactQueryParamAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace DqtApi.Logging
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public sealed class RedactQueryParamAttribute : Attribute, IActionModelConvention
+    {
+        public RedactQueryParamAttribute(string queryParameterName)
+        {
+            QueryParameterName = queryParameterName ?? throw new ArgumentNullException(nameof(queryParameterName));
+        }
+
+        public string QueryParameterName { get; }
+
+        public void Apply(ActionModel action)
+        {
+            foreach (var selector in action.Selectors)
+            {
+                var endpointMetadata = selector.EndpointMetadata;
+
+                var redactedInfo = endpointMetadata.OfType<RedactedUrlParameters>().SingleOrDefault();
+                if (redactedInfo is null)
+                {
+                    redactedInfo = new();
+                    endpointMetadata.Add(redactedInfo);
+                }
+
+                redactedInfo.QueryParameters.Add(QueryParameterName);
+            }
+        }
+    }
+}

--- a/src/DqtApi/Logging/RedactedUrlParameters.cs
+++ b/src/DqtApi/Logging/RedactedUrlParameters.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace DqtApi.Logging
+{
+    internal sealed class RedactedUrlParameters
+    {
+        public RedactedUrlParameters()
+        {
+            QueryParameters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public ISet<string> QueryParameters { get; }
+
+        public string ScrubUrl(string url)
+        {
+            if (url is null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            if (!url.Contains("?"))
+            {
+                return url;
+            }
+
+            var path = url.Split('?')[0];
+            var queryString = url.Split('?')[1];
+
+            var scrubbedQueryString = ScrubQueryString(queryString);
+            return $"{path}{scrubbedQueryString}";
+        }
+
+        public string ScrubQueryString(string queryString)
+        {
+            if (string.IsNullOrEmpty(queryString))
+            {
+                return string.Empty;
+            }
+
+            var query = QueryHelpers.ParseQuery(queryString);
+
+            foreach (var key in query.Keys.ToArray())
+            {
+                if (QueryParameters.Contains(key))
+                {
+                    query[key] = "**REDACTED**";
+                }
+            }
+
+            var scrubbedQueryString = new QueryBuilder(query).ToString();
+            return scrubbedQueryString;
+        }
+    }
+}

--- a/src/DqtApi/Logging/RemoveRedactedUrlParametersEnricher.cs
+++ b/src/DqtApi/Logging/RemoveRedactedUrlParametersEnricher.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Http;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace DqtApi.Logging
+{
+    public class RemoveRedactedUrlParametersEnricher : ILogEventEnricher
+    {
+        private readonly HttpContext _httpContext;
+
+        public RemoveRedactedUrlParametersEnricher(HttpContext httpContext)
+        {
+            _httpContext = httpContext;
+        }
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            const string requestPathPropertyName = "RequestPath";
+
+            if (logEvent.Properties.ContainsKey(requestPathPropertyName))
+            {
+                var scrubbedRequestPath = _httpContext.Request.GetScrubbedRequestPathAndQuery();
+                logEvent.AddOrUpdateProperty(new LogEventProperty(requestPathPropertyName, new ScalarValue(scrubbedRequestPath)));
+            }
+        }
+    }
+}

--- a/src/DqtApi/Logging/RemoveRedactedUrlParametersEventProcessor.cs
+++ b/src/DqtApi/Logging/RemoveRedactedUrlParametersEventProcessor.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Http;
+using Sentry;
+using Sentry.Extensibility;
+
+namespace DqtApi.Logging
+{
+    public class RemoveRedactedUrlParametersEventProcessor : ISentryEventProcessor
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public RemoveRedactedUrlParametersEventProcessor(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public SentryEvent Process(SentryEvent @event)
+        {
+            var httpContext = _httpContextAccessor.HttpContext;
+            @event.Request.QueryString = httpContext.Request.GetScrubbedQueryString();
+            return @event;
+        }
+    }
+}

--- a/src/DqtApi/V1/Controllers/TeachersController.cs
+++ b/src/DqtApi/V1/Controllers/TeachersController.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
+using DqtApi.Logging;
 using DqtApi.V1.Responses;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -27,6 +28,7 @@ namespace DqtApi.V1.Controllers
         [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+        [RedactQueryParam("birthdate")]
         public async Task<IActionResult> GetTeacher([FromRoute] GetTeacherRequest request)           
         {            
             if (!request.BirthDate.HasValue)

--- a/src/DqtApi/appsettings.Production.json
+++ b/src/DqtApi/appsettings.Production.json
@@ -22,6 +22,9 @@
   },
   "Serilog": {
     "Using": [ "Serilog", "Sentry" ],
+    "MinimumLevel": {
+      "Default": "Warning"
+    },
     "WriteTo": [
       {
         "Name": "Console",

--- a/src/DqtApi/appsettings.Production.json
+++ b/src/DqtApi/appsettings.Production.json
@@ -14,12 +14,26 @@
       }
     ]
   },
+  "Sentry": {
+    "SendDefaultPii": true,
+    "IncludeActivityData": true,
+    "MaxRequestBodySize": "None",
+    "TracesSampleRate": 0.1
+  },
   "Serilog": {
+    "Using": [ "Serilog", "Sentry" ],
     "WriteTo": [
       {
         "Name": "Console",
         "Args": {
           "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      },
+      {
+        "Name": "Sentry",
+        "Args": {
+          "minimumBreadcrumbLevel": "Debug",
+          "minimumEventLevel": "Error"
         }
       }
     ]

--- a/src/DqtApi/appsettings.json
+++ b/src/DqtApi/appsettings.json
@@ -1,5 +1,6 @@
 {
   "Serilog": {
+    "Using": [ "Serilog", "Sentry" ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
@@ -9,6 +10,13 @@
     "WriteTo": [
       {
         "Name": "Console"
+      },
+      {
+        "Name": "Sentry",
+        "Args": {
+          "minimumBreadcrumbLevel": "Debug",
+          "minimumEventLevel": "Error"
+        }
       }
     ],
     "Enrich": [ "FromLogContext" ]

--- a/terraform/api-app.tf
+++ b/terraform/api-app.tf
@@ -1,6 +1,8 @@
 locals {
   api_app_config = {
-    AppConfig = data.azurerm_key_vault_secret.secrets["APP-CONFIG"].value
+    AppConfig       = data.azurerm_key_vault_secret.secrets["APP-CONFIG"].value,
+    AppVersion      = var.api_app_version,
+    PaasEnvironment = var.environment_name
   }
 
   logstash_endpoint = data.azurerm_key_vault_secret.secrets["LOGSTASH-ENDPOINT"].value

--- a/terraform/dev.tfvars.json
+++ b/terraform/dev.tfvars.json
@@ -1,4 +1,5 @@
 {
+  "environment_name": "dev",
   "key_vault_name": "s165d01-kv",
   "resource_group_name": "s165d01-rg",
   "api_app_name": "qualified-teachers-api-dev",

--- a/terraform/preprod.tfvars.json
+++ b/terraform/preprod.tfvars.json
@@ -1,4 +1,5 @@
 {
+  "environment_name": "preprod",
   "key_vault_name": "s165t01-preprod-kv",
   "resource_group_name": "s165t01-preprod-rg",
   "api_app_name": "qualified-teachers-api-preprod",

--- a/terraform/prod.tfvars.json
+++ b/terraform/prod.tfvars.json
@@ -1,4 +1,5 @@
 {
+  "environment_name": "prod",
   "key_vault_name": "s165p01-kv",
   "resource_group_name": "s165p01-rg",
   "api_app_name": "qualified-teachers-api-prod",

--- a/terraform/test.tfvars.json
+++ b/terraform/test.tfvars.json
@@ -1,4 +1,5 @@
 {
+  "environment_name": "test",
   "key_vault_name": "s165t01-kv",
   "resource_group_name": "s165t01-rg",
   "api_app_name": "qualified-teachers-api-test",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,7 @@
+variable "environment_name" {
+  type = string
+}
+
 variable "azure_sp_credentials_json" {
   type = string
 }
@@ -28,6 +32,10 @@ variable "api_app_name" {
 }
 
 variable "api_docker_image" {
+  type = string
+}
+
+variable "api_app_version" {
   type = string
 }
 


### PR DESCRIPTION
### Context

https://trello.com/c/LM4vWwgI/59-integrate-with-sentry-dqt-api

### Changes proposed in this pull request

* Adds Sentry integration
Send the `environment` and `version` with every event too. `version` is the deployed commit SHA.

* Prevent logging PII from query parameters
Annotating an action method with one or more `RedactQueryParamAttribute`s will redact the query parameter value when logging. Sentry is configured to never send the request body.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
