### PR TITLE
Added Validation rule to not allow dob >= today & dob < 01-01-1940

### DIFF
--- a/src/DqtApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
+++ b/src/DqtApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
@@ -1,4 +1,5 @@
-﻿using DqtApi.DataStore.Crm.Models;
+﻿using System;
+using DqtApi.DataStore.Crm.Models;
 using DqtApi.DataStore.Sql.Models;
 using DqtApi.Properties;
 using DqtApi.V2.Requests;
@@ -8,7 +9,7 @@ namespace DqtApi.V2.Validators
 {
     public class GetOrCreateTrnRequestValidator : AbstractValidator<GetOrCreateTrnRequest>
     {
-        public GetOrCreateTrnRequestValidator()
+        public GetOrCreateTrnRequestValidator(IClock clock)
         {
             RuleFor(r => r.RequestId)
                 .Matches(TrnRequest.ValidRequestIdPattern)
@@ -28,7 +29,14 @@ namespace DqtApi.V2.Validators
                 .MaximumLength(AttributeConstraints.Contact.LastNameMaxLength);
 
             RuleFor(r => r.BirthDate)
-                .NotEmpty();
+                .NotEmpty()
+                .Custom((value, ctx) =>
+                {
+                    if (value >= DateOnly.FromDateTime(clock.UtcNow) || value < new DateOnly(1940, 1, 1))
+                    {
+                        ctx.AddFailure(ctx.PropertyName, StringResources.ErrorMessages_BirthDateIsOutOfRange);
+                    }
+                });
 
             RuleFor(r => r.EmailAddress)
                 .EmailAddress()

--- a/tests/DqtApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -296,6 +296,55 @@ namespace DqtApi.Tests.V2.Operations
                 expectedError: Properties.StringResources.Errors_10008_Title);
         }
 
+
+        [Theory]
+        [InlineData(1900,1,1)]
+        public async Task Given_dob_before_1_1_1940_returns_error(int year, int month, int day)
+        {
+            // Arrange
+            var dob = new DateOnly(year, month, day);
+            var requestId = Guid.NewGuid().ToString();
+            Clock.UtcNow = new DateTime(2022, 1, 1);
+
+            var request = CreateRequest(cmd =>
+            {
+                cmd.BirthDate = dob;
+            });
+
+            // Act
+            var response = await HttpClient.PutAsync($"v2/trn-requests/{requestId}", request);
+
+            // Assert
+            await AssertEx.ResponseIsValidationErrorForProperty(
+                response,
+                "Birthdate",
+                StringResources.ErrorMessages_BirthDateIsOutOfRange);
+        }
+
+        [Theory]
+        [InlineData(2022, 1, 1)]
+        [InlineData(2023, 1, 1)]
+        public async Task Given_dob_equal_or_after_today_returns_error(int year, int month, int day)
+        {
+            // Arrange
+            var dob = new DateOnly(year, month, day);
+            var requestId = Guid.NewGuid().ToString();
+            Clock.UtcNow = new DateTime(2022, 1, 1);
+            var request = CreateRequest(cmd =>
+            {
+                cmd.BirthDate = dob;
+            });
+
+            // Act
+            var response = await HttpClient.PutAsync($"v2/trn-requests/{requestId}", request);
+
+            // Assert
+            await AssertEx.ResponseIsValidationErrorForProperty(
+                response,
+                "Birthdate",
+                StringResources.ErrorMessages_BirthDateIsOutOfRange);
+        }
+
         [Theory]
         [MemberData(nameof(InvalidAgeCombinationsData))]
         public async Task Given_invalid_age_combination_returns_error(


### PR DESCRIPTION
### Context

Added new validation rule to stop dob being in the future and less than 1940-01-01

### Changes proposed in this pull request

new validation rule & tests.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
