### PR TITLE
added activeOnly field for get GetIttProviderOrganizationByName & Get…

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -455,7 +455,7 @@ namespace DqtApi.DataStore.Crm
                     _command.InitialTeacherTraining.ProviderUkprn,
                     ukprn => _dataverseAdapter._cache.GetOrCreateAsync(
                         CacheKeys.GetIttProviderOrganizationByUkprnKey(ukprn),
-                        _ => _dataverseAdapter.GetIttProviderOrganizationByUkprn(ukprn, columnNames: Array.Empty<string>(), requestBuilder)));
+                        _ => _dataverseAdapter.GetIttProviderOrganizationByUkprn(ukprn, true, columnNames: Array.Empty<string>(), requestBuilder)));
 
                 var getIttCountryTask = Let(
                     "XK",  // XK == 'United Kingdom'

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
@@ -250,7 +250,7 @@ namespace DqtApi.DataStore.Crm
                         Contact.Fields.dfeta_TRN
                     });
 
-                var getIttProviderTask = _dataverseAdapter.GetIttProviderOrganizationByUkprn(_ittProviderUkprn);
+                var getIttProviderTask = _dataverseAdapter.GetIttProviderOrganizationByUkprn(_ittProviderUkprn, true);
 
                 var getIttRecordsTask = _dataverseAdapter.GetInitialTeacherTrainingByTeacher(
                     _teacherId,

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
@@ -463,7 +463,7 @@ namespace DqtApi.DataStore.Crm
                     _command.InitialTeacherTraining.ProviderUkprn,
                     ukprn => _dataverseAdapter._cache.GetOrCreateAsync(
                         CacheKeys.GetIttProviderOrganizationByUkprnKey(ukprn),
-                        _ => _dataverseAdapter.GetIttProviderOrganizationByUkprn(ukprn)));
+                        _ => _dataverseAdapter.GetIttProviderOrganizationByUkprn(ukprn, true)));
 
                 var getQualificationProviderTask = !string.IsNullOrEmpty(_command.Qualification?.ProviderUkprn) ?
                      Let(

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -157,10 +157,11 @@ namespace DqtApi.DataStore.Crm
             return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_initialteachertraining>()).ToArray();
         }
 
-        public async Task<Account[]> GetIttProviders()
+        public async Task<Account[]> GetIttProviders(bool activeOnly)
         {
             var filter = new FilterExpression(LogicalOperator.And);
-            filter.AddCondition(Account.Fields.StateCode, ConditionOperator.Equal, (int)AccountState.Active);
+            if (activeOnly)
+                filter.AddCondition(Account.Fields.StateCode, ConditionOperator.Equal, (int)AccountState.Active);
             filter.AddCondition(Account.Fields.dfeta_TrainingProvider, ConditionOperator.Equal, true);
             filter.AddCondition(Account.Fields.dfeta_UKPRN, ConditionOperator.NotNull);
 
@@ -336,8 +337,8 @@ namespace DqtApi.DataStore.Crm
             }
         }
 
-        public Task<Account> GetIttProviderOrganizationByName(string name, params string[] columnNames) =>
-            GetIttProviderOrganizationByUkprn(name, columnNames, requestBuilder: null);
+        public Task<Account> GetIttProviderOrganizationByName(string name, bool activeOnly, params string[] columnNames) =>
+            GetIttProviderOrganizationByUkprn(name, activeOnly, columnNames, requestBuilder: null);
 
         public async Task<Account> GetIttProviderOrganizationByName(string name, string[] columnNames, RequestBuilder requestBuilder)
         {
@@ -362,10 +363,10 @@ namespace DqtApi.DataStore.Crm
             return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
         }
 
-        public Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, params string[] columnNames) =>
-            GetIttProviderOrganizationByUkprn(ukprn, columnNames, requestBuilder: null);
+        public Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, bool activeOnly, params string[] columnNames) =>
+            GetIttProviderOrganizationByUkprn(ukprn, activeOnly, columnNames, requestBuilder: null);
 
-        public async Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, bool activeOnly, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -376,7 +377,9 @@ namespace DqtApi.DataStore.Crm
 
             query.AddAttributeValue(Account.Fields.dfeta_TrainingProvider, true);
             query.AddAttributeValue(Account.Fields.dfeta_UKPRN, ukprn);
-            query.AddAttributeValue(Account.Fields.StateCode, (int)AccountState.Active);
+
+            if (activeOnly)
+                query.AddAttributeValue(Account.Fields.StateCode, (int)AccountState.Active);
 
             var request = new RetrieveMultipleRequest()
             {
@@ -647,10 +650,10 @@ namespace DqtApi.DataStore.Crm
             }
         }
 
-        public Task<Account> GetOrganizationByName(string name, params string[] columnNames) =>
-            GetOrganizationByName(name, columnNames, requestBuilder: null);
+        public Task<Account> GetOrganizationByName(string name, bool activeOnly, params string[] columnNames) =>
+            GetOrganizationByName(name, activeOnly, columnNames, requestBuilder: null);
 
