### PR TITLE
Add Prometheus metrics for CRM service limits

### DIFF
--- a/src/DqtApi/DataStore/Crm/IWebApiAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IWebApiAdapter.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace DqtApi.DataStore.Crm
+{
+    public interface IWebApiAdapter
+    {
+        Task<(int NumberOfRequests, double RemainingExecutionTime)> GetRemainingApiLimits();
+    }
+}

--- a/src/DqtApi/DataStore/Crm/WebApiAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/WebApiAdapter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+
+namespace DqtApi.DataStore.Crm
+{
+    public class WebApiAdapter : IWebApiAdapter
+    {
+        private static readonly TimeSpan _tokenExpirationBuffer = TimeSpan.FromSeconds(30);
+
+        private readonly HttpClient _httpClient;
+        private readonly IConfiguration _configuration;
+        private (string AccessToken, DateTime Expires)? _currentAccessToken;
+
+        public WebApiAdapter(IConfiguration configuration)
+        {
+            _configuration = configuration;
+
+            _httpClient = new HttpClient();
+            _httpClient.BaseAddress = new Uri(configuration["CrmUrl"].TrimEnd('/') + "/api/data/v9.2/");
+            _httpClient.DefaultRequestHeaders.Add("OData-MaxVersion", "4.0");
+            _httpClient.DefaultRequestHeaders.Add("OData-Version", "4.0");
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
+
+        public async Task<(int NumberOfRequests, double RemainingExecutionTime)> GetRemainingApiLimits()
+        {
+            await EnsureAccessToken();
+
+            var whoAmIResponse = await _httpClient.GetAsync("WhoAmI");
+            whoAmIResponse.EnsureSuccessStatusCode();
+
+            var numberOfRequests = int.Parse(whoAmIResponse.Headers.NonValidated["x-ms-ratelimit-burst-remaining-xrm-requests"].Single());
+            var executionTime = double.Parse(whoAmIResponse.Headers.NonValidated["x-ms-ratelimit-time-remaining-xrm-requests"].Single());
+
+            return (numberOfRequests, executionTime);
+        }
+
+        private async Task EnsureAccessToken()
+        {
+            if (!_currentAccessToken.HasValue ||
+                _currentAccessToken.Value.Expires.Subtract(_tokenExpirationBuffer) <= DateTime.UtcNow)
+            {
+                _currentAccessToken = await GetAccessToken();
+
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _currentAccessToken.Value.AccessToken);
+            }
+        }
+
+        private async Task<(string AccessToken, DateTime Expires)> GetAccessToken()
+        {
+            var scope = $"https://{(new Uri(_configuration["CrmUrl"]).Host)}/.default";
+            var clientId = _configuration["CrmClientId"];
+            var clientSecret = _configuration["CrmClientSecret"];
+
+            using var oauthClient = new HttpClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://login.microsoftonline.com/fad277c9-c60a-4da1-b5f3-b3b8b34a82f9/oauth2/v2.0/token");
+
+            var postParams = new Dictionary<string, string>()
+            {
+                { "grant_type", "client_credentials" },
+                { "scope", scope },
+                { "client_id", clientId },
+                { "client_secret", clientSecret }
+            };
+
+            request.Content = new FormUrlEncodedContent(postParams);
+
+            var response = await oauthClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var tokenResponse = await response.Content.ReadFromJsonAsync<TokenResponse>();
+
+            var expires = DateTime.UtcNow.Add(TimeSpan.FromSeconds(tokenResponse.ExpiresIn));
+
+            return (tokenResponse.AccessToken, expires);
+        }
+
+        private class TokenResponse
+        {
+            [JsonPropertyName("access_token")]
+            public string AccessToken { get; set; }
+
+            [JsonPropertyName("expires_in")]
+            public int ExpiresIn { get; set; }
+        }
+    }
+}

--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -12,6 +12,7 @@ using DqtApi.Json;
 using DqtApi.Logging;
 using DqtApi.ModelBinding;
 using DqtApi.Security;
