### PR TITLE
Simple fixes for TRN generation process

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -139,10 +139,10 @@ namespace DqtApi.DataStore.Crm
                     {
                         sb.AppendLine(matchedAttribute switch
                         {
-                            Contact.Fields.FirstName => $"\t- First name: '{_command.FirstName}'",
-                            Contact.Fields.MiddleName => $"\t- Middle name: '{_command.MiddleName}'",
-                            Contact.Fields.LastName => $"\t- Last name: '{_command.LastName}'",
-                            Contact.Fields.BirthDate => $"\t- Date of birth: '{_command.BirthDate:dd/MM/yyyy}'",
+                            Contact.Fields.FirstName => $"  - First name: '{_command.FirstName}'",
+                            Contact.Fields.MiddleName => $"  - Middle name: '{_command.MiddleName}'",
+                            Contact.Fields.LastName => $"  - Last name: '{_command.LastName}'",
+                            Contact.Fields.BirthDate => $"  - Date of birth: '{_command.BirthDate:dd/MM/yyyy}'",
                             _ => throw new Exception($"Unknown matched field: '{matchedAttribute}'.")
                         });
                     }

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -469,7 +469,7 @@ namespace DqtApi.DataStore.Crm
             while (resolveMerges && teacher.Merged == true)
             {
                 var masterReference = teacher.MasterId;
-                return await GetTeacher(masterReference.Id, resolveMerges);
+                return await GetTeacher(masterReference.Id, resolveMerges, columnNames);
             }
 
             return teacher;

--- a/src/DqtApi/V2/Handlers/GetTrnRequestHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetTrnRequestHandler.cs
@@ -47,7 +47,7 @@ namespace DqtApi.V2.Handlers
                 trn = teacher.dfeta_TRN;
             }
 
-            var status = trnRequest.TeacherId.HasValue ? TrnRequestStatus.Completed : TrnRequestStatus.Pending;
+            var status = trn != null ? TrnRequestStatus.Completed : TrnRequestStatus.Pending;
 
             return new TrnRequestInfo()
             {

--- a/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -152,7 +152,7 @@ namespace DqtApi.Tests.DataverseIntegration
             Assert.Equal("Notification for QTS Unit Team", crmTask.Subject);
             Assert.Equal(_clock.UtcNow, crmTask.ScheduledEnd);
 
-            var expectedDescription = $"Potential duplicate\nMatched on\n\t- First name: '{firstName}'\n\t- Middle name: '{middleName}'\n\t- Last name: '{lastName}'\n\t- Date of birth: '{birthDate:dd/MM/yyyy}'\n" +
+            var expectedDescription = $"Potential duplicate\nMatched on\n  - First name: '{firstName}'\n  - Middle name: '{middleName}'\n  - Last name: '{lastName}'\n  - Date of birth: '{birthDate:dd/MM/yyyy}'\n" +
                 expectedDescriptionSupplement;
 
             Assert.Equal(


### PR DESCRIPTION
### Context

https://trello.com/c/lmnxcAtJ/173-close-up-gaps-between-dttp-integration-tests-and-dqt-api-tests

### Changes proposed in this pull request

- Fix pulling back TRN column for a merged record.
- Ensure `Status` field is consistent for both Create and Get TRN request operations.
- Amend copy for duplicate review task.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