-        public async Task<Account> GetOrganizationByName(string name, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account> GetOrganizationByName(string name, bool activeOnly, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -660,7 +663,9 @@ namespace DqtApi.DataStore.Crm
             };
 
             query.AddAttributeValue(Account.Fields.Name, name);
-            query.AddAttributeValue(Account.Fields.StateCode, (int)AccountState.Active);
+
+            if (activeOnly)
+                query.AddAttributeValue(Account.Fields.StateCode, (int)AccountState.Active);
 
             var request = new RetrieveMultipleRequest()
             {

--- a/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
@@ -8,7 +8,7 @@ namespace DqtApi.DataStore.Crm
     {
         Task<CreateTeacherResult> CreateTeacher(CreateTeacherCommand command);
 
-        Task<Account[]> GetIttProviders();
+        Task<Account[]> GetIttProviders(bool activeOnly);
 
         Task<Contact[]> FindTeachers(FindTeachersByTrnBirthDateAndNinoQuery query);
 
@@ -24,11 +24,11 @@ namespace DqtApi.DataStore.Crm
 
         Task<UpdateTeacherResult> UpdateTeacher(UpdateTeacherCommand command);
 
-        Task<Account> GetIttProviderOrganizationByName(string ukprn, params string[] columnNames);
+        Task<Account> GetIttProviderOrganizationByName(string ukprn, bool activeOnly, params string[] columnNames);
 
-        Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, params string[] columnNames);
+        Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, bool activeOnly, params string[] columnNames);
 
-        Task<Account> GetOrganizationByName(string providerName, params string[] columnNames);
+        Task<Account> GetOrganizationByName(string providerName, bool activeOnly, params string[] columnNames);
 
         Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames);
 

--- a/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
+++ b/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
@@ -27,7 +27,7 @@ namespace DqtApi.V2.Handlers
 
             if (!string.IsNullOrEmpty(request.IttProviderUkprn))
             {
-                ittProvider = await _dataverseAdapter.GetIttProviderOrganizationByUkprn(request.IttProviderUkprn);
+                ittProvider = await _dataverseAdapter.GetIttProviderOrganizationByUkprn(request.IttProviderUkprn, false);
 
                 if (ittProvider == null)
                 {
@@ -36,7 +36,7 @@ namespace DqtApi.V2.Handlers
             }
             else if (!string.IsNullOrEmpty(request.IttProviderName))
             {
-                ittProvider = await _dataverseAdapter.GetIttProviderOrganizationByName(request.IttProviderName);
+                ittProvider = await _dataverseAdapter.GetIttProviderOrganizationByName(request.IttProviderName, false);
 
                 if (ittProvider == null)
                 {

--- a/src/DqtApi/V2/Handlers/GetIttProvidersHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetIttProvidersHandler.cs
@@ -19,7 +19,7 @@ namespace DqtApi.V2.Handlers
 
         public async Task<GetIttProvidersResponse> Handle(GetIttProvidersRequest request, CancellationToken cancellationToken)
         {
-            var ittProviders = await _dataverseAdapter.GetIttProviders();
+            var ittProviders = await _dataverseAdapter.GetIttProviders(false);
 
             return new GetIttProvidersResponse()
             {

--- a/tests/DqtApi.Tests/DataverseIntegration/GetIttProvidersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetIttProvidersTests.cs
@@ -24,7 +24,7 @@ namespace DqtApi.Tests.DataverseIntegration
             // Arrange
 
             // Act
-            var result = await _dataverseAdapter.GetIttProviders();
+            var result = await _dataverseAdapter.GetIttProviders(false);
 
             // Assert
             Assert.NotEmpty(result);

--- a/tests/DqtApi.Tests/TestDataHelper.CreatePerson.cs
+++ b/tests/DqtApi.Tests/TestDataHelper.CreatePerson.cs
@@ -161,7 +161,6 @@ namespace DqtApi.Tests
                     }
                 });
             }
-
             await txnRequestBuilder.Execute();
 
             var ittId = createIttTask.GetResponse().id;

--- a/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -135,11 +135,11 @@ namespace DqtApi.Tests.V2.Operations
             var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 1, 1), dfeta_TRN = "someReference" };
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetIttProviderOrganizationByName(It.IsAny<string>()))
+                .Setup(mock => mock.GetIttProviderOrganizationByName(It.IsAny<string>(), false))
                 .ReturnsAsync(account);
 
             ApiFixture.DataverseAdapter
-                 .Setup(mock => mock.GetIttProviderOrganizationByUkprn(It.IsAny<string>()))
+                 .Setup(mock => mock.GetIttProviderOrganizationByUkprn(It.IsAny<string>(), false))
                  .ReturnsAsync(account);
 
             ApiFixture.DataverseAdapter

--- a/tests/DqtApi.Tests/V2/Operations/GetIttProvidersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/GetIttProvidersTests.cs
@@ -31,7 +31,7 @@ namespace DqtApi.Tests.V2.Operations
             };
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetIttProviders())
+                .Setup(mock => mock.GetIttProviders(false))
                 .ReturnsAsync(new[] { provider1, provider2 });
 
             var request = new HttpRequestMessage(HttpMethod.Get, "/v2/itt-providers");


### PR DESCRIPTION
added activeOnly field for get GetIttProviderOrganizationByName & Get…

### Context
https://trello.com/c/PQTH8vDN/409-include-inactive-itt-providers-in-find-api-operation

### Changes proposed in this pull request

added activeOnly field for get GetIttProviderOrganizationByName & Get…

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
