### PR TITLE
stop passing dateonly to crm rather than datetime

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -624,7 +624,7 @@ namespace DqtApi.DataStore.Crm
                 (FieldName: Contact.Fields.FirstName, Value: filter.FirstName),
                 (FieldName: Contact.Fields.MiddleName, Value: filter.MiddleName),
                 (FieldName: Contact.Fields.LastName, Value: filter.LastName),
-                (FieldName: Contact.Fields.BirthDate, Value: (object)filter.DateOfBirth),
+                (FieldName: Contact.Fields.BirthDate, Value: (object)(filter.DateOfBirth.HasValue ? filter.DateOfBirth.Value.ToDateTime() : null)),
                 (FieldName: Contact.Fields.dfeta_NINumber, Value: filter.NationalInsuranceNumber),
                 (FieldName: Contact.Fields.EMailAddress1, Value: filter.EmailAddress),
                 (FieldName: Contact.Fields.FirstName, Value: filter.PreviousFirstName),


### PR DESCRIPTION
### Context

Immediate fix for passing dateonly to crm rather than a date time.

### Changes proposed in this pull request

This fix stops the api from throwing a 500 when calling find.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
