### PR TITLE
Tidy signature of IDataverseAdapter

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
@@ -208,7 +208,7 @@ namespace DqtApi.DataStore.Crm
 
             public async Task<SetIttResultForTeacherLookupResult> LookupData()
             {
-                var getTeacherTask = _dataverseAdapter.GetTeacherAsync(
+                var getTeacherTask = _dataverseAdapter.GetTeacher(
                     _teacherId,
                     columnNames: new[]
                     {

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
@@ -131,7 +131,7 @@ namespace DqtApi.DataStore.Crm
 
             public async Task<SetIttResultForUpdateTeacherLookupResult> LookupData()
             {
-                var getTeacherTask = _dataverseAdapter.GetTeacherAsync(
+                var getTeacherTask = _dataverseAdapter.GetTeacher(
                     TeacherId,
                     columnNames: new[]
                     {
@@ -173,7 +173,7 @@ namespace DqtApi.DataStore.Crm
                     CacheKeys.GetTeacherStatusKey("211"),  // 211 == 'Trainee Teacher:DMS'
                     _ => _dataverseAdapter.GetTeacherStatus("211", qtsDateRequired: false));
 
-                var getQualifications = _dataverseAdapter.GetQualificationsAsync(TeacherId,
+                var getQualifications = _dataverseAdapter.GetQualificationsForTeacher(TeacherId,
                     columnNames: new[]
                     {
                         dfeta_qualification.Fields.dfeta_CompletionorAwardDate,
@@ -435,7 +435,7 @@ namespace DqtApi.DataStore.Crm
 
             public async Task<UpdateTeacherFindResult> FindExistingTeacherToUpdate()
             {
-                var match = await _dataverseAdapter.GetTeacherAsync(TeacherId, columnNames: new[] {Contact.Fields.dfeta_ActiveSanctions,
+                var match = await _dataverseAdapter.GetTeacher(TeacherId, columnNames: new[] {Contact.Fields.dfeta_ActiveSanctions,
                             Contact.Fields.dfeta_QTSDate,
                             Contact.Fields.dfeta_EYTSDate,
                             Contact.Fields.BirthDate

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -89,7 +89,7 @@ namespace DqtApi.DataStore.Crm
             return result.Entities.Select(entity => entity.ToEntity<dfeta_hesubject>()).FirstOrDefault();
         }
 
-        public async Task<IEnumerable<dfeta_initialteachertraining>> GetInitialTeacherTrainingByTeacher(
+        public async Task<dfeta_initialteachertraining[]> GetInitialTeacherTrainingByTeacher(
             Guid teacherId,
             params string[] columnNames)
         {
@@ -103,10 +103,10 @@ namespace DqtApi.DataStore.Crm
 
             var result = await _service.RetrieveMultipleAsync(query);
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_initialteachertraining>());
+            return result.Entities.Select(entity => entity.ToEntity<dfeta_initialteachertraining>()).ToArray();
         }
 
-        public async Task<IEnumerable<Account>> GetIttProviders()
+        public async Task<Account[]> GetIttProviders()
         {
             var filter = new FilterExpression(LogicalOperator.And);
             filter.AddCondition(Account.Fields.StateCode, ConditionOperator.Equal, (int)AccountState.Active);
@@ -127,7 +127,7 @@ namespace DqtApi.DataStore.Crm
 
             var result = await _service.RetrieveMultipleAsync(query);
 
-            return result.Entities.Select(entity => entity.ToEntity<Account>());
+            return result.Entities.Select(entity => entity.ToEntity<Account>()).ToArray();
         }
 
         public async Task<dfeta_ittsubject> GetIttSubjectByName(string name)
@@ -145,7 +145,7 @@ namespace DqtApi.DataStore.Crm
             return result.Entities.Select(entity => entity.ToEntity<dfeta_ittsubject>()).FirstOrDefault();
         }
 
-        public async Task<IEnumerable<Contact>> GetMatchingTeachersAsync(GetTeacherRequest request)
+        public async Task<Contact[]> GetMatchingTeachers(GetTeacherRequest request)
         {
             var query = request.GenerateQuery();
 
@@ -155,7 +155,7 @@ namespace DqtApi.DataStore.Crm
 
             var result = await _service.RetrieveMultipleAsync(query);
 
-            return result.Entities.Select(entity => entity.ToEntity<Contact>());
+            return result.Entities.Select(entity => entity.ToEntity<Contact>()).ToArray();
 
             static void AddInitialTeacherTrainingLink(QueryExpression query)
             {
@@ -262,7 +262,7 @@ namespace DqtApi.DataStore.Crm
             return result.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
         }
 
-        public async Task<IEnumerable<dfeta_qtsregistration>> GetQtsRegistrationsByTeacher(
+        public async Task<dfeta_qtsregistration[]> GetQtsRegistrationsByTeacher(
             Guid teacherId,
             params string[] columnNames)
         {
@@ -276,10 +276,10 @@ namespace DqtApi.DataStore.Crm
 
             var result = await _service.RetrieveMultipleAsync(query);
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_qtsregistration>());
+            return result.Entities.Select(entity => entity.ToEntity<dfeta_qtsregistration>()).ToArray();
         }
 
-        public async Task<IEnumerable<dfeta_qualification>> GetQualificationsAsync(Guid teacherId, params string[] columnNames)
+        public async Task<dfeta_qualification[]> GetQualificationsForTeacher(Guid teacherId, params string[] columnNames)
         {
             var query = new QueryByAttribute(dfeta_qualification.EntityLogicalName)
             {
@@ -290,10 +290,10 @@ namespace DqtApi.DataStore.Crm
 
             var result = await _service.RetrieveMultipleAsync(query);
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_qualification>());
+            return result.Entities.Select(entity => entity.ToEntity<dfeta_qualification>()).ToArray();
         }
 
-        public async Task<Contact> GetTeacherAsync(Guid teacherId, bool resolveMerges = true, params string[] columnNames)
+        public async Task<Contact> GetTeacher(Guid teacherId, bool resolveMerges = true, params string[] columnNames)
         {
             var columnSet = new ColumnSet(
                 columnNames
@@ -316,13 +316,13 @@ namespace DqtApi.DataStore.Crm
             while (resolveMerges && teacher.Merged == true)
             {
                 var masterReference = teacher.MasterId;
-                return await GetTeacherAsync(masterReference.Id, resolveMerges);
+                return await GetTeacher(masterReference.Id, resolveMerges);
             }
 
             return teacher;
         }
 
-        public async Task<IEnumerable<Contact>> GetTeachersByTrn(string trn, bool activeOnly = true, params string[] columnNames)
+        public async Task<Contact[]> GetTeachersByTrn(string trn, bool activeOnly = true, params string[] columnNames)
         {
             var filter = new FilterExpression(LogicalOperator.And);
             filter.AddCondition(Contact.Fields.dfeta_TRN, ConditionOperator.Equal, trn);
@@ -340,18 +340,20 @@ namespace DqtApi.DataStore.Crm
 
             var result = await _service.RetrieveMultipleAsync(query);
 
-            return result.Entities.Select(e => e.ToEntity<Contact>());
+            return result.Entities.Select(e => e.ToEntity<Contact>()).ToArray();
         }
 
-        public async Task<IEnumerable<CrmTask>> GetCrmTasks(Guid teacherId, params string[] columnNames)
+        public async Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, params string[] columnNames)
         {
             var query = new QueryByAttribute(CrmTask.EntityLogicalName)
             {
                 ColumnSet = new ColumnSet(columnNames)
             };
             query.AddAttributeValue(CrmTask.Fields.RegardingObjectId, teacherId);
+
             var result = await _service.RetrieveMultipleAsync(query);
-            return result.Entities.Select(entity => entity.ToEntity<CrmTask>());
+
+            return result.Entities.Select(entity => entity.ToEntity<CrmTask>()).ToArray();
         }
 
         public async Task<dfeta_teacherstatus> GetTeacherStatus(
@@ -377,7 +379,7 @@ namespace DqtApi.DataStore.Crm
             return result.Entities.Select(entity => entity.ToEntity<dfeta_teacherstatus>()).FirstOrDefault();
         }
 
-        public async Task<bool> UnlockTeacherRecordAsync(Guid teacherId)
+        public async Task<bool> UnlockTeacherRecord(Guid teacherId)
         {
             var update = new Entity(Contact.EntityLogicalName, teacherId);
             update[Contact.Fields.dfeta_loginfailedcounter] = 0;
@@ -409,7 +411,7 @@ namespace DqtApi.DataStore.Crm
             return result.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
         }
 
-        public async Task<IReadOnlyCollection<Contact>> FindTeachers(FindTeachersQuery filter)
+        public async Task<Contact[]> FindTeachers(FindTeachersQuery filter)
         {
             var fields = new[]
             {
@@ -464,8 +466,10 @@ namespace DqtApi.DataStore.Crm
                 le1.LinkCriteria.AddCondition(dfeta_initialteachertraining.Fields.dfeta_EstablishmentId, ConditionOperator.Equal, filter.IttProviderOrganizationId);
                 query.LinkEntities.Add(le1);
             }
+
             var result = await _service.RetrieveMultipleAsync(query);
-            return result.Entities.Select(entity => entity.ToEntity<Contact>()).ToList(); ;
+
+            return result.Entities.Select(entity => entity.ToEntity<Contact>()).ToArray();
         }
     }
 }

--- a/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm.Models;
 
@@ -9,21 +8,25 @@ namespace DqtApi.DataStore.Crm
     {
         Task<CreateTeacherResult> CreateTeacher(CreateTeacherCommand command);
 
-        Task<IEnumerable<Account>> GetIttProviders();
+        Task<Account[]> GetIttProviders();
 
-        Task<IEnumerable<Contact>> GetMatchingTeachersAsync(GetTeacherRequest request);
+        Task<Contact[]> GetMatchingTeachers(GetTeacherRequest request);
 
-        Task<IEnumerable<dfeta_qualification>> GetQualificationsAsync(Guid teacherId, params string[] columnNames);
+        Task<dfeta_qualification[]> GetQualificationsForTeacher(Guid teacherId, params string[] columnNames);
 
-        Task<Contact> GetTeacherAsync(Guid teacherId, bool resolveMerges = true, params string[] columnNames);
+        Task<Contact> GetTeacher(Guid teacherId, bool resolveMerges = true, params string[] columnNames);
 
-        Task<IEnumerable<Contact>> GetTeachersByTrn(string trn, bool activeOnly = true, params string[] columnNames);
+        Task<Contact[]> GetTeachersByTrn(string trn, bool activeOnly = true, params string[] columnNames);
 
-        Task<IReadOnlyCollection<Contact>> FindTeachers(FindTeachersQuery query);
+        Task<Contact[]> FindTeachers(FindTeachersQuery query);
+
         Task<UpdateTeacherResult> UpdateTeacher(UpdateTeacherCommand command);
+
         Task<Account> GetOrganizationByProviderName(string providerName, params string[] columnNames);
+
         Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames);
-        Task<IEnumerable<CrmTask>> GetCrmTasks(Guid teacherId, params string[] columnNames);
+
+        Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, params string[] columnNames);
 
         Task<SetIttResultForTeacherResult> SetIttResultForTeacher(
             Guid teacherId,
@@ -31,6 +34,6 @@ namespace DqtApi.DataStore.Crm
             dfeta_ITTResult result,
             DateOnly? assessmentDate);
 
-        Task<bool> UnlockTeacherRecordAsync(Guid teacherId);
+        Task<bool> UnlockTeacherRecord(Guid teacherId);
     }
 }

--- a/src/DqtApi/V1/Controllers/TeachersController.cs
+++ b/src/DqtApi/V1/Controllers/TeachersController.cs
@@ -36,7 +36,7 @@ namespace DqtApi.V1.Controllers
                 return NotFound();
             }
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             var teacher = request.SelectMatch(matchingTeachers);
 
@@ -46,7 +46,7 @@ namespace DqtApi.V1.Controllers
             }
             else
             {
-                var qualifications = await _dataverseAdapter.GetQualificationsAsync(teacher.Id,
+                var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(teacher.Id,
                     new [] { dfeta_qualification.Fields.dfeta_CompletionorAwardDate, dfeta_qualification.Fields.dfeta_Type});
 
                 if (qualifications.Any())

--- a/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -53,7 +53,7 @@ namespace DqtApi.V2.Handlers
             if (trnRequest != null)
             {
                 var teacher = trnRequest.TeacherId.HasValue ?
-                    await _dataverseAdapter.GetTeacherAsync(trnRequest.TeacherId.Value) :
+                    await _dataverseAdapter.GetTeacher(trnRequest.TeacherId.Value) :
                     null;
 
                 wasCreated = false;

--- a/src/DqtApi/V2/Handlers/GetTrnRequestHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetTrnRequestHandler.cs
@@ -43,7 +43,7 @@ namespace DqtApi.V2.Handlers
 
             if (trnRequest.TeacherId.HasValue)
             {
-                var teacher = await _dataverseAdapter.GetTeacherAsync(trnRequest.TeacherId.Value, columnNames: Contact.Fields.dfeta_TRN);
+                var teacher = await _dataverseAdapter.GetTeacher(trnRequest.TeacherId.Value, columnNames: Contact.Fields.dfeta_TRN);
                 trn = teacher.dfeta_TRN;
             }
 

--- a/src/DqtApi/V2/Handlers/UnlockTeacherHandler.cs
+++ b/src/DqtApi/V2/Handlers/UnlockTeacherHandler.cs
@@ -18,7 +18,7 @@ namespace DqtApi.V2.Handlers
 
         public async Task<Unit> Handle(UnlockTeacherRequest request, CancellationToken cancellationToken)
         {
-            var found = await _dataverseAdapter.UnlockTeacherRecordAsync(request.TeacherId);
+            var found = await _dataverseAdapter.UnlockTeacherRecord(request.TeacherId);
 
             if (!found)
             {

--- a/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
@@ -24,7 +24,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, true);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Single(matchingTeachers);
 
@@ -36,7 +36,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(None, true);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -46,7 +46,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, false);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -56,7 +56,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(None, false);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -66,7 +66,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, true, One);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Single(matchingTeachers);
 
@@ -78,7 +78,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, true, Two);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Collection(matchingTeachers,
                 firstTeacher => _fixture.AssertMatchesFixture(firstTeacher, 0),
@@ -91,7 +91,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(None, true, One);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Single(matchingTeachers);
 
@@ -103,7 +103,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, true, None);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Single(matchingTeachers);
 
@@ -115,7 +115,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(None, false, One);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -125,7 +125,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, false, None);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Empty(matchingTeachers);
         }
@@ -135,7 +135,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var request = _fixture.GetRequest(One, false, One);
 
-            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachersAsync(request);
+            var matchingTeachers = await _dataverseAdapter.GetMatchingTeachers(request);
 
             Assert.Empty(matchingTeachers);
         }

--- a/tests/DqtApi.Tests/DataverseIntegration/GetTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetTeacherTests.cs
@@ -32,7 +32,7 @@ namespace DqtApi.Tests.DataverseIntegration
             var teacherId = Guid.NewGuid();
 
             // Act
-            var result = await _dataverseAdapter.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
+            var result = await _dataverseAdapter.GetTeacher(teacherId, resolveMerges: false, Contact.Fields.StateCode);
 
             // Assert
             Assert.Null(result);
@@ -45,7 +45,7 @@ namespace DqtApi.Tests.DataverseIntegration
             var teacherId = await _organizationService.CreateAsync(new Contact());
 
             // Act
-            var result = await _dataverseAdapter.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
+            var result = await _dataverseAdapter.GetTeacher(teacherId, resolveMerges: false, Contact.Fields.StateCode);
 
             // Assert
             Assert.NotNull(result);
@@ -68,7 +68,7 @@ namespace DqtApi.Tests.DataverseIntegration
             });
 
             // Act
-            var result = await _dataverseAdapter.GetTeacherAsync(teacherId, resolveMerges: true, Contact.Fields.StateCode);
+            var result = await _dataverseAdapter.GetTeacher(teacherId, resolveMerges: true, Contact.Fields.StateCode);
 
             // Assert
             Assert.NotNull(result);
@@ -91,7 +91,7 @@ namespace DqtApi.Tests.DataverseIntegration
             });
 
             // Act
-            var result = await _dataverseAdapter.GetTeacherAsync(teacherId, resolveMerges: false, Contact.Fields.StateCode);
+            var result = await _dataverseAdapter.GetTeacher(teacherId, resolveMerges: false, Contact.Fields.StateCode);
 
             // Assert
             Assert.NotNull(result);

--- a/tests/DqtApi.Tests/DataverseIntegration/SetIttOutcomeForTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/SetIttOutcomeForTeacherTests.cs
@@ -62,7 +62,7 @@ namespace DqtApi.Tests.DataverseIntegration
 
             transactionRequest.AssertDoesNotContainUpdateRequest<dfeta_induction>();
 
-            var teacher = await _dataverseAdapter.GetTeacherAsync(teacherId, columnNames: Contact.Fields.dfeta_EYTSDate);
+            var teacher = await _dataverseAdapter.GetTeacher(teacherId, columnNames: Contact.Fields.dfeta_EYTSDate);
             Assert.Equal(assessmentDate.ToDateTime(), teacher.dfeta_EYTSDate);
         }
 
