### PR TITLE
CRM request batching improvements

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.RequestBuilder.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.RequestBuilder.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+
+namespace DqtApi.DataStore.Crm
+{
+    public partial class DataverseAdapter
+    {
+        /// <summary>
+        /// A helper type for composing CRM requests.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var builder = MultiRequestBuilder.CreateTransaction(organizationService);
+        /// var request1 = builder.AddRequest(new CreateRequest());
+        /// var request2 = builder.AddRequest(new UpdateRequest());
+        /// await builder.Execute();
+        /// var response1 = request1.GetResponse();
+        /// var response2 = request2.GetResponse();
+        /// </code>
+        /// </example>
+        private class RequestBuilder
+        {
+            private readonly IOrganizationServiceAsync _organizationService;
+            private readonly RequestType _requestType;
+            private readonly List<OrganizationRequest> _requests;
+            private OrganizationResponse[] _responses;
+            private readonly TaskCompletionSource _completedTcs;
+
+            private RequestBuilder(IOrganizationServiceAsync organizationService, RequestType requestType)
+            {
+                _organizationService = organizationService;
+                _requestType = requestType;
+                _requests = new();
+                _completedTcs = new();
+            }
+
+            public static RequestBuilder CreateSingle(IOrganizationServiceAsync organizationService) =>
+                new(organizationService, RequestType.Single);
+
+            public static RequestBuilder CreateMultiple(IOrganizationServiceAsync organizationService) =>
+                new(organizationService, RequestType.Multiple);
+
+            public static RequestBuilder CreateTransaction(IOrganizationServiceAsync organizationService) =>
+                new(organizationService, RequestType.Transaction);
+
+            public IInnerRequestHandle<TResponse> AddRequest<TResponse>(OrganizationRequest request)
+                where TResponse : OrganizationResponse
+            {
+                ThrowIfCompleted();
+
+                if (_requestType == RequestType.Single && _requests.Count != 0)
+                {
+                    throw new InvalidOperationException($"Only a single request can be specified when {nameof(RequestType)} is {nameof(RequestType.Single)}.");
+                }
+
+                _requests.Add(request);
+
+                if (_requestType == RequestType.Single)
+                {
+                    Execute();
+                }
+
+                return new InnerRequestHandle<TResponse>(this, request);
+            }
+
+            public Task Execute()
+            {
+                ThrowIfCompleted();
+
+                return _requestType switch
+                {
+                    RequestType.Single => ExecuteSingleRequest(),
+                    RequestType.Multiple => ExecuteMultipleRequest(),
+                    RequestType.Transaction => ExecuteTransactionRequest(),
+                    _ => throw new NotSupportedException($"Unknown {nameof(RequestType)}: '{_requestType}'.")
+                };
+
+                async Task ExecuteSingleRequest()
+                {
+                    if (_requests.Count == 0)
+                    {
+                        throw new InvalidOperationException("No request has been specified.");
+                    }
+
+                    try
+                    {
+                        var request = _requests.Single();
+                        var response = await _organizationService.ExecuteAsync(request);
+                        _responses = new[] { response };
+
+                        _completedTcs.SetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        _completedTcs.SetException(ex);
+                    }
+                }
+
+                async Task ExecuteMultipleRequest()
+                {
+                    if (_requests.Count == 0)
+                    {
+                        _responses = Array.Empty<OrganizationResponse>();
+                        _completedTcs.SetResult();
+                    }
+
+                    var request = new ExecuteMultipleRequest()
+                    {
+                        Requests = new OrganizationRequestCollection(),
+                        Settings = new()
+                        {
+                            ContinueOnError = false,
+                            ReturnResponses = true
+                        }
+                    };
+
+                    request.Requests.AddRange(_requests);
+
+                    try
+                    {
+                        var response = (ExecuteMultipleResponse)await _organizationService.ExecuteAsync(request);
+                        _responses = response.Responses.Select(r => r.Response).ToArray();
+
+                        _completedTcs.SetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        _completedTcs.SetException(ex);
+                    }
+                }
+
+                async Task ExecuteTransactionRequest()
+                {
+                    if (_requests.Count == 0)
+                    {
+                        _responses = Array.Empty<OrganizationResponse>();
+                        _completedTcs.SetResult();
+                    }
+
+                    var request = new ExecuteTransactionRequest()
+                    {
+                        Requests = new OrganizationRequestCollection(),
+                        ReturnResponses = true
+                    };
+
+                    request.Requests.AddRange(_requests);
+
+                    try
+                    {
+                        var response = (ExecuteTransactionResponse)await _organizationService.ExecuteAsync(request);
+                        _responses = response.Responses.ToArray();
+
+                        _completedTcs.SetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        _completedTcs.SetException(ex);
+                    }
+                }
+            }
+
+            private void ThrowIfCompleted()
+            {
+                if (_completedTcs.Task.IsCompleted)
+                {
+                    throw new InvalidOperationException("Request has already been executed.");
+                }
+            }
+
+            public interface IInnerRequestHandle<TResponse>
+                where TResponse : OrganizationResponse
+            {
+                TResponse GetResponse();
+                Task<TResponse> GetResponseAsync();
+            }
+
+            private class InnerRequestHandle<TResponse> : IInnerRequestHandle<TResponse>
+                where TResponse : OrganizationResponse
+            {
+                private readonly RequestBuilder _requestBuilder;
+                private readonly OrganizationRequest _request;
+
+                public InnerRequestHandle(RequestBuilder requestBuilder, OrganizationRequest request)
+                {
+                    _requestBuilder = requestBuilder;
+                    _request = request;
+                }
+
+                public TResponse GetResponse()
+                {
+                    if (!_requestBuilder._completedTcs.Task.IsCompleted)
+                    {
+                        throw new InvalidOperationException("Request has not been executed.");
+                    }
+
+                    if (_requestBuilder._completedTcs.Task.IsFaulted)
+                    {
+                        throw _requestBuilder._completedTcs.Task.Exception;
+                    }
+
+                    var index = _requestBuilder._requests.IndexOf(_request);
+                    var response = _requestBuilder._responses[index];
+                    return (TResponse)response;
+                }
+
+                public Task<TResponse> GetResponseAsync() => _requestBuilder._completedTcs.Task.ContinueWith(_ => GetResponse());
+            }
+
+            private enum RequestType { Single, Transaction, Multiple }
+        }
+    }
+}

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.PowerPlatform.Dataverse.Client.Utils;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 
 namespace DqtApi.DataStore.Crm
