### PR TITLE
Prefer errors from model binders over FluentValidation errors

### DIFF
--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -13,6 +13,7 @@ using DqtApi.Logging;
 using DqtApi.ModelBinding;
 using DqtApi.Security;
 using DqtApi.Swagger;
+using DqtApi.Validation;
 using FluentValidation.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
@@ -106,6 +107,8 @@ namespace DqtApi
                     fv.RegisterValidatorsFromAssemblyContaining(typeof(Program));
                     fv.DisableDataAnnotationsValidation = true;
                 });
+
+            services.AddTransient<IValidatorInterceptor, PreferModelBindingErrorsValidationInterceptor>();
 
             services.AddTransient<IApiDescriptionProvider, HybridBodyApiDescriptionProvider>();
 

--- a/src/DqtApi/Validation/PreferModelBindingErrorsValidationInterceptor.cs
+++ b/src/DqtApi/Validation/PreferModelBindingErrorsValidationInterceptor.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DqtApi.Validation
+{
+    public class PreferModelBindingErrorsValidationInterceptor : IValidatorInterceptor
+    {
+        public ValidationResult AfterAspNetValidation(ActionContext actionContext, IValidationContext validationContext, ValidationResult result)
+        {
+            // If there are model binding errors, ignore additional errors from our validators.
+            // This prevents getting both 'Thing is invalid' and 'Thing is required' messages.
+
+            var failures = result.Errors.ToList();
+
+            foreach (var error in result.Errors)
+            {
+                if (actionContext.ModelState.TryGetValue(error.PropertyName, out var modelStateEntry) &&
+                    modelStateEntry.Errors.Count > 0)
+                {
+                    failures.Remove(error);
+                }
+            }
+
+            return new ValidationResult(failures);
+        }
+
+        public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
+        {
+            return commonContext;
+        }
+    }
+}


### PR DESCRIPTION
Prevents us returning multiple errors like 'Birthdate is invalid' and
'Birthdate is required'.