### PR TITLE
Disable Timestamp Disclosure ZAP errors

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,1 +1,2 @@
 40018	IGNORE	(SQL Injection)
+10096	IGNORE	(Timestamp Disclosure)


### PR DESCRIPTION
We get these erratically on CI and it's not a real issue.