### PR TITLE
Turn off Sentry sampling

### DIFF
--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -227,11 +227,6 @@ namespace DqtApi
 
             app.UseRouting();
 
-            if (env.IsProduction())
-            {
-                app.UseSentryTracing();
-            }
-
             app.UseHttpMetrics();
 
             app.UseHealthChecks("/status");

--- a/src/DqtApi/appsettings.Production.json
+++ b/src/DqtApi/appsettings.Production.json
@@ -18,7 +18,7 @@
     "SendDefaultPii": true,
     "IncludeActivityData": true,
     "MaxRequestBodySize": "None",
-    "TracesSampleRate": 0.1
+    "TracesSampleRate": 0
   },
   "Serilog": {
     "Using": [ "Serilog", "Sentry" ],


### PR DESCRIPTION
Don't track every request - only log errors. Reduces the volume of events we're sending to Sentry.