### PR TITLE
Added validation to setittoutcome and update teacher to make birthdate mandatory

### DIFF
--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -20,6 +20,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "birthdate",
+            "in": "query",
+            "description": "DoB of teacher",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           }
         ],
         "requestBody": {
@@ -256,6 +266,16 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "birthdate",
+            "in": "query",
+            "description": "DoB of teacher",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
             }
           }
         ],

--- a/src/DqtApi/V2/Handlers/SetIttOutcomeHandler.cs
+++ b/src/DqtApi/V2/Handlers/SetIttOutcomeHandler.cs
@@ -22,7 +22,7 @@ namespace DqtApi.V2.Handlers
 
         public async Task<SetIttOutcomeResponse> Handle(SetIttOutcomeRequest request, CancellationToken cancellationToken)
         {
-            var teachers = (await _dataverseAdapter.GetTeachersByTrnAndDoB(request.Trn, request.BirthDate, activeOnly: true)).ToArray();
+            var teachers = (await _dataverseAdapter.GetTeachersByTrnAndDoB(request.Trn, request.BirthDate.Value, activeOnly: true)).ToArray();
 
             if (teachers.Length == 0)
             {

--- a/src/DqtApi/V2/Handlers/UpdateTeacherHandler.cs
+++ b/src/DqtApi/V2/Handlers/UpdateTeacherHandler.cs
@@ -27,7 +27,7 @@ namespace DqtApi.V2.Handlers
 
         public async Task<Unit> Handle(UpdateTeacherRequest request, CancellationToken cancellationToken)
         {
-            var teachers = (await _dataverseAdapter.GetTeachersByTrnAndDoB(request.Trn, request.BirthDate, activeOnly: true)).ToArray();
+            var teachers = (await _dataverseAdapter.GetTeachersByTrnAndDoB(request.Trn, request.BirthDate.Value, activeOnly: true)).ToArray();
             if (teachers.Length == 0)
             {
                 throw new ErrorException(ErrorRegistry.TeacherWithSpecifiedTrnNotFound());

--- a/src/DqtApi/V2/Requests/SetIttOutcomeRequest.cs
+++ b/src/DqtApi/V2/Requests/SetIttOutcomeRequest.cs
@@ -27,10 +27,9 @@ namespace DqtApi.V2.Requests
         [SwaggerParameter(description: $"The assessment date for a {nameof(IttOutcome.Pass)} outcome.")]
         public DateOnly? AssessmentDate { get; set; }
 
-
         [Required]
-        [SwaggerParameter(description: "DoB of teacher")]
-        public DateOnly BirthDate { get; set; }
+        [FromQuery(Name = "birthdate"), SwaggerParameter(Required = true, Description = "DoB of teacher"), SwaggerSchema(Format = "date"), ModelBinder(typeof(ModelBinding.DateModelBinder))]
+        public DateOnly? BirthDate { get; set; }
     }
 
     public class SetQtsRequestExample : IExamplesProvider<SetIttOutcomeRequest>

--- a/src/DqtApi/V2/Requests/UpdateTeacherRequest.cs
+++ b/src/DqtApi/V2/Requests/UpdateTeacherRequest.cs
@@ -20,8 +20,8 @@ namespace DqtApi.V2.Requests
         public UpdateTeacherRequestRequestQualification Qualification { get; set; }
 
         [Required]
-        [SwaggerParameter(description: "DoB of teacher")]
-        public DateOnly BirthDate { get; set; }
+        [FromQuery(Name = "birthdate"), SwaggerParameter(Required = true, Description = "DoB of teacher"), SwaggerSchema(Format = "date"), ModelBinder(typeof(ModelBinding.DateModelBinder))]
+        public DateOnly? BirthDate { get; set; }
     }
 
     public class UpdateTeacherRequestInitialTeacherTraining

--- a/src/DqtApi/V2/Validators/SetIttOutcomeValidator.cs
+++ b/src/DqtApi/V2/Validators/SetIttOutcomeValidator.cs
@@ -7,6 +7,10 @@ namespace DqtApi.V2.Validators
     {
         public SetIttOutcomeValidator(IClock clock)
         {
+            RuleFor(x => x.BirthDate)
+                .NotEmpty()
+                .WithMessage("Birthdate is required.");
+
             RuleFor(c => c.IttProviderUkprn)
                 .NotEmpty()
                 .WithMessage("ITT provider UKPRN is required.");

--- a/src/DqtApi/V2/Validators/UpdateTeacherValidator.cs
+++ b/src/DqtApi/V2/Validators/UpdateTeacherValidator.cs
@@ -51,6 +51,10 @@ namespace DqtApi.V2.Validators
 
             RuleFor(r => r.Qualification.Class)
                 .IsInEnum();
+
+            RuleFor(x => x.BirthDate)
+                .NotEmpty()
+                .WithMessage("Birthdate is required.");
         }
     }
 }

--- a/tests/DqtApi.Tests/V2/Operations/SetIttOutcomeTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/SetIttOutcomeTests.cs
@@ -36,7 +36,7 @@ namespace DqtApi.Tests.V2.Operations
                 AssessmentDate = Clock.Today
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Put, $"/v2/teachers/{trn}/itt-outcome")
+            var request = new HttpRequestMessage(HttpMethod.Put, $"/v2/teachers/{trn}/itt-outcome?birthdate={dob.ToString("yyyy-MM-dd")}")
             {
                 Content = CreateJsonContent(requestBody)
             };
