### PR TITLE
Ensure JSON DateOnly parse failures yield a useful error message

### DIFF
--- a/src/DqtApi/Json/DateOnlyConverter.cs
+++ b/src/DqtApi/Json/DateOnlyConverter.cs
@@ -17,7 +17,7 @@ namespace DqtApi.Json
             var asString = reader.GetString();
             if (!DateOnly.TryParseExact(asString, Constants.DateFormat, out var value))
             {
-                throw new FormatException("The JSON value is not in a supported DateOnly format.");
+                throw new JsonException("The JSON value is not in a supported DateOnly format.");
             }
 
             return value;


### PR DESCRIPTION
### Context

`DateOnly` parse failures inside a JSON request currently return a useless error message that doesn't even include the field name. This fixes that.

### Changes proposed in this pull request

Change exception thrown on parse failure so the failure is rendered in the error response.

### Checklist

~~-   [ ] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
