### PR TITLE
Log request body with errors for non-production environments

### DIFF
--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -53,6 +53,8 @@ namespace DqtApi
             var env = builder.Environment;
             var configuration = builder.Configuration;
 
+            var paasEnvironmentName = configuration["PaasEnvironment"];
+
             builder.Host.UseSerilog((ctx, config) => config.ReadFrom.Configuration(ctx.Configuration));
 
             if (env.IsProduction())
@@ -165,7 +167,6 @@ namespace DqtApi
 
             services.Configure<SentryAspNetCoreOptions>(options =>
             {
-                var paasEnvironmentName = configuration["PaasEnvironment"];
                 if (!string.IsNullOrEmpty(paasEnvironmentName))
                 {
                     options.Environment = paasEnvironmentName;
@@ -223,7 +224,7 @@ namespace DqtApi
 
             var app = builder.Build();
 
-            app.UseRequestLogging();
+            app.UseRequestLogging(logRequestBody: paasEnvironmentName != "prod");
 
             app.UseRouting();
 


### PR DESCRIPTION
This makes debugging considerably easier.

### Context

We have an error on Sentry with a `NullReferenceException` and the stack trace is somewhere inside Fluent Validation. Getting the request body with errors such as this will make debugging simpler.

Disabled for production environment because a) buffering the request has a cost and b) we don't want to store PII in logs.

### Changes proposed in this pull request

Add a `RequestBody` property to logs for non-production environments.

### Checklist

~~-   [ ] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
