### PR TITLE
Stop creating new qualification incorrectly

### DIFF
--- a/tests/DqtApi.Tests/ExecuteTransactionRequestExtensions.cs
+++ b/tests/DqtApi.Tests/ExecuteTransactionRequestExtensions.cs
@@ -30,6 +30,16 @@ namespace DqtApi.Tests
             return (TEntity)createRequest.Target;
         }
 
+        public static TEntity AssertSingleUpsertRequest<TEntity>(this ExecuteTransactionRequest request)
+            where TEntity : Entity
+        {
+            var upsertRequest = (UpsertRequest)Assert.Single(
+            request.Requests,
+            request => request is UpsertRequest upsertRequest && upsertRequest.Target is TEntity);
+
+            return (TEntity)upsertRequest.Target;
+        }
+
         public static void AssertDoesNotContainCreateRequest<TEntity>(this ExecuteTransactionRequest request)
             where TEntity : Entity
         {


### PR DESCRIPTION
### Context

This stops creating a new qualification when there are alreay more than 1 qualification.

### Changes proposed in this pull request

It was raised on the DTTP testing spreadsheet that when there are more than one qualification - dqt api was creating a new qualification incorrectly.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
