### PR TITLE
Only run unit/integration tests for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
     - name: Test
       id: test
       run: dotnet test tests/DqtApi.Tests --configuration Release --no-build --logger trx
+      if: github.event_name == 'pull_request'
       env:
         IntegrationTests_CrmUrl: ${{ secrets.INTEGRATIONTESTS_CRMURL }}
         IntegrationTests_CrmClientId: ${{ secrets.INTEGRATIONTESTS_CRMCLIENTID }}
@@ -75,7 +76,7 @@ jobs:
 
     - name: Test report
       uses: dorny/test-reporter@v1
-      if: ${{ steps.test.outcome != 'skipped' }}
+      if: always() && github.event_name == 'pull_request'
       with:
         name: Test results
         path: "**/*.trx"


### PR DESCRIPTION
### Context

We currently run tests on PRs (these have to pass before we can merge) then we merge to `main` then the same tests run again. These tests aren't the fastest so we're wasting time in actually deploying the change. This changes that so we don't run the tests for `main`.

### Changes proposed in this pull request

Don't run unit & integration tests for builds on `main`.