@@ -106,7 +106,7 @@ namespace DqtApi.Tests.DataverseIntegration
             Assert.Equal(teacherId, induction.dfeta_PersonId?.Id);
             Assert.Equal(dfeta_InductionStatus.RequiredtoComplete, induction.dfeta_InductionStatus);
 
-            var teacher = await _dataverseAdapter.GetTeacherAsync(teacherId, columnNames: Contact.Fields.dfeta_QTSDate);
+            var teacher = await _dataverseAdapter.GetTeacher(teacherId, columnNames: Contact.Fields.dfeta_QTSDate);
             Assert.Equal(assessmentDate.ToDateTime(), teacher.dfeta_QTSDate);
         }
 

--- a/tests/DqtApi.Tests/DataverseIntegration/UnlockTeacherRecordTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/UnlockTeacherRecordTests.cs
@@ -31,7 +31,7 @@ namespace DqtApi.Tests.DataverseIntegration
             var teacherId = Guid.NewGuid();
 
             // Act
-            var result = await _dataverseAdapter.UnlockTeacherRecordAsync(teacherId);
+            var result = await _dataverseAdapter.UnlockTeacherRecord(teacherId);
 
             // Assert
             Assert.False(result);
@@ -49,7 +49,7 @@ namespace DqtApi.Tests.DataverseIntegration
             });
 
             // Act