@@ -29,8 +30,12 @@ namespace DqtApi.DataStore.Crm
             _cache = cache;
         }
 
-        public async Task<dfeta_country> GetCountry(string value)
+        public Task<dfeta_country> GetCountry(string value) => GetCountry(value, requestBuilder: null);
+
+        private async Task<dfeta_country> GetCountry(string value, RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(dfeta_country.EntityLogicalName)
             {
                 ColumnSet = new() { AllColumns = true }
@@ -39,13 +44,22 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(dfeta_country.Fields.dfeta_Value, value);
             query.AddAttributeValue(dfeta_country.Fields.StateCode, (int)dfeta_countryState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_country>()).FirstOrDefault();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_country>()).FirstOrDefault();
         }
 
-        public async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(string value)
+        public Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(string value) => GetEarlyYearsStatus(value, requestBuilder: null);
+
+        private async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(string value, RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(dfeta_earlyyearsstatus.EntityLogicalName)
             {
                 ColumnSet = new() { AllColumns = true }
@@ -54,13 +68,22 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(dfeta_earlyyearsstatus.Fields.dfeta_Value, value);
             query.AddAttributeValue(dfeta_earlyyearsstatus.Fields.StateCode, (int)dfeta_earlyyearsStatusState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_earlyyearsstatus>()).FirstOrDefault();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_earlyyearsstatus>()).FirstOrDefault();
         }
 
