### PR TITLE
Add internal route

### DIFF
--- a/terraform/api-app.tf
+++ b/terraform/api-app.tf
@@ -14,6 +14,13 @@ resource "cloudfoundry_route" "api_public" {
   space    = data.cloudfoundry_space.space.id
 }
 
+resource "cloudfoundry_route" "api_internal" {
+  count    = local.configure_prometheus_network_policy
+  domain   = data.cloudfoundry_domain.internal.id
+  hostname = var.api_app_name
+  space    = data.cloudfoundry_space.space.id
+}
+
 resource "cloudfoundry_route" "api_education" {
   for_each = toset(var.hostnames)
   domain   = data.cloudfoundry_domain.education_gov_uk.id

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -22,6 +22,10 @@ data "cloudfoundry_domain" "cloudapps" {
   name = "london.cloudapps.digital"
 }
 
+data "cloudfoundry_domain" "internal" {
+  name = "apps.internal"
+}
+
 data "cloudfoundry_domain" "education_gov_uk" {
   name = "education.gov.uk"
 }

--- a/terraform/dev.tfvars.json
+++ b/terraform/dev.tfvars.json
@@ -7,5 +7,6 @@
   "paas_space": "tra-dev",
   "postgres_database_name": "qualified-teachers-api-dev-pg-svc",
   "redis_name": "qualified-teachers-api-dev-redis-svc",
-  "statuscake_alerts": {}
+  "statuscake_alerts": {},
+  "prometheus_app": "prometheus-tra-monitoring-dev"
 }

--- a/terraform/network-policies.tf
+++ b/terraform/network-policies.tf
@@ -1,0 +1,25 @@
+locals {
+  configure_prometheus_network_policy = var.prometheus_app == null ? 0 : 1
+}
+
+data "cloudfoundry_app" "api_web_app" {
+  depends_on = [cloudfoundry_app.api]
+  name_or_id = cloudfoundry_app.api.name
+  space      = data.cloudfoundry_space.space.id
+}
+
+data "cloudfoundry_app" "prometheus_app" {
+  count      = local.configure_prometheus_network_policy
+  name_or_id = var.prometheus_app
+  space      = data.cloudfoundry_space.space.id
+}
+
+resource "cloudfoundry_network_policy" "apply_prometheus_policy" {
+  depends_on = [data.cloudfoundry_app.api_web_app]
+  count      = local.configure_prometheus_network_policy
+  policy {
+    source_app      = data.cloudfoundry_app.prometheus_app[0].id
+    destination_app = data.cloudfoundry_app.api_web_app.id
+    port            = "80"
+  }
+}

--- a/terraform/prod.tfvars.json
+++ b/terraform/prod.tfvars.json
@@ -22,5 +22,6 @@
       "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
       "confirmations": 2
     }
-  }
+  },
+  "prometheus_app": "prometheus-tra-monitoring-prod"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,6 +31,10 @@ variable "api_app_name" {
   type = string
 }
 
+variable "prometheus_app" {
+  default = null
+}
+
 variable "api_docker_image" {
   type = string
 }
@@ -89,6 +93,7 @@ variable "hostnames" {
 locals {
   api_routes = flatten([
     cloudfoundry_route.api_public,
+    cloudfoundry_route.api_internal,
     values(cloudfoundry_route.api_education)
   ])
 }


### PR DESCRIPTION
### Context

Add internal route for the api app and network policy so that Prometheus can receive metrics from the api app through internal route. This will enable aggregation of metrics over the number of api app instances running.

### Trello card

https://trello.com/c/G6763qSL