### PR TITLE
Ensure errors applying migrations fail the deployment stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,16 @@ jobs:
     - name: Generate migrations artifact
       run: |
         mkdir migrations
+        migrations_file=migrations/script.sql
+
         dotnet tool install --global dotnet-ef
-        dotnet ef migrations script --idempotent --output migrations/script.sql --configuration Release --project src/DqtApi/DqtApi.csproj --no-build
+        dotnet ef migrations script --idempotent --output $migrations_file --configuration Release --project src/DqtApi/DqtApi.csproj --no-build
+
+        # Remove the BOM
+        sed -i $'1s/^\uFEFF//' $migrations_file
+
+        # Ensure any errors return a non-zero exit code when migrations are applied
+        echo "$(echo "\set ON_ERROR_STOP true"; echo ""; cat $migrations_file)" > $migrations_file
 
     - name: Publish migrations
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
### Context

https://trello.com/c/h9MO3pOl/207-fix-sql-migration-issues-on-test-environment

### Changes proposed in this pull request

Errors applying migrations have historically not failed the pipeline which means the test environment has had an issue for a while. This fixes the pipeline so errors fail each stage. Fixing the test environment has been done manually.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