-            var result = await _dataverseAdapter.UnlockTeacherRecordAsync(teacherId);
+            var result = await _dataverseAdapter.UnlockTeacherRecord(teacherId);
 
             // Assert
             Assert.True(result);

--- a/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
@@ -67,7 +67,7 @@ namespace DqtApi.Tests.DataverseIntegration
             });
 
             var oldProvider = (await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn)).Id;
-            var qualifications = await _dataverseAdapter.GetQualificationsAsync(
+            var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,
                 columnNames: new[]
                 {
@@ -230,7 +230,7 @@ namespace DqtApi.Tests.DataverseIntegration
                 ReturnResponses = true
             });
 
-            await _dataverseAdapter.GetQualificationsAsync(
+            await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,
                 columnNames: new[]
                 {
@@ -268,7 +268,7 @@ namespace DqtApi.Tests.DataverseIntegration
                 }
             });
 
-            var qualifications = await _dataverseAdapter.GetQualificationsAsync(
+            var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,
                 columnNames: new[]
                 {
@@ -521,7 +521,7 @@ namespace DqtApi.Tests.DataverseIntegration
             });
 
             var oldProvider = (await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn)).Id;
-            var qualifications = await _dataverseAdapter.GetQualificationsAsync(
+            var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,
                 columnNames: new[]
                 {
@@ -702,7 +702,7 @@ namespace DqtApi.Tests.DataverseIntegration
 
             var oldProvider = (await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn)).Id;
             var newProviderProvider = (await _dataverseAdapter.GetOrganizationByUkprn(newIttProviderUkprn)).Id;
-            var qualifications = await _dataverseAdapter.GetQualificationsAsync(
+            var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,
                 columnNames: new[]
                 {

--- a/tests/DqtApi.Tests/V1/UnitTests/TeachersController.cs
+++ b/tests/DqtApi.Tests/V1/UnitTests/TeachersController.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -17,13 +15,13 @@ namespace DqtApi.Tests.V1.UnitTests
 
         public TeachersController()
         {
-            _adapter = new Mock<IDataverseAdapter>();            
+            _adapter = new Mock<IDataverseAdapter>();
         }
 
         [Fact]
         public async Task Given_there_is_no_match_return_not_found()
         {
-            _adapter.Setup(a => a.GetMatchingTeachersAsync(It.IsAny<GetTeacherRequest>())).ReturnsAsync(new List<Contact>());
+            _adapter.Setup(a => a.GetMatchingTeachers(It.IsAny<GetTeacherRequest>())).ReturnsAsync(Array.Empty<Contact>());
 
             var result = await new DqtApi.V1.Controllers.TeachersController(_adapter.Object).GetTeacher(new GetTeacherRequest { TRN = trn, BirthDate = birthDate });
 
@@ -33,7 +31,7 @@ namespace DqtApi.Tests.V1.UnitTests
         [Fact]
         public async Task Given_there_is_a_match_return_ok()
         {
-            _adapter.Setup(a => a.GetMatchingTeachersAsync(It.IsAny<GetTeacherRequest>())).ReturnsAsync(new[] { new Contact{ dfeta_TRN = trn } });
+            _adapter.Setup(a => a.GetMatchingTeachers(It.IsAny<GetTeacherRequest>())).ReturnsAsync(new[] { new Contact{ dfeta_TRN = trn } });
 
             var result = await new DqtApi.V1.Controllers.TeachersController(_adapter.Object).GetTeacher(new GetTeacherRequest { TRN = trn, BirthDate = birthDate });
 

--- a/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -47,7 +47,7 @@ namespace DqtApi.Tests.V2.Operations
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
-                .ReturnsAsync(new List<Contact> { contact1 });
+                .ReturnsAsync(new[] { contact1 });
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}");
 
@@ -86,7 +86,7 @@ namespace DqtApi.Tests.V2.Operations
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
-                .ReturnsAsync(new List<Contact> { contact1 });
+                .ReturnsAsync(new[] { contact1 });
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}&IttProviderUkPrn={providerUkprn}&IttProviderName={providerName}");
 
@@ -117,7 +117,7 @@ namespace DqtApi.Tests.V2.Operations
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
-                .ReturnsAsync(new List<Contact> { contact1 });
+                .ReturnsAsync(new[] { contact1 });
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}&IttProviderUkPrn={providerUkprn}&IttProviderName={providerName}");
 
@@ -154,7 +154,7 @@ namespace DqtApi.Tests.V2.Operations
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
-                .ReturnsAsync(new List<Contact> { contact1 });
+                .ReturnsAsync(new[] { contact1 });
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}&IttProviderUkPrn=12345678910&IttProviderName=provider");
 

--- a/tests/DqtApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -28,7 +28,7 @@ namespace DqtApi.Tests.V2.Operations
             var trn = "1234567";
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetTeacherAsync(teacherId, /* resolveMerges: */ true, It.IsAny<string[]>()))
+                .Setup(mock => mock.GetTeacher(teacherId, /* resolveMerges: */ true, It.IsAny<string[]>()))
                 .ReturnsAsync(new Contact()
                 {
                     Id = teacherId,

--- a/tests/DqtApi.Tests/V2/Operations/GetTrnRequestTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/GetTrnRequestTests.cs
@@ -98,7 +98,7 @@ namespace DqtApi.Tests.V2.Operations
             var trn = "1234567";
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetTeacherAsync(teacherId, /* resolveMerges: */ true, It.IsAny<string[]>()))
+                .Setup(mock => mock.GetTeacher(teacherId, /* resolveMerges: */ true, It.IsAny<string[]>()))
                 .ReturnsAsync(new Contact()
                 {
                     Id = teacherId,

--- a/tests/DqtApi.Tests/V2/Operations/SetIttOutcomeTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/SetIttOutcomeTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Net.Http;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
@@ -26,7 +25,7 @@ namespace DqtApi.Tests.V2.Operations
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.GetTeachersByTrn(trn, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
-                .ReturnsAsync(Enumerable.Empty<Contact>());
+                .ReturnsAsync(Array.Empty<Contact>());
 
             var requestBody = new SetIttOutcomeRequest()
             {

--- a/tests/DqtApi.Tests/V2/Operations/UnlockTeacherTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/UnlockTeacherTests.cs
@@ -20,7 +20,7 @@ namespace DqtApi.Tests.V2.Operations
             var teacherId = Guid.NewGuid();
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.UnlockTeacherRecordAsync(teacherId))
+                .Setup(mock => mock.UnlockTeacherRecord(teacherId))
                 .ReturnsAsync(false);
 
             var request = new HttpRequestMessage(HttpMethod.Put, $"v2/unlock-teacher/{teacherId}");
@@ -39,7 +39,7 @@ namespace DqtApi.Tests.V2.Operations
             var teacherId = Guid.NewGuid();
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.UnlockTeacherRecordAsync(teacherId))
+                .Setup(mock => mock.UnlockTeacherRecord(teacherId))
                 .ReturnsAsync(true)
                 .Verifiable();
 

--- a/tests/DqtApi.Tests/V2/Operations/UpdateTeacherTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/UpdateTeacherTests.cs
@@ -28,7 +28,8 @@ namespace DqtApi.Tests.V2.Operations
             // Arrange
             var ukprn = "xxx";
             var contact = new Contact() { Id = Guid.NewGuid() };
-            var contactList = new List<Contact>() { contact };
+            var contactList = new[] { contact };
+
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.UpdateTeacher(It.IsAny<UpdateTeacherCommand>()))
                 .ReturnsAsync(UpdateTeacherResult.Failed(UpdateTeacherFailedReasons.NoMatchingIttRecord));
@@ -53,7 +54,8 @@ namespace DqtApi.Tests.V2.Operations
             var ukprn = "xxx";
             var subject = "xxx";
             var contact = new Contact() { Id = Guid.NewGuid() };
-            var contactList = new List<Contact>() { contact };
+            var contactList = new[] { contact };
+
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.UpdateTeacher(It.IsAny<UpdateTeacherCommand>()))
                     .ReturnsAsync(UpdateTeacherResult.Failed(UpdateTeacherFailedReasons.Subject1NotFound));
@@ -78,7 +80,8 @@ namespace DqtApi.Tests.V2.Operations
             var ukprn = "xxx";
             var subject = "xxx";
             var contact = new Contact() { Id = Guid.NewGuid() };
-            var contactList = new List<Contact>() { contact };
+            var contactList = new[] { contact };
+
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.UpdateTeacher(It.IsAny<UpdateTeacherCommand>()))
                     .ReturnsAsync(UpdateTeacherResult.Failed(UpdateTeacherFailedReasons.Subject2NotFound));
