### PR TITLE
Add simple load test of Get Teacher API using k6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,5 +22,8 @@ indent_size = 2
 [*.tsv]
 indent_style = tab
 
+[*.js]
+indent_size = 2
+
 [*.cs]
 dotnet_sort_system_directives_first = true

--- a/docs/running-load-tests.md
+++ b/docs/running-load-tests.md
@@ -1,0 +1,20 @@
+# Running load tests
+
+## Software requirements
+- [k6](https://k6.io/docs/getting-started/installation/)
+- node & npm
+
+## Initial setup
+
+### Install NPM packages
+```shell
+load-tests$ npm install
+```
+
+## Running a test
+
+Each of the `.js` files in the `load-tests` folder has a test within in. Find the test you want to run and examine it to determine what environment variables it requires.
+Use the `k6` CLI to run the test and provide the required environment variables.
+
+### Example
+`k6 run -e API_KEY="developer" -e HOST="https://qualified-teachers-api-dev.london.cloudapps.digital" -e TRN=2007946 -e BIRTH_DATE="1996-07-02" .\get-teacher.js`

--- a/load-tests/get-teacher.js
+++ b/load-tests/get-teacher.js
@@ -1,0 +1,38 @@
+import http from "k6/http";
+
+export const options = {
+  scenarios: {
+    rate_limit: {
+      executor: "constant-arrival-rate",
+      rate: 300,
+      timeUnit: "60s",
+      duration: "3m",
+      preAllocatedVUs: 20
+    }
+  }
+};
+
+export default function() {
+  const getRequiredEnvVar = name => {
+    const value = __ENV[name];
+
+    if (!value) {
+      throw new Error(`Missing environment variable: '${name}'.`);
+    }
+
+    return value;
+  };
+
+  const apiKey = getRequiredEnvVar('API_KEY');
+  const host = getRequiredEnvVar('HOST');
+  const trn = getRequiredEnvVar('TRN');
+  const birthDate = getRequiredEnvVar('BIRTH_DATE');
+
+  const params = {
+    headers: {
+      "Authorization": `Bearer ${apiKey}`
+    }
+  };
+
+  http.get(`${host}/v1/teachers/${trn}?birthdate=${birthDate}`, params);
+}

--- a/load-tests/package-lock.json
+++ b/load-tests/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "dqt-api-load-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dqt-api-load-tests",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "k6": "^0.0.0"
+      }
+    },
+    "node_modules/k6": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/k6/-/k6-0.0.0.tgz",
+      "integrity": "sha1-jJIyAL4KaMV46PWjK+lrHYBlzDs="
+    }
+  },
+  "dependencies": {
+    "k6": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/k6/-/k6-0.0.0.tgz",
+      "integrity": "sha1-jJIyAL4KaMV46PWjK+lrHYBlzDs="
+    }
+  }
+}

--- a/load-tests/package.json
+++ b/load-tests/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dqt-api-load-tests",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "dependencies": {
+    "k6": "^0.0.0"
+  }
+}


### PR DESCRIPTION
### Context

https://trello.com/c/hB1bNKtO/76-test-dqt-api

### Changes proposed in this pull request

Adds a simple load test of the Get Teacher API using k6. Test is configured to go up to 300reqs/minute to match our rate limiting configuration.

### Guidance to review

Pull PR and try to execute tests using docs.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
