### PR TITLE
Fix Task description to show matched attributes on duplicate teacher

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -333,7 +333,11 @@ namespace DqtApi.DataStore.Crm
                         {
                             Contact.Fields.dfeta_ActiveSanctions,
                             Contact.Fields.dfeta_QTSDate,
-                            Contact.Fields.dfeta_EYTSDate
+                            Contact.Fields.dfeta_EYTSDate,
+                            Contact.Fields.FirstName,
+                            Contact.Fields.MiddleName,
+                            Contact.Fields.LastName,
+                            Contact.Fields.BirthDate
                         }
                     },
                     Criteria = filter


### PR DESCRIPTION
### Context

The query that returns potential duplicate teachers wasn't returning the fields we matching so weren't correctly figuring out the Task description.

### Changes proposed in this pull request

Include the matched fields in the response so we correctly produce description.