-        public async Task<dfeta_hequalification> GetHeQualificationByName(string name)
+        public Task<dfeta_hequalification> GetHeQualificationByName(string name) => GetHeQualificationByName(name, requestBuilder: null);
+
+        private async Task<dfeta_hequalification> GetHeQualificationByName(string name, RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(dfeta_hequalification.EntityLogicalName)
             {
                 ColumnSet = new() { AllColumns = true }
@@ -69,13 +92,22 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(dfeta_hequalification.Fields.dfeta_name, name);
             query.AddAttributeValue(dfeta_hequalification.Fields.StateCode, (int)dfeta_hequalificationState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_hequalification>()).FirstOrDefault();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_hequalification>()).FirstOrDefault();
         }
 
-        public async Task<dfeta_hesubject> GetHeSubjectByName(string name)
+        public Task<dfeta_hesubject> GetHeSubjectByName(string name) => GetHeSubjectByName(name, requestBuilder: null);
+
+        private async Task<dfeta_hesubject> GetHeSubjectByName(string name, RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(dfeta_hesubject.EntityLogicalName)
             {
                 ColumnSet = new() { AllColumns = true }
@@ -84,15 +116,28 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(dfeta_hesubject.Fields.dfeta_name, name);
             query.AddAttributeValue(dfeta_hesubject.Fields.StateCode, (int)dfeta_hesubjectState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_hesubject>()).FirstOrDefault();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_hesubject>()).FirstOrDefault();
         }
 
-        public async Task<dfeta_initialteachertraining[]> GetInitialTeacherTrainingByTeacher(
+        public Task<dfeta_initialteachertraining[]> GetInitialTeacherTrainingByTeacher(
             Guid teacherId,
-            params string[] columnNames)
+            params string[] columnNames) =>
+                GetInitialTeacherTrainingByTeacher(teacherId, columnNames, requestBuilder: null);
+
+        private async Task<dfeta_initialteachertraining[]> GetInitialTeacherTrainingByTeacher(
+            Guid teacherId,
+            string[] columnNames,
+            RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(dfeta_initialteachertraining.EntityLogicalName)
             {
                 ColumnSet = new(columnNames)
@@ -101,9 +146,14 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(dfeta_initialteachertraining.Fields.dfeta_PersonId, teacherId);
             query.AddAttributeValue(dfeta_initialteachertraining.Fields.StateCode, (int)dfeta_initialteachertrainingState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_initialteachertraining>()).ToArray();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_initialteachertraining>()).ToArray();
         }
 
         public async Task<Account[]> GetIttProviders()
@@ -130,8 +180,12 @@ namespace DqtApi.DataStore.Crm
             return result.Entities.Select(entity => entity.ToEntity<Account>()).ToArray();
         }
 
-        public async Task<dfeta_ittsubject> GetIttSubjectByName(string name)
+        public Task<dfeta_ittsubject> GetIttSubjectByName(string name) => GetIttSubjectByName(name, requestBuilder: null);
+
+        private async Task<dfeta_ittsubject> GetIttSubjectByName(string name, RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(dfeta_ittsubject.EntityLogicalName)
             {
                 ColumnSet = new() { AllColumns = true }
@@ -140,9 +194,14 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(dfeta_ittsubject.Fields.dfeta_name, name);
             query.AddAttributeValue(dfeta_ittsubject.Fields.StateCode, (int)dfeta_ittsubjectState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_ittsubject>()).FirstOrDefault();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_ittsubject>()).FirstOrDefault();
         }
 
         public async Task<Contact[]> GetMatchingTeachers(GetTeacherRequest request)
@@ -247,8 +306,13 @@ namespace DqtApi.DataStore.Crm
             }
         }
 
