### PR TITLE
Remove the Server header

### DIFF
--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -51,6 +51,8 @@ namespace DqtApi
 
             var builder = WebApplication.CreateBuilder(args);
 
+            builder.WebHost.ConfigureKestrel(options => options.AddServerHeader = false);
+
             var services = builder.Services;
             var env = builder.Environment;
             var configuration = builder.Configuration;


### PR DESCRIPTION
### Context

https://trello.com/c/K2jtnkau/321-remove-verbose-server-headers-from-api

### Changes proposed in this pull request

Remove the `Server: Kestrel` header.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