@@ -64,7 +64,31 @@ namespace DqtApi.Tests.V2.Operations
 
             var requestBody = new SetIttOutcomeRequest()
             {
-                BirthDate = dob,
+                IttProviderUkprn = "1001234",
+                Outcome = IttOutcome.Pass,
+                AssessmentDate = Clock.Today
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Put, $"/v2/teachers/{trn}/itt-outcome?birthdate={dob.ToString("yyyy-MM-dd")}")
+            {
+                Content = CreateJsonContent(requestBody)
+            };
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            await AssertEx.ResponseIsError(response, errorCode: 10002, expectedStatusCode: StatusCodes.Status409Conflict);
+        }
+
+        [Fact]
+        public async Task Given_missing_birthdate_returns_error()
+        {
+            // Arrange
+            var trn = "1234567";
+
+            var requestBody = new SetIttOutcomeRequest()
+            {
                 IttProviderUkprn = "1001234",
                 Outcome = IttOutcome.Pass,
                 AssessmentDate = Clock.Today
@@ -79,7 +103,10 @@ namespace DqtApi.Tests.V2.Operations
             var response = await HttpClient.SendAsync(request);
 
             // Assert
-            await AssertEx.ResponseIsError(response, errorCode: 10002, expectedStatusCode: StatusCodes.Status409Conflict);
+            await AssertEx.ResponseIsValidationErrorForProperty(
+                response,
+                propertyName: nameof(requestBody.BirthDate),
+                expectedError: "Birthdate is required.");
         }
 
         [Fact]
@@ -234,7 +261,7 @@ namespace DqtApi.Tests.V2.Operations
                 AssessmentDate = assessmentDate
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Put, $"/v2/teachers/{trn}/itt-outcome")
+            var request = new HttpRequestMessage(HttpMethod.Put, $"/v2/teachers/{trn}/itt-outcome?birthdate={dob.ToString("yyyy-MM-dd")}")
             {
                 Content = CreateJsonContent(requestBody)
             };
@@ -276,13 +303,12 @@ namespace DqtApi.Tests.V2.Operations
 
             var requestBody = new SetIttOutcomeRequest()
             {
-                BirthDate = dob,
                 IttProviderUkprn = ittProviderUkprn,
                 Outcome = outcome,
                 AssessmentDate = assessmentDate
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Put, $"/v2/teachers/{trn}/itt-outcome")
+            var request = new HttpRequestMessage(HttpMethod.Put, $"/v2/teachers/{trn}/itt-outcome?birthdate={dob.ToString("yyyy-MM-dd")}")
             {
                 Content = CreateJsonContent(requestBody)
             };

--- a/tests/DqtApi.Tests/V2/Operations/UpdateTeacherTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/UpdateTeacherTests.cs
@@ -21,10 +21,30 @@ namespace DqtApi.Tests.V2.Operations
         }
 
         [Fact]