@@ -103,7 +106,7 @@ namespace DqtApi.Tests.V2.Operations
             var ukprn = "xxx";
             var country = "some non existent country country";
             var contact = new Contact() { Id = Guid.NewGuid() };
-            var contactList = new List<Contact>() { contact };
+            var contactList = new[] { contact };
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.GetTeachersByTrn(ukprn, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
@@ -129,7 +132,7 @@ namespace DqtApi.Tests.V2.Operations
             var ukprn = "xxx";
             var subject = "xxx";
             var contact = new Contact() { Id = Guid.NewGuid() };
-            var contactList = new List<Contact>() { contact };
+            var contactList = new[] { contact };
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.GetTeachersByTrn(ukprn, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
@@ -155,8 +158,9 @@ namespace DqtApi.Tests.V2.Operations
             var ukprn = "xxx";
             var subject = "xxx";
             var contact = new Contact() { Id = Guid.NewGuid() };
-            var contactList = new List<Contact>() { contact };
+            var contactList = new[] { contact };
             var result = UpdateTeacherResult.Success(Guid.NewGuid(), "some trn");
+
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.GetTeachersByTrn(ukprn, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
                     .ReturnsAsync(contactList);
@@ -210,7 +214,8 @@ namespace DqtApi.Tests.V2.Operations
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.GetTeachersByTrn(trn, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
-                .ReturnsAsync(Enumerable.Empty<Contact>());
+                .ReturnsAsync(Array.Empty<Contact>());
+
             var requestBody = new UpdateTeacherRequest()
             {
                 InitialTeacherTraining = new UpdateTeacherRequestInitialTeacherTraining()
@@ -252,7 +257,8 @@ namespace DqtApi.Tests.V2.Operations
 
             var contact1 = new Contact();
             var contact2 = new Contact();
-            var contactList = new List<Contact>() { contact1, contact2 };
+            var contactList = new[] { contact1, contact2 };
+
             var requestBody = new UpdateTeacherRequest()
             {
                 InitialTeacherTraining = new UpdateTeacherRequestInitialTeacherTraining()


### PR DESCRIPTION
- Remove Async suffix from method names.
- Return arrays instead of IEnumerable<T>.
- Fix up a few method names.