### PR TITLE
Add education.gov.uk domain

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -22,6 +22,10 @@ data "cloudfoundry_domain" "cloudapps" {
   name = "london.cloudapps.digital"
 }
 
+data "cloudfoundry_domain" "education_gov_uk" {
+  name = "education.gov.uk"
+}
+
 data "cloudfoundry_service" "postgres" {
   name = "postgres"
 }

--- a/terraform/preprod.tfvars.json
+++ b/terraform/preprod.tfvars.json
@@ -7,6 +7,7 @@
   "paas_space": "tra-test",
   "postgres_database_name": "qualified-teachers-api-preprod-pg-svc",
   "redis_name": "qualified-teachers-api-preprod-redis-svc",
+  "hostnames": ["preprod-teacher-qualifications-api"],
   "statuscake_alerts": {
     "tra-preprod": {
       "website_name": "qualified-teachers-api-preprod",

--- a/terraform/prod.tfvars.json
+++ b/terraform/prod.tfvars.json
@@ -10,6 +10,7 @@
   "postgres_database_service_plan": "small-ha-13",
   "redis_name": "qualified-teachers-api-prod-redis-svc",
   "redis_service_plan": "tiny-ha-6_x",
+  "hostnames": ["teacher-qualifications-api"],
   "statuscake_alerts": {
     "tra-prod": {
       "website_name": "qualified-teachers-api-prod",

--- a/terraform/test.tfvars.json
+++ b/terraform/test.tfvars.json
@@ -7,6 +7,7 @@
   "paas_space": "tra-test",
   "postgres_database_name": "qualified-teachers-api-test-pg-svc",
   "redis_name": "qualified-teachers-api-test-redis-svc",
+  "hostnames": ["test-teacher-qualifications-api"],
   "statuscake_alerts": {
     "tra-test": {
       "website_name": "qualified-teachers-api-test",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -80,3 +80,15 @@ variable "migrations_file" {
 variable "statuscake_alerts" {
   type = map(any)
 }
+
+variable "hostnames" {
+  default = []
+  type    = list(any)
+}
+
+locals {
+  api_routes = flatten([
+    cloudfoundry_route.api_public,
+    values(cloudfoundry_route.api_education)
+  ])
+}


### PR DESCRIPTION
## Context

Terraform resources and variable defined for creating a route for
education.gov.uk. This will enable access of API instance through
custom domain.

## Trello card
https://trello.com/c/5J3h8Phh
