### PR TITLE
Amend FindTeachers endpoint to use revised matching criteria

### DIFF
--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -147,25 +147,9 @@
         "summary": "Returns teachers matching the specified criteria",
         "parameters": [
           {
-            "name": "emailAddress",
-            "in": "query",
-            "description": "Email Address",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "firstName",
             "in": "query",
             "description": "First name of person",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "middleName",
-            "in": "query",
-            "description": "Middle name of person",
             "schema": {
               "type": "string"
             }

--- a/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
@@ -24,6 +24,10 @@ namespace DqtApi.DataStore.Crm
 
         Task<UpdateTeacherResult> UpdateTeacher(UpdateTeacherCommand command);
 
+        Task<Account> GetIttProviderOrganizationByName(string ukprn, params string[] columnNames);
+
+        Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, params string[] columnNames);
+
         Task<Account> GetOrganizationByName(string providerName, params string[] columnNames);
 
         Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames);

--- a/src/DqtApi/DataStore/Crm/Models/FindTeachersQuery.cs
+++ b/src/DqtApi/DataStore/Crm/Models/FindTeachersQuery.cs
@@ -4,9 +4,7 @@ namespace DqtApi.DataStore.Crm
 {
     public class FindTeachersQuery
     {
-        public string EmailAddress { get; set; }
         public string FirstName { get; set; }
-        public string MiddleName { get; set; }
         public string LastName { get; set; }
         public string PreviousFirstName { get; set; }
         public string PreviousLastName { get; set; }

--- a/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
+++ b/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
@@ -23,26 +23,31 @@ namespace DqtApi.V2.Handlers
 
         public async Task<FindTeachersResponse> Handle(FindTeachersRequest request, CancellationToken cancellationToken)
         {
-            var ittProvider = default(Account);
+            Account ittProvider = null;
+
             if (!string.IsNullOrEmpty(request.IttProviderUkprn))
             {
-                ittProvider = await _dataverseAdapter.GetOrganizationByUkprn(request.IttProviderUkprn);
+                ittProvider = await _dataverseAdapter.GetIttProviderOrganizationByUkprn(request.IttProviderUkprn);
+
                 if (ittProvider == null)
+                {
                     throw new ErrorException(ErrorRegistry.OrganisationNotFound());
+                }
             }
             else if (!string.IsNullOrEmpty(request.IttProviderName))
             {
-                ittProvider = await _dataverseAdapter.GetOrganizationByName(request.IttProviderName);
+                ittProvider = await _dataverseAdapter.GetIttProviderOrganizationByName(request.IttProviderName);
+
                 if (ittProvider == null)
+                {
                     throw new ErrorException(ErrorRegistry.OrganisationNotFound());
+                }
             }
 
             var query = new FindTeachersQuery()
             {
                 FirstName = request.FirstName,
-                MiddleName = request.MiddleName,
                 LastName = request.LastName,
-                EmailAddress = request.EmailAddress,
                 PreviousFirstName = request.PreviousFirstName,
                 PreviousLastName = request.PreviousLastName,
                 NationalInsuranceNumber = request.NationalInsuranceNumber,

--- a/src/DqtApi/V2/Requests/FindTeachersRequest.cs
+++ b/src/DqtApi/V2/Requests/FindTeachersRequest.cs
@@ -8,17 +8,9 @@ namespace DqtApi.V2.Requests
 {
     public class FindTeachersRequest : IRequest<FindTeachersResponse>
     {
-        [SwaggerParameter(Description = "Email Address")]
-        [FromQuery(Name = "emailAddress")]
-        public string EmailAddress { get; set; }
-
         [SwaggerParameter(Description = "First name of person")]
         [FromQuery(Name = "firstName")]
         public string FirstName { get; set; }
-
-        [SwaggerParameter(Description = "Middle name of person")]
-        [FromQuery(Name = "middleName")]
-        public string MiddleName { get; set; }
 
         [SwaggerParameter(Description = "Last name of person")]
         [FromQuery(Name = "lastName")]

--- a/tests/DqtApi.Tests/DataverseIntegration/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/FindTeachersTests.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
+using Xunit;
+
+namespace DqtApi.Tests.DataverseIntegration
+{
+    public class FindTeachersTests : IClassFixture<FindTeachersFixture>
+    {
+        private readonly CrmClientFixture.TestDataScope _dataScope;
+        private readonly DataverseAdapter _dataverseAdapter;
+        private readonly FindTeachersFixture _findTeachersFixture;
+
+        public FindTeachersTests(FindTeachersFixture findTeachersFixture, CrmClientFixture crmClientFixture)
+        {
+            _findTeachersFixture = findTeachersFixture;
+            _dataScope = crmClientFixture.CreateTestDataScope();
+            _dataverseAdapter = _dataScope.CreateDataverseAdapter();
+        }
+
+        [Fact]
+        public async Task Given_less_than_3_identifiers_returns_no_matches()
+        {
+            var queries = Enumerable.Range(0, 3).SelectMany(f => CreateQueries(matchingFieldsCount: f, populateNonMatchingFields: false));
+
+            foreach (var query in queries)
+            {
+                var result = await _dataverseAdapter.FindTeachers(query);
+                AssertDoesNotContainMatch(result);
+            }
+        }
+
+        [Fact]
+        public async Task Given_3_matching_identifiers_returns_match()
+        {
+            var queries = CreateQueries(matchingFieldsCount: 3, populateNonMatchingFields: false);
+
+            foreach (var query in queries)
+            {
+                var result = await _dataverseAdapter.FindTeachers(query);
+                AssertContainsMatch(result);
+            }
+        }
+
+        [Fact]
+        public async Task Given_4_matching_identifiers_returns_match()
+        {
+            var queries = CreateQueries(matchingFieldsCount: 4, populateNonMatchingFields: true);
+
+            foreach (var query in queries)
+            {
+                var result = await _dataverseAdapter.FindTeachers(query);
+                AssertContainsMatch(result);
+            }
+        }
+
+        [Fact]
+        public async Task Given_3_matching_identifiers_and_one_mismatching_identifier_returns_match()
+        {
+            var queries = CreateQueries(matchingFieldsCount: 3, populateNonMatchingFields: true);
+
+            foreach (var query in queries)
+            {
+                var result = await _dataverseAdapter.FindTeachers(query);
+                AssertContainsMatch(result);
+            }
+        }
+
+        private void AssertDoesNotContainMatch(Contact[] results) =>
+            Assert.DoesNotContain(_findTeachersFixture.MatchingTeacherId, results.Select(r => r.Id));
+
+        private void AssertContainsMatch(Contact[] results) =>
+            Assert.Contains(_findTeachersFixture.MatchingTeacherId, results.Select(r => r.Id));
+
+        /// <summary>
+        /// Returns a collection of <see cref="FindTeachersQuery"/>s with the specified number of properties matching our reference record.
+        /// </summary>
+        /// <param name="matchingFieldsCount">The number of fields that should match with the reference record.</param>
+        /// <param name="populateNonMatchingFields">Whether non-matching fields should be filled with non-matching values.</param>
+        private IEnumerable<FindTeachersQuery> CreateQueries(int matchingFieldsCount, bool populateNonMatchingFields = true)
+        {
+            var fields = new (Action<FindTeachersQuery> SetMatchingValue, Action<FindTeachersQuery> SetNonMatchingValue)[]
+            {
+                (
+                    (FindTeachersQuery q) =>
+                    {
+                        q.FirstName = _findTeachersFixture.MatchingTeacherFirstName;
+                        q.LastName = _findTeachersFixture.MatchingTeacherLastName;
+                    },
+                    (FindTeachersQuery q) =>
+                    {
+                        q.FirstName = "Bad First Name";
+                        q.LastName = "Bad Last Name";
+                    }),
+                ((FindTeachersQuery q) => q.DateOfBirth = _findTeachersFixture.MatchingTeacherBirthDate, (FindTeachersQuery q) => q.DateOfBirth = _findTeachersFixture.MatchingTeacherBirthDate.AddDays(1)),
+                ((FindTeachersQuery q) => q.NationalInsuranceNumber = _findTeachersFixture.MatchingTeacherNino, (FindTeachersQuery q) => q.NationalInsuranceNumber = "ABC"),
+                ((FindTeachersQuery q) => q.IttProviderOrganizationId = _findTeachersFixture.MatchingTeacherIttProviderId, (FindTeachersQuery q) => q.IttProviderOrganizationId = Guid.NewGuid()),
+            };
+
+            var combinations = fields.GetCombinations(matchingFieldsCount);
+
+            foreach (var c in combinations)
+            {
+                var query = new FindTeachersQuery();
+
+                foreach (var field in c)
+                {
+                    field.SetMatchingValue(query);
+                }
+
+                if (populateNonMatchingFields)
+                {
+                    foreach (var field in fields.Except(c))
+                    {
+                        field.SetNonMatchingValue(query);
+                    }
+                }
+
+                yield return query;
+            }
+        }
+    }
+
+    public class FindTeachersFixture : IAsyncLifetime
+    {
+        private readonly CrmClientFixture.TestDataScope _dataScope;
+
+        public FindTeachersFixture(CrmClientFixture crmClientFixture)
+        {
+            _dataScope = crmClientFixture.CreateTestDataScope();
+        }
+
+        public Guid MatchingTeacherId { get; private set; }
+        public Guid MatchingTeacherIttProviderId { get; private set; }
+        public string MatchingTeacherFirstName { get; private set; }
+        public string MatchingTeacherLastName { get; private set; }
+        public DateOnly MatchingTeacherBirthDate { get; private set; }
+        public string MatchingTeacherNino { get; private set; }
+
+        public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+        public async Task InitializeAsync()
+        {
+            var testDataHelper = _dataScope.CreateTestDataHelper();
+
+            var createPersonResult = await testDataHelper.CreatePerson();
+            MatchingTeacherId = createPersonResult.TeacherId;
+            MatchingTeacherIttProviderId = createPersonResult.IttProviderId;
+            MatchingTeacherFirstName = createPersonResult.FirstName;
+            MatchingTeacherLastName = createPersonResult.LastName;
+            MatchingTeacherBirthDate = createPersonResult.BirthDate;
+            MatchingTeacherNino = createPersonResult.Nino;
+        }
+    }
+}

--- a/tests/DqtApi.Tests/TestDataHelper.CreatePerson.cs
+++ b/tests/DqtApi.Tests/TestDataHelper.CreatePerson.cs
@@ -21,6 +21,12 @@ namespace DqtApi.Tests
             }
 
             var teacherId = Guid.NewGuid();
+            var firstName = Faker.Name.First();
+            var middleName = Faker.Name.Middle();
+            var lastName = Faker.Name.Last();
+            var birthDate = Faker.Identification.DateOfBirth();
+            var nino = Faker.Identification.UkNationalInsuranceNumber();
+            var email = Faker.Internet.Email();
 
             var programmeType = earlyYears ? dfeta_ITTProgrammeType.EYITTAssessmentOnly :
                 assessmentOnly ? dfeta_ITTProgrammeType.AssessmentOnlyRoute :
@@ -84,12 +90,12 @@ namespace DqtApi.Tests
                     Target = new Contact()
                     {
                         Id = teacherId,
-                        FirstName = Faker.Name.First(),
-                        MiddleName = Faker.Name.Middle(),
-                        LastName = Faker.Name.Last(),
-                        BirthDate = Faker.Identification.DateOfBirth(),
-                        dfeta_NINumber = Faker.Identification.UkNationalInsuranceNumber(),
-                        EMailAddress1 = Faker.Internet.Email(),
+                        FirstName = firstName,
+                        MiddleName = middleName,
+                        LastName = lastName,
+                        BirthDate = birthDate,
+                        dfeta_NINumber = nino,
+                        EMailAddress1 = email,
                         Address1_Line1 = Faker.Address.StreetAddress(),
                         Address1_City = Faker.Address.City(),
                         Address1_Country = "United Kingdom",
@@ -161,13 +167,18 @@ namespace DqtApi.Tests
             var ittId = createIttTask.GetResponse().id;
             var qtsId = createQtsTask.GetResponse().id;
 
-            return new CreatePersonResult(teacherId, ittId, qtsId, ittProviderUkprn);
+            return new CreatePersonResult(teacherId, firstName, lastName, DateOnly.FromDateTime(birthDate), nino, ittId, qtsId, ittProvider.Id, ittProviderUkprn);
         }
 
         public record CreatePersonResult(
             Guid TeacherId,
+            string FirstName,
+            string LastName,
+            DateOnly BirthDate,
+            string Nino,
             Guid InitialTeacherTrainingId,
             Guid QtsRegistrationId,
+            Guid IttProviderId,
             string IttProviderUkprn);
     }
 }

--- a/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -134,11 +134,11 @@ namespace DqtApi.Tests.V2.Operations
             var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 1, 1), dfeta_TRN = "someReference" };
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetOrganizationByName(It.IsAny<string>()))
+                .Setup(mock => mock.GetIttProviderOrganizationByName(It.IsAny<string>()))
                 .ReturnsAsync(account);
 
             ApiFixture.DataverseAdapter
-                 .Setup(mock => mock.GetOrganizationByUkprn(It.IsAny<string>()))
+                 .Setup(mock => mock.GetIttProviderOrganizationByUkprn(It.IsAny<string>()))
                  .ReturnsAsync(account);
 
             ApiFixture.DataverseAdapter


### PR DESCRIPTION
### Context

https://trello.com/c/dRCLwGgG/380-update-matching-rules-for-qualified-teachers-api-find-endpoints

### Changes proposed in this pull request

Amend the matching rules to align with https://tra-digital-design-history.herokuapp.com/find-a-lost-trn/matching-rules-for-mvp/ - require a match on at least 3 identifiers (of ITT provider, DOB, NINO and Name).

Added de-duping for cases where a person has multiple ITT records but hasn't necessarily matched on ITT provider.

Also changed ITT Provider lookup to ensure we're only looking at training provider orgs. (We were occasionally getting errors from duplicates before.)

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