+using DqtApi.Services;
 using DqtApi.Swagger;
 using DqtApi.Validation;
 using FluentValidation.AspNetCore;
@@ -200,6 +201,7 @@ namespace DqtApi
             services.AddMemoryCache();
             services.AddSingleton<ISentryEventProcessor, RemoveRedactedUrlParametersEventProcessor>();
             services.AddSingleton<IWebApiAdapter, WebApiAdapter>();
+            services.AddSingleton<IHostedService, LogRemainingCrmLimitsService>();
 
             services.AddDbContext<DqtContext>(options =>
             {

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -199,6 +199,7 @@ namespace DqtApi
             services.AddSingleton<IClock, Clock>();
             services.AddMemoryCache();
             services.AddSingleton<ISentryEventProcessor, RemoveRedactedUrlParametersEventProcessor>();
+            services.AddSingleton<IWebApiAdapter, WebApiAdapter>();
 
             services.AddDbContext<DqtContext>(options =>
             {

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -201,7 +201,6 @@ namespace DqtApi
             services.AddMemoryCache();
             services.AddSingleton<ISentryEventProcessor, RemoveRedactedUrlParametersEventProcessor>();
             services.AddSingleton<IWebApiAdapter, WebApiAdapter>();
-            services.AddSingleton<IHostedService, LogRemainingCrmLimitsService>();
 
             services.AddDbContext<DqtContext>(options =>
             {
@@ -224,6 +223,11 @@ namespace DqtApi
             {
                 ConfigureRateLimitServices();
                 ConfigureRedisServices();
+
+                if (Environment.GetEnvironmentVariable("CF_INSTANCE_INDEX") == "0")
+                {
+                    services.AddSingleton<IHostedService, LogRemainingCrmLimitsService>();
+                }
             }
 
             MetricLabels.ConfigureLabels(builder.Configuration);

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -300,7 +300,10 @@ namespace DqtApi
                     new Uri(configuration["CrmUrl"]),
                     configuration["CrmClientId"],
                     configuration["CrmClientSecret"],
-                    useUniqueInstance: true);
+                    useUniqueInstance: true)
+                {
+                    EnableAffinityCookie = false
+                };
 
             void ConfigureRateLimitServices()
             {

--- a/src/DqtApi/Services/LogRemainingCrmLimitsService.cs
+++ b/src/DqtApi/Services/LogRemainingCrmLimitsService.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading;
+using DqtApi.DataStore.Crm;
+using Microsoft.Extensions.Hosting;
+using Prometheus;
+
+namespace DqtApi.Services
+{
+    public class LogRemainingCrmLimitsService : BackgroundService
+    {
+        private static readonly TimeSpan _pollInterval = TimeSpan.FromMinutes(1);
+
+        private readonly IWebApiAdapter _webApiAdapter;
+        private readonly Gauge _remainingRequestsMetric;
+        private readonly Gauge _remainingExecutionTimeMetric;
+
+        public LogRemainingCrmLimitsService(IWebApiAdapter webApiAdapter)
+        {
+            _webApiAdapter = webApiAdapter;
+
+            _remainingRequestsMetric = Metrics.CreateGauge("crm_remaining_requests", "Remaining CRM requests");
+            _remainingExecutionTimeMetric = Metrics.CreateGauge("crm_remaining_execution_time", "Remaining CRM execution time");
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var timer = new PeriodicTimer(_pollInterval);
+
+            do
+            {
+                var limits = await _webApiAdapter.GetRemainingApiLimits();
+
+                _remainingRequestsMetric.Set(limits.NumberOfRequests);
+                _remainingExecutionTimeMetric.Set(limits.RemainingExecutionTime);
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+    }
+}


### PR DESCRIPTION
### Context

https://trello.com/c/BEEIWcVq/273-spike-dqt-reg-performance-load-monitoring

### Changes proposed in this pull request

Adds a `BackgroundService` that periodically calls CRM and extracts the remaining API limits and logs these to Prometheus.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
