### PR TITLE
Use a common helper method for creating teacher records in tests

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.RequestBuilder.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.RequestBuilder.cs
@@ -48,6 +48,8 @@ namespace DqtApi.DataStore.Crm
             public static RequestBuilder CreateTransaction(IOrganizationServiceAsync organizationService) =>
                 new(organizationService, RequestType.Transaction);
 
+            public void AddRequest(OrganizationRequest request) => AddRequest<OrganizationResponse>(request);
+
             public IInnerRequestHandle<TResponse> AddRequest<TResponse>(OrganizationRequest request)
                 where TResponse : OrganizationResponse
             {
@@ -66,6 +68,14 @@ namespace DqtApi.DataStore.Crm
                 }
 
                 return new InnerRequestHandle<TResponse>(this, request);
+            }
+
+            public void AddRequests(params OrganizationRequest[] requests)
+            {
+                foreach (var request in requests)
+                {
+                    AddRequest<OrganizationResponse>(request);
+                }
             }
 
             public Task Execute()

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -31,7 +31,7 @@ namespace DqtApi.DataStore.Crm
 
         public Task<dfeta_country> GetCountry(string value) => GetCountry(value, requestBuilder: null);
 
-        private async Task<dfeta_country> GetCountry(string value, RequestBuilder requestBuilder)
+        public async Task<dfeta_country> GetCountry(string value, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -55,7 +55,7 @@ namespace DqtApi.DataStore.Crm
 
         public Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(string value) => GetEarlyYearsStatus(value, requestBuilder: null);
 
-        private async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(string value, RequestBuilder requestBuilder)
+        public async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(string value, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -79,7 +79,7 @@ namespace DqtApi.DataStore.Crm
 
         public Task<dfeta_hequalification> GetHeQualificationByName(string name) => GetHeQualificationByName(name, requestBuilder: null);
 
-        private async Task<dfeta_hequalification> GetHeQualificationByName(string name, RequestBuilder requestBuilder)
+        public async Task<dfeta_hequalification> GetHeQualificationByName(string name, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -103,7 +103,7 @@ namespace DqtApi.DataStore.Crm
 
         public Task<dfeta_hesubject> GetHeSubjectByCode(string value) => GetHeSubjectByCode(value, requestBuilder: null);
 
-        private async Task<dfeta_hesubject> GetHeSubjectByCode(string value, RequestBuilder requestBuilder)
+        public async Task<dfeta_hesubject> GetHeSubjectByCode(string value, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -130,7 +130,7 @@ namespace DqtApi.DataStore.Crm
             params string[] columnNames) =>
                 GetInitialTeacherTrainingByTeacher(teacherId, columnNames, requestBuilder: null);
 
-        private async Task<dfeta_initialteachertraining[]> GetInitialTeacherTrainingByTeacher(
+        public async Task<dfeta_initialteachertraining[]> GetInitialTeacherTrainingByTeacher(
             Guid teacherId,
             string[] columnNames,
             RequestBuilder requestBuilder)
@@ -181,7 +181,7 @@ namespace DqtApi.DataStore.Crm
 
         public Task<dfeta_ittsubject> GetIttSubjectByCode(string code) => GetIttSubjectByCode(code, requestBuilder: null);
 
-        private async Task<dfeta_ittsubject> GetIttSubjectByCode(string code, RequestBuilder requestBuilder)
+        public async Task<dfeta_ittsubject> GetIttSubjectByCode(string code, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -337,7 +337,7 @@ namespace DqtApi.DataStore.Crm
         public Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, params string[] columnNames) =>
             GetIttProviderOrganizationByUkprn(ukprn, columnNames, requestBuilder: null);
 
-        private async Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -363,7 +363,7 @@ namespace DqtApi.DataStore.Crm
         public Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames) =>
             GetOrganizationByUkprn(ukprn, columnNames, requestBuilder: null);
 
-        private async Task<Account> GetOrganizationByUkprn(string ukprn, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account> GetOrganizationByUkprn(string ukprn, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -390,7 +390,7 @@ namespace DqtApi.DataStore.Crm
             params string[] columnNames) =>
                 GetQtsRegistrationsByTeacher(teacherId, columnNames, requestBuilder: null);
 
-        private async Task<dfeta_qtsregistration[]> GetQtsRegistrationsByTeacher(
+        public async Task<dfeta_qtsregistration[]> GetQtsRegistrationsByTeacher(
             Guid teacherId,
             string[] columnNames,
             RequestBuilder requestBuilder)
@@ -545,7 +545,7 @@ namespace DqtApi.DataStore.Crm
         public Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, params string[] columnNames) =>
             GetCrmTasksForTeacher(teacherId, columnNames, requestBuilder: null);
 
-        private async Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -570,7 +570,7 @@ namespace DqtApi.DataStore.Crm
             bool qtsDateRequired) =>
                 GetTeacherStatus(value, qtsDateRequired, requestBuilder: null);
 
-        private async Task<dfeta_teacherstatus> GetTeacherStatus(
+        public async Task<dfeta_teacherstatus> GetTeacherStatus(
             string value,
             bool qtsDateRequired,
             RequestBuilder requestBuilder)
@@ -621,7 +621,7 @@ namespace DqtApi.DataStore.Crm
         public Task<Account> GetOrganizationByName(string name, params string[] columnNames) =>
             GetOrganizationByName(name, columnNames, requestBuilder: null);
 
-        private async Task<Account> GetOrganizationByName(string name, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account> GetOrganizationByName(string name, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 

--- a/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -2,12 +2,10 @@
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
-using Microsoft.Xrm.Sdk.Messages;
 using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    [Collection(nameof(ExclusiveCrmTestCollection))]
     public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLifetime
     {
         private readonly CreateTeacherFixture _createTeacherFixture;
@@ -428,16 +426,16 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             var command = new CreateTeacherCommand()
             {
-                FirstName = "Minnie",
-                MiddleName = "Van",
-                LastName = "Ryder",
-                BirthDate = new(1990, 5, 23),
-                EmailAddress = "minnie.van.ryder@example.com",
+                FirstName = Faker.Name.First(),
+                MiddleName = Faker.Name.Middle(),
+                LastName = Faker.Name.Last(),
+                BirthDate = Faker.Identification.DateOfBirth(),
+                EmailAddress = Faker.Internet.Email(),
                 Address = new()
                 {
-                    AddressLine1 = "52 Quernmore Road",
-                    City = "Liverpool",
-                    PostalCode = "L33 6UZ",
+                    AddressLine1 = Faker.Address.StreetAddress(),
+                    City = Faker.Address.City(),
+                    PostalCode = Faker.Address.UkPostCode(),
                     Country = "United Kingdom"
                 },
                 GenderCode = Contact_GenderCode.Female,

--- a/tests/DqtApi.Tests/DqtApi.Tests.csproj
+++ b/tests/DqtApi.Tests/DqtApi.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Faker.Net" Version="2.0.154" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/tests/DqtApi.Tests/Startup.cs
+++ b/tests/DqtApi.Tests/Startup.cs
@@ -8,6 +8,7 @@ namespace DqtApi.Tests
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<CrmClientFixture>();
+            services.AddMemoryCache();
         }
     }
 }

--- a/tests/DqtApi.Tests/TestDataHelper.CreatePerson.cs
+++ b/tests/DqtApi.Tests/TestDataHelper.CreatePerson.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Threading.Tasks;
+using DqtApi.DataStore.Crm.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+
+namespace DqtApi.Tests
+{
+    public partial class TestDataHelper
+    {
+        public async Task<CreatePersonResult> CreatePerson(
+            bool earlyYears = false,
+            bool assessmentOnly = false,
+            bool withQualification = false,
+            bool withActiveSanction = false)
+        {
+            if (earlyYears && assessmentOnly)
+            {
+                throw new ArgumentException($"Cannot set both {nameof(earlyYears)} and {nameof(assessmentOnly)}.");
+            }
+
+            var teacherId = Guid.NewGuid();
+
+            var programmeType = earlyYears ? dfeta_ITTProgrammeType.EYITTAssessmentOnly :
+                assessmentOnly ? dfeta_ITTProgrammeType.AssessmentOnlyRoute :
+                dfeta_ITTProgrammeType.RegisteredTeacherProgramme;
+
+            var ittProviderUkprn = "10044534";
+
+            var lookupRequestBuilder = _dataverseAdapter.CreateMultipleRequestBuilder();
+
+            var getIttProviderTask = _globalCache.GetOrCreateAsync(
+                CacheKeys.GetIttProviderOrganizationByUkprnKey(ittProviderUkprn),
+                _ => _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn, columnNames: Array.Empty<string>(), lookupRequestBuilder));
+
+            var earlyYearsStatus = "220"; // 220 == 'Early Years Trainee'
+
+            var getEarlyYearsStatusTask = earlyYears ?
+                _globalCache.GetOrCreateAsync(
+                    CacheKeys.GetEarlyYearsStatusKey(earlyYearsStatus),
+                    _ => _dataverseAdapter.GetEarlyYearsStatus(earlyYearsStatus, lookupRequestBuilder)) :
+                Task.FromResult<dfeta_earlyyearsstatus>(null);
+
+            var teacherStatus = programmeType == dfeta_ITTProgrammeType.AssessmentOnlyRoute ?
+                "212" :  // 212 == 'AOR Candidate'
+                "211";   // 211 == 'Trainee Teacher:DMS'
+
+            var getTeacherStatusTask = !earlyYears ?
+                _globalCache.GetOrCreateAsync(
+                    CacheKeys.GetTeacherStatusKey(teacherStatus),
+                    _ => _dataverseAdapter.GetTeacherStatus(teacherStatus, qtsDateRequired: false, lookupRequestBuilder)) :
+                Task.FromResult<dfeta_teacherstatus>(null);
+
+            var country = "XK";
+            var getCountryCodeTask = _globalCache.GetOrCreateAsync(
+                CacheKeys.GetCountryKey(country),
+                _ => _dataverseAdapter.GetCountry(country, lookupRequestBuilder));
+
+            var heSubjectCode = "100366";  // computer science
+            var getHeSubjectTask = _globalCache.GetOrCreateAsync(
+                CacheKeys.GetHeSubjectKey(heSubjectCode),
+                _ => _dataverseAdapter.GetHeSubjectByCode(heSubjectCode, lookupRequestBuilder));
+
+            var qualificationName = "First Degree";
+            var getQualificationTask = _globalCache.GetOrCreateAsync(
+                CacheKeys.GetHeQualificationKey(qualificationName),
+                _ => _dataverseAdapter.GetHeQualificationByName(qualificationName, lookupRequestBuilder));
+
+            await lookupRequestBuilder.Execute();
+
+            var ittProvider = getIttProviderTask.Result;
+            var earlyYearsStatusId = getEarlyYearsStatusTask?.Result?.Id;
+            var teacherStatusId = getTeacherStatusTask?.Result?.Id;
+            var countryId = getCountryCodeTask.Result.Id;
+            var heSubjectId = getHeSubjectTask.Result.Id;
+            var qualificationId = getQualificationTask.Result.Id;
+
+            var txnRequestBuilder = _dataverseAdapter.CreateTransactionRequestBuilder();
+
+            txnRequestBuilder.AddRequests(
+                new CreateRequest()
+                {
+                    Target = new Contact()
+                    {
+                        Id = teacherId,
+                        FirstName = Faker.Name.First(),
+                        MiddleName = Faker.Name.Middle(),
+                        LastName = Faker.Name.Last(),
+                        BirthDate = Faker.Identification.DateOfBirth(),
+                        dfeta_NINumber = Faker.Identification.UkNationalInsuranceNumber(),
+                        EMailAddress1 = Faker.Internet.Email(),
+                        Address1_Line1 = Faker.Address.StreetAddress(),
+                        Address1_City = Faker.Address.City(),
+                        Address1_Country = "United Kingdom",
+                        Address1_PostalCode = Faker.Address.UkPostCode()
+                    }
+                },
+                new UpdateRequest()
+                {
+                    Target = new Contact()
+                    {
+                        Id = teacherId,
+                        dfeta_TRNAllocateRequest = DateTime.UtcNow
+                    }
+                });
+
+            var createIttTask = txnRequestBuilder.AddRequest<CreateResponse>(new CreateRequest()
+            {
+                Target = new dfeta_initialteachertraining()
+                {
+                    dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+                    dfeta_EstablishmentId = new EntityReference(Account.EntityLogicalName, ittProvider.Id),
+                    dfeta_ProgrammeType = programmeType,
+                    dfeta_Result = assessmentOnly ? dfeta_ITTResult.UnderAssessment : dfeta_ITTResult.InTraining
+                }
+            });
+
+            var createQtsTask = txnRequestBuilder.AddRequest<CreateResponse>(new CreateRequest()
+            {
+                Target = new dfeta_qtsregistration()
+                {
+                    dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+                    dfeta_EarlyYearsStatusId = earlyYearsStatusId.HasValue ? new EntityReference(dfeta_earlyyearsstatus.EntityLogicalName, earlyYearsStatusId.Value) : null,
+                    dfeta_TeacherStatusId = teacherStatusId.HasValue ? new EntityReference(dfeta_teacherstatus.EntityLogicalName, teacherStatusId.Value) : null
+                }
+            });
+
+            if (withQualification)
+            {
+                txnRequestBuilder.AddRequest(new CreateRequest()
+                {
+                    Target = new dfeta_qualification()
+                    {
+                        dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+                        dfeta_HE_CountryId = new EntityReference(dfeta_qualification.EntityLogicalName, countryId),
+                        dfeta_HE_EstablishmentId = new EntityReference(Account.EntityLogicalName, ittProvider.Id),
+                        dfeta_Type = dfeta_qualification_dfeta_Type.HigherEducation,
+                        dfeta_HE_ClassDivision = dfeta_classdivision.Pass,
+                        dfeta_HE_CompletionDate = DateTime.Now.AddMonths(-1),
+                        dfeta_HE_HESubject1Id = new EntityReference(dfeta_hesubject.EntityLogicalName, heSubjectId),
+                        dfeta_HE_HEQualificationId = new EntityReference(dfeta_hequalification.EntityLogicalName, qualificationId)
+                    }
+                });
+            }
+
+            if (withActiveSanction)
+            {
+                txnRequestBuilder.AddRequest(new CreateRequest()
+                {
+                    Target = new dfeta_sanction()
+                    {
+                        dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+                    }
+                });
+            }
+
+            await txnRequestBuilder.Execute();
+
+            var ittId = createIttTask.GetResponse().id;
+            var qtsId = createQtsTask.GetResponse().id;
+
+            return new CreatePersonResult(teacherId, ittId, qtsId, ittProviderUkprn);
+        }
+
+        public record CreatePersonResult(
+            Guid TeacherId,
+            Guid InitialTeacherTrainingId,
+            Guid QtsRegistrationId,
+            string IttProviderUkprn);
+    }
+}

--- a/tests/DqtApi.Tests/TestDataHelper.cs
+++ b/tests/DqtApi.Tests/TestDataHelper.cs
@@ -1,0 +1,18 @@
+﻿using DqtApi.DataStore.Crm;
+using DqtApi.Tests.DataverseIntegration;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DqtApi.Tests
+{
+    public partial class TestDataHelper
+    {
+        private readonly DataverseAdapter _dataverseAdapter;
+        private readonly IMemoryCache _globalCache;
+
+        public TestDataHelper(CrmClientFixture.TestDataScope dataScope, IMemoryCache memoryCache)
+        {
+            _dataverseAdapter = dataScope.CreateDataverseAdapter();
+            _globalCache = memoryCache;
+        }
+    }
+}


### PR DESCRIPTION
Also add caching for reference data lookups.

### Context

Integration tests are taking longer and longer to run. Many tests do the same work (around creating teacher records etc.). We can optimise some of this by caching lookups. As a side-effect we get a single helper method for creating a teacher.

### Changes proposed in this pull request

- Add a `TestDataHelper.CreatePerson()` method for creating contact, ITT, qualification, QTS and sanction records. Use caching for reference data lookups.
- Allow more test classes to run in parallel. There's no data dependency between them so they're fine to run in parallel.

### Checklist

~~-   [ ] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