+        public async Task Given_missing_birthdate_returns_error()
+        {
+            // Arrange
+            var trn = "1234567";
+            var ukprn = "123456";
+
+            // Act
+            var response = await HttpClient.PatchAsync(
+                $"v2/teachers/update/{trn}",
+                CreateRequest(req => req.InitialTeacherTraining.ProviderUkprn = ukprn));
+
+            // Assert
+            await AssertEx.ResponseIsValidationErrorForProperty(
+                response,
+                propertyName: "Birthdate",
+                expectedError: "Birthdate is required.");
+        }
+
+        [Fact]
         public async Task Given_invalid_itt_provider_returns_error()
         {
             // Arrange
             var ukprn = "xxx";
+            var trn = "12345";
             var contact = new Contact() { Id = Guid.NewGuid() };
             var contactList = new[] { contact };
             var dob = new DateOnly(1987, 01, 01);
@@ -34,12 +54,12 @@ namespace DqtApi.Tests.V2.Operations
                 .ReturnsAsync(UpdateTeacherResult.Failed(UpdateTeacherFailedReasons.NoMatchingIttRecord));
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetTeachersByTrnAndDoB(ukprn, dob, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
+                .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, dob, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
                 .ReturnsAsync(contactList);
 
             // Act
             var response = await HttpClient.PatchAsync(
-                $"v2/teachers/update/{ukprn}",
+                $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}",
                 CreateRequest(req => req.InitialTeacherTraining.ProviderUkprn = ukprn));
 
             // Assert
@@ -50,8 +70,8 @@ namespace DqtApi.Tests.V2.Operations
         public async Task Given_invalid_itt_subject1_returns_error()
         {
             // Arrange
-            var ukprn = "xxx";
             var subject = "xxx";
+            var trn = "123456";
             var contact = new Contact() { Id = Guid.NewGuid() };
             var contactList = new[] { contact };
             var dob = new DateOnly(1987, 01, 01);
@@ -61,12 +81,12 @@ namespace DqtApi.Tests.V2.Operations
                     .ReturnsAsync(UpdateTeacherResult.Failed(UpdateTeacherFailedReasons.Subject1NotFound));
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetTeachersByTrnAndDoB(ukprn, dob,/* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
+                .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, dob,/* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
                     .ReturnsAsync(contactList);
 
             // Act
             var response = await HttpClient.PatchAsync(
-                $"v2/teachers/update/{ukprn}",
+                $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}",
                 CreateRequest(req => req.InitialTeacherTraining.Subject1 = subject));
 
             // Assert
@@ -77,8 +97,8 @@ namespace DqtApi.Tests.V2.Operations
         public async Task Given_invalid_itt_subject2_returns_error()
         {
             // Arrange
-            var ukprn = "xxx";
             var subject = "xxx";
+            var trn = "12345";
             var contact = new Contact() { Id = Guid.NewGuid() };
             var contactList = new[] { contact };
             var dob = new DateOnly(1987, 01, 01);
@@ -88,12 +108,12 @@ namespace DqtApi.Tests.V2.Operations
                     .ReturnsAsync(UpdateTeacherResult.Failed(UpdateTeacherFailedReasons.Subject2NotFound));
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetTeachersByTrnAndDoB(ukprn, dob, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
+                .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, dob, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
                     .ReturnsAsync(contactList);
 
             // Act
             var response = await HttpClient.PatchAsync(
-                $"v2/teachers/update/{ukprn}",
+                $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}",
                 CreateRequest(req => req.InitialTeacherTraining.Subject2 = subject));
 
             // Assert
@@ -104,14 +124,14 @@ namespace DqtApi.Tests.V2.Operations
         public async Task Given_invalid_qualification_country_returns_error()
         {
             // Arrange
-            var ukprn = "xxx";
+            var trn = "123456";
             var country = "some non existent country country";
             var contact = new Contact() { Id = Guid.NewGuid() };
             var contactList = new[] { contact };
             var dob = new DateOnly(1987, 01, 01);
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetTeachersByTrnAndDoB(ukprn, dob, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
+                .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, dob, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
                     .ReturnsAsync(contactList);
 
             ApiFixture.DataverseAdapter
@@ -120,7 +140,7 @@ namespace DqtApi.Tests.V2.Operations
 
             // Act
             var response = await HttpClient.PatchAsync(
-                $"v2/teachers/update/{ukprn}",
+                $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}",
                 CreateRequest(req => req.Qualification.CountryCode = country));
 
             // Assert
@@ -131,14 +151,14 @@ namespace DqtApi.Tests.V2.Operations
         public async Task Given_invalid_qualification_subject_returns_error()
         {
             // Arrange
-            var ukprn = "xxx";
             var subject = "xxx";
             var contact = new Contact() { Id = Guid.NewGuid() };
             var contactList = new[] { contact };
             var dob = new DateOnly(1987, 01, 01);
+            var trn = "xxx";
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetTeachersByTrnAndDoB(ukprn, dob,/* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
+                .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, dob,/* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
                     .ReturnsAsync(contactList);
 
             ApiFixture.DataverseAdapter
@@ -147,7 +167,7 @@ namespace DqtApi.Tests.V2.Operations
 
             // Act
             var response = await HttpClient.PatchAsync(
-                $"v2/teachers/update/{ukprn}",
+                $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}",
                 CreateRequest(req => req.Qualification.Subject = subject));
 
             // Assert
@@ -158,15 +178,15 @@ namespace DqtApi.Tests.V2.Operations
         public async Task Given_valid_update_succeeds_return_nocontent()
         {
             // Arrange
-            var ukprn = "xxx";
             var subject = "xxx";
+            var trn = "123456";
             var contact = new Contact() { Id = Guid.NewGuid() };
             var contactList = new[] { contact };
             var result = UpdateTeacherResult.Success(Guid.NewGuid(), "some trn");
             var dob = new DateOnly(1987, 01, 01);
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetTeachersByTrnAndDoB(ukprn, dob, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
+                .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, dob, /* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
                     .ReturnsAsync(contactList);
 
             ApiFixture.DataverseAdapter
@@ -175,7 +195,7 @@ namespace DqtApi.Tests.V2.Operations
 
             // Act
             var response = await HttpClient.PatchAsync(
-                $"v2/teachers/update/{ukprn}",
+                $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}",
                 CreateRequest(req => req.Qualification.Subject = subject));
 
             // Assert
@@ -191,7 +211,8 @@ namespace DqtApi.Tests.V2.Operations
             string expectedErrorMessage)
         {
             // Arrange
-            var ukprn = "xxx";
+            var trn = "123456";
+            var dob = new DateOnly(1980, 01, 01);
             var request = CreateRequest(cmd =>
             {
                 cmd.InitialTeacherTraining.AgeRangeFrom = ageRangeFrom;
@@ -200,7 +221,7 @@ namespace DqtApi.Tests.V2.Operations
 
             // Act
             var response = await HttpClient.PatchAsync(
-                $"v2/teachers/update/{ukprn}", request);
+                $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}", request);
 
             // Assert
             await AssertEx.ResponseIsValidationErrorForProperty(
@@ -223,7 +244,6 @@ namespace DqtApi.Tests.V2.Operations
 
             var requestBody = new UpdateTeacherRequest()
             {
-                BirthDate = dob,
                 InitialTeacherTraining = new UpdateTeacherRequestInitialTeacherTraining()
                 {
                     ProviderUkprn = "123456",
@@ -242,7 +262,7 @@ namespace DqtApi.Tests.V2.Operations
                 }
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Patch, $"v2/teachers/update/{trn}")
+            var request = new HttpRequestMessage(HttpMethod.Patch, $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}")
             {
                 Content = CreateJsonContent(requestBody)
             };
@@ -268,7 +288,6 @@ namespace DqtApi.Tests.V2.Operations
 
             var requestBody = new UpdateTeacherRequest()
             {
-                BirthDate = dob,
                 InitialTeacherTraining = new UpdateTeacherRequestInitialTeacherTraining()
                 {
                     ProviderUkprn = "123456",
@@ -294,7 +313,7 @@ namespace DqtApi.Tests.V2.Operations
                 .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, dob,/* activeOnly: */ true, /* columnNames: */ It.IsAny<string[]>()))
                 .ReturnsAsync(contactList);
 
-            var request = new HttpRequestMessage(HttpMethod.Patch, $"v2/teachers/update/{trn}")
+            var request = new HttpRequestMessage(HttpMethod.Patch, $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}")
             {
                 Content = CreateJsonContent(requestBody)
             };
@@ -310,7 +329,6 @@ namespace DqtApi.Tests.V2.Operations
         {
             var request = new UpdateTeacherRequest()
             {
-                BirthDate = new DateOnly(1987, 01, 01),
                 InitialTeacherTraining = new()
                 {
                     ProviderUkprn = "10044534",


### PR DESCRIPTION
### Context

Added validation rule for birthdate to stop birthdate being optional and causing an error when not being provided & updated corresponding tests.

### Changes proposed in this pull request

Added birthdate to the querystring parameter and updated tests.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
