### PR TITLE
Fix to handle nulls in find teacher

### DIFF
--- a/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
+++ b/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
@@ -54,7 +54,7 @@ namespace DqtApi.V2.Handlers
 
             return new FindTeachersResponse()
             {
-                Results = result.Select(a => new FindTeacherResult()
+                Results = result?.Select(a => new FindTeacherResult()
                 {
                     Trn = a.dfeta_TRN,
                     EmailAddresses = !string.IsNullOrEmpty(a.EMailAddress1) ? new List<string> { a.EMailAddress1 } : null,
@@ -63,7 +63,7 @@ namespace DqtApi.V2.Handlers
                     DateOfBirth = a.BirthDate.HasValue ? DateOnly.FromDateTime(a.BirthDate.Value) : null,
                     NationalInsuranceNumber = a.dfeta_NINumber,
                     Uid = a.Id.ToString()
-                })
+                }) ?? Enumerable.Empty<FindTeacherResult>()
             };
         }
     }

--- a/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using DqtApi.TestCommon;
+using DqtApi.V2.Responses;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
@@ -75,6 +77,30 @@ namespace DqtApi.Tests.V2.Operations
                 },
                 expectedStatusCode: StatusCodes.Status200OK);
         }
+
+        [Fact]
+        public async Task Given_find_with_no_search_parameters_return_empty_collection()
+        {
+            // Arrange
+            ApiFixture.DataverseAdapter
+                .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
+                .ReturnsAsync((Contact[])null);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"v2/teachers/find?dateOfBirth&emailAddress&firstName&ittProviderName&lastName&nationalInsuranceNumber");
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            await AssertEx.JsonResponseEquals(
+                response,
+                expected: new
+                {
+                    results = Enumerable.Empty<FindTeacherResult>()
+                },
+                expectedStatusCode: StatusCodes.Status200OK);
+        }
+
 
         [Theory]
         [InlineData("someProvider", "")]


### PR DESCRIPTION
### Context
Handler was previously not able to handle nulls when there are no query string parameters, the dataverseadapter returned null early, but the handler was tryting to call .select on null. This change fixes this.

### Changes proposed in this pull request

Change handler to handle nulls & add a missing test.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