-        public async Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames)
+        public Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames) =>
+            GetOrganizationByUkprn(ukprn, columnNames, requestBuilder: null);
+
+        private async Task<Account> GetOrganizationByUkprn(string ukprn, string[] columnNames, RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(Account.EntityLogicalName)
             {
                 ColumnSet = new(columnNames)
@@ -257,15 +321,28 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(Account.Fields.dfeta_UKPRN, ukprn);
             query.AddAttributeValue(Account.Fields.StateCode, (int)AccountState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
         }
 
-        public async Task<dfeta_qtsregistration[]> GetQtsRegistrationsByTeacher(
+        public Task<dfeta_qtsregistration[]> GetQtsRegistrationsByTeacher(
             Guid teacherId,
-            params string[] columnNames)
+            params string[] columnNames) =>
+                GetQtsRegistrationsByTeacher(teacherId, columnNames, requestBuilder: null);
+
+        private async Task<dfeta_qtsregistration[]> GetQtsRegistrationsByTeacher(
+            Guid teacherId,
+            string[] columnNames,
+            RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(dfeta_qtsregistration.EntityLogicalName)
             {
                 ColumnSet = new(columnNames)
@@ -274,9 +351,14 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(dfeta_qtsregistration.Fields.dfeta_PersonId, teacherId);
             query.AddAttributeValue(dfeta_qtsregistration.Fields.StateCode, (int)dfeta_qtsregistrationState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_qtsregistration>()).ToArray();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_qtsregistration>()).ToArray();
         }
 
         public async Task<dfeta_qualification[]> GetQualificationsForTeacher(Guid teacherId, params string[] columnNames)
@@ -343,27 +425,45 @@ namespace DqtApi.DataStore.Crm
             return result.Entities.Select(e => e.ToEntity<Contact>()).ToArray();
         }
 
-        public async Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, params string[] columnNames)
+        public Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, params string[] columnNames) =>
+            GetCrmTasksForTeacher(teacherId, columnNames, requestBuilder: null);
+
+        private async Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, string[] columnNames, RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(CrmTask.EntityLogicalName)
             {
                 ColumnSet = new ColumnSet(columnNames)
             };
             query.AddAttributeValue(CrmTask.Fields.RegardingObjectId, teacherId);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<CrmTask>()).ToArray();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<CrmTask>()).ToArray();
         }
 
-        public async Task<dfeta_teacherstatus> GetTeacherStatus(
+        public Task<dfeta_teacherstatus> GetTeacherStatus(
             string value,
-            bool qtsDateRequired)
+            bool qtsDateRequired) =>
+                GetTeacherStatus(value, qtsDateRequired, requestBuilder: null);
+
+        private async Task<dfeta_teacherstatus> GetTeacherStatus(
+            string value,
+            bool qtsDateRequired,
+            RequestBuilder requestBuilder)
         {
             // TECH DEBT Some junk reference data in the build environment means we have teacher statuses duplicated.
             // In some cases the duplicate records vary by 'dfeta_qtsdaterequired' - we need to ensure we get the correct
             // one as a workflow will prevent us allocating a qtsregistration for a status where dfeta_qtsdaterequired is true
             // without a QTS Date.
+
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
             var query = new QueryByAttribute(dfeta_teacherstatus.EntityLogicalName)
             {
@@ -374,9 +474,14 @@ namespace DqtApi.DataStore.Crm
             query.AddAttributeValue(dfeta_teacherstatus.Fields.StateCode, (int)dfeta_teacherStatusState.Active);
             query.AddAttributeValue(dfeta_teacherstatus.Fields.dfeta_QTSDateRequired, qtsDateRequired);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<dfeta_teacherstatus>()).FirstOrDefault();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_teacherstatus>()).FirstOrDefault();
         }
 
         public async Task<bool> UnlockTeacherRecord(Guid teacherId)
@@ -396,19 +501,29 @@ namespace DqtApi.DataStore.Crm
             }
         }
 
