### PR TITLE
Fix Sentry release identification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,8 @@ jobs:
         context: .
         push: true
         tags: ${{ steps.image.outputs.tag }}
+        build-args: |
+          GIT_SHA=${{ github.sha }}
 
   validate_terraform:
     name: Validate Terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1
   FROM mcr.microsoft.com/dotnet/aspnet:6.0
+  ARG GIT_SHA
+  ENV GitSha ${GIT_SHA}
   COPY src/DqtApi/bin/Release/net6.0/publish/ App/
   WORKDIR /App
   ENTRYPOINT ["dotnet", "DqtApi.dll"]


### PR DESCRIPTION
Sentry release ID relies on a `GitSha` environment variable that wasn't being set. Fix that here.