### PR TITLE
Fix bug and modify checkrate

### DIFF
--- a/terraform/preprod.tfvars.json
+++ b/terraform/preprod.tfvars.json
@@ -13,9 +13,11 @@
       "website_name": "qualified-teachers-api-preprod",
       "website_url": "https://qualified-teachers-api-preprod.london.cloudapps.digital/status",
       "test_type": "HTTP",
-      "contact_group": [
-        "twd_tra_dqt"
-      ]
+      "contact_group": [249142],
+      "check_rate": 30,
+      "trigger_rate": 0,
+      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
+      "confirmations": 2
     }
   }
 }

--- a/terraform/prod.tfvars.json
+++ b/terraform/prod.tfvars.json
@@ -16,9 +16,11 @@
       "website_name": "qualified-teachers-api-prod",
       "website_url": "https://qualified-teachers-api-prod.london.cloudapps.digital/status",
       "test_type": "HTTP",
-      "contact_group": [
-        "twd_tra_dqt"
-      ]
+      "contact_group": [249142],
+      "check_rate": 30,
+      "trigger_rate": 0,
+      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
+      "confirmations": 2
     }
   }
 }

--- a/terraform/statuscake.tf
+++ b/terraform/statuscake.tf
@@ -1,8 +1,12 @@
 resource "statuscake_test" "alert" {
   for_each = var.statuscake_alerts
 
-  website_name  = each.value.website_name
-  website_url   = each.value.website_url
-  test_type     = each.value.test_type
-  contact_group = each.value.contact_group
+  website_name   = each.value.website_name
+  website_url    = each.value.website_url
+  test_type      = each.value.test_type
+  contact_group  = each.value.contact_group
+  check_rate     = each.value.check_rate
+  trigger_rate   = each.value.trigger_rate
+  node_locations = each.value.node_locations
+  confirmations  = each.value.confirmations
 }

--- a/terraform/test.tfvars.json
+++ b/terraform/test.tfvars.json
@@ -13,9 +13,11 @@
       "website_name": "qualified-teachers-api-test",
       "website_url": "https://qualified-teachers-api-test.london.cloudapps.digital/status",
       "test_type": "HTTP",
-      "contact_group": [
-        "twd_tra_dqt"
-      ]
+      "contact_group": [249142],
+      "check_rate": 30,
+      "trigger_rate": 0,
+      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
+      "confirmations": 2
     }
   }
 }


### PR DESCRIPTION
### Context

Status cake contact group name passed in fails to populate contact group
field on deployment. Contact group ID fixes this issue. Default check
rate is too high means url could be down for few minutes without alerts
being sent. This commit address these to issues.

### Trello card

https://trello.com/c/yZ1wrROi