-        public async Task<Account> GetOrganizationByProviderName(string providerName, params string[] columnNames)
+        public Task<Account> GetOrganizationByName(string name, params string[] columnNames) =>
+            GetOrganizationByName(name, columnNames, requestBuilder: null);
+
+        private async Task<Account> GetOrganizationByName(string name, string[] columnNames, RequestBuilder requestBuilder)
         {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
             var query = new QueryByAttribute(Account.EntityLogicalName)
             {
                 ColumnSet = new ColumnSet(columnNames)
             };
 
-            query.AddAttributeValue(Account.Fields.Name, providerName);
+            query.AddAttributeValue(Account.Fields.Name, name);
             query.AddAttributeValue(Account.Fields.StateCode, (int)AccountState.Active);
 
-            var result = await _service.RetrieveMultipleAsync(query);
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
 
-            return result.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
         }
 
         public async Task<Contact[]> FindTeachers(FindTeachersQuery filter)
@@ -471,5 +586,11 @@ namespace DqtApi.DataStore.Crm
 
             return result.Entities.Select(entity => entity.ToEntity<Contact>()).ToArray();
         }
+
+        private RequestBuilder CreateMultipleRequestBuilder() => RequestBuilder.CreateMultiple(_service);
+
+        private RequestBuilder CreateSingleRequestBuilder() => RequestBuilder.CreateSingle(_service);
+
+        private RequestBuilder CreateTransactionRequestBuilder() => RequestBuilder.CreateTransaction(_service);
     }
 }

--- a/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
@@ -22,7 +22,7 @@ namespace DqtApi.DataStore.Crm
 
         Task<UpdateTeacherResult> UpdateTeacher(UpdateTeacherCommand command);
 
-        Task<Account> GetOrganizationByProviderName(string providerName, params string[] columnNames);
+        Task<Account> GetOrganizationByName(string providerName, params string[] columnNames);
 
         Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames);
 

--- a/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
+++ b/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
@@ -32,7 +32,7 @@ namespace DqtApi.V2.Handlers
             }
             else if (!string.IsNullOrEmpty(request.IttProviderName))
             {
-                ittProvider = await _dataverseAdapter.GetOrganizationByProviderName(request.IttProviderName);
+                ittProvider = await _dataverseAdapter.GetOrganizationByName(request.IttProviderName);
                 if (ittProvider == null)
                     throw new ErrorException(ErrorRegistry.OrganisationNotFound());
             }

--- a/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -108,7 +108,7 @@ namespace DqtApi.Tests.V2.Operations
             var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 1, 1), dfeta_TRN = "someReference" };
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetOrganizationByProviderName(It.IsAny<string>()))
+                .Setup(mock => mock.GetOrganizationByName(It.IsAny<string>()))
                 .ReturnsAsync(account);
 
             ApiFixture.DataverseAdapter

--- a/tests/DqtApi.Tests/xunit.runner.json
+++ b/tests/DqtApi.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": -1
+}


### PR DESCRIPTION
### Context

Some operations like Create Teacher need to lookup a lot of data from CRM. Our helper methods on `DataverseAdapter` are used for these lookups. Currently these methods both construct the CRM requests *and* send them. With this design we cannot easily batch requests; the best we could do was running these requests in parallel.

This PR changes reference data methods to introduce a second, private overload that takes a `RequestBuilder` argument. `RequestBuilder` is a new type that can be used for bundling requests then send them all to CRM in a single hit. With this we can decouple the sending of the request from our lookup methods and have the caller orchestrate that when it's ready. The general pattern is:

```cs
public Task<Thing> LookupThing(string id) => LookupThing(id, requestBuilder: null);

private async Task(string id, RequestBuilder requestBuilder)
{
    requestBuilder ??= RequestBuilder.CreateSingle(_service);

    // Construct the request message
    OrganizationRequest request = ...;

    // Add the request to the requestBuilder then wait for it to return the result.
    var result = await requestBuilder.AddRequest<TResponse>(request).GetResponseAsync();

    // Process result
}
```

### Changes proposed in this pull request

- Modify lookup methods to introduce a private overload that takes a `RequestBuilder`.
- Amend `CreateTeacher` to batch its lookup requests.

### Checklist

~~-   [ ] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
