### PR TITLE
Change prometheus metric label

### DIFF
--- a/src/DqtApi/Configuration/MetricLabels.cs
+++ b/src/DqtApi/Configuration/MetricLabels.cs
@@ -14,7 +14,7 @@ namespace DqtApi.Configuration
                     { "app", configuration["VCAP_APPLICATION:application_name"] },
                     { "organisation", configuration["VCAP_APPLICATION:organization_name"] },
                     { "space", configuration["VCAP_APPLICATION:space_name"] },
-                    { "instance", configuration["CF_INSTANCE_INDEX"] }
+                    { "app_instance", configuration["CF_INSTANCE_INDEX"] }
                 });
             }
         }


### PR DESCRIPTION
## Context

Changed metric label from instance to app_instance. This enables to
easily identify and process instance metrics in prometheus.

## Trello card

https://trello.com/c/xDKhH54u