### PR TITLE
Fix out of range birth date triggering an error from CRM

### DIFF
--- a/src/DqtApi/Properties/StringResources.Designer.cs
+++ b/src/DqtApi/Properties/StringResources.Designer.cs
@@ -88,6 +88,15 @@ namespace DqtApi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Birth date is out of expected range..
+        /// </summary>
+        public static string ErrorMessages_BirthDateIsOutOfRange {
+            get {
+                return ResourceManager.GetString("ErrorMessages.BirthDateIsOutOfRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Birth date must be in format yyyy-MM-dd.
         /// </summary>
         public static string ErrorMessages_InvalidBirthDate {

--- a/src/DqtApi/Properties/StringResources.resx
+++ b/src/DqtApi/Properties/StringResources.resx
@@ -126,6 +126,9 @@
   <data name="ErrorMessages.AgeToCannotBeLessThanAgeFrom" xml:space="preserve">
     <value>'Age to' cannot be less than 'age from'.</value>
   </data>
+  <data name="ErrorMessages.BirthDateIsOutOfRange" xml:space="preserve">
+    <value>Birth date is out of expected range.</value>
+  </data>
   <data name="ErrorMessages.InvalidBirthDate" xml:space="preserve">
     <value>Birth date must be in format yyyy-MM-dd</value>
   </data>

--- a/src/DqtApi/V1/Validators/GetTeacherRequestValidator.cs
+++ b/src/DqtApi/V1/Validators/GetTeacherRequestValidator.cs
@@ -1,4 +1,5 @@
 ﻿using DqtApi.DataStore.Crm.Models;
+using DqtApi.Validation;
 using FluentValidation;
 
 namespace DqtApi.V1.Validators
@@ -10,6 +11,10 @@ namespace DqtApi.V1.Validators
             RuleFor(x => x.TRN)
                 .Matches(@"^\d{7}$")
                 .WithMessage(Properties.StringResources.ErrorMessages_TRNMustBe7Digits);
+
+            RuleFor(x => x.BirthDate)
+                .GreaterThanOrEqualTo(Constants.MinCrmDateTime)
+                .WithMessage(Properties.StringResources.ErrorMessages_BirthDateIsOutOfRange);
         }
     }
 }

--- a/src/DqtApi/Validation/Constants.cs
+++ b/src/DqtApi/Validation/Constants.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace DqtApi.Validation
+{
+    public static class Constants
+    {
+        public static DateOnly MinCrmDate { get; } = new DateOnly(1753, 1, 1);
+
+        public static DateTime MinCrmDateTime { get; } = new DateTime(1753, 1, 1);
+    }
+}


### PR DESCRIPTION
### Context

https://trello.com/c/w4spryA5/206-fix-validation-exception-from-get-teacher-endpoint

### Changes proposed in this pull request

Add extra validation to ensure the birth date is within the acceptable bounds for CRM.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
