### PR TITLE
Set correct status to null when teacher is withdrawn

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
@@ -162,11 +162,12 @@ namespace DqtApi.DataStore.Crm
             }
             else
             {
-                qtsUpdate.Attributes[dfeta_qtsregistration.Fields.dfeta_TeacherStatusId] = null;
-
-                if ((result == dfeta_ITTResult.Fail || result == dfeta_ITTResult.Withdrawn) && isEarlyYears)
+                if (result == dfeta_ITTResult.Withdrawn)
                 {
-                    qtsUpdate.Attributes[dfeta_qtsregistration.Fields.dfeta_EarlyYearsStatusId] = null;
+                    if (isEarlyYears)
+                        qtsUpdate.Attributes[dfeta_qtsregistration.Fields.dfeta_EarlyYearsStatusId] = null;
+                    else
+                        qtsUpdate.Attributes[dfeta_qtsregistration.Fields.dfeta_TeacherStatusId] = null;
                 }
             }
 


### PR DESCRIPTION
### Context

Update set itt outcome to clear teacherstatusid/earlyyearsstatusid conditionally.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
