### PR TITLE
Fix GetProvider* queries to return an array

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -455,7 +455,8 @@ namespace DqtApi.DataStore.Crm
                     _command.InitialTeacherTraining.ProviderUkprn,
                     ukprn => _dataverseAdapter._cache.GetOrCreateAsync(
                         CacheKeys.GetIttProviderOrganizationByUkprnKey(ukprn),
-                        _ => _dataverseAdapter.GetIttProviderOrganizationByUkprn(ukprn, true, columnNames: Array.Empty<string>(), requestBuilder)));
+                        _ => _dataverseAdapter.GetIttProviderOrganizationsByUkprn(ukprn, true, columnNames: Array.Empty<string>(), requestBuilder)
+                            .ContinueWith(t => t.Result.SingleOrDefault())));
 
                 var getIttCountryTask = Let(
                     "XK",  // XK == 'United Kingdom'
@@ -498,7 +499,8 @@ namespace DqtApi.DataStore.Crm
                         _command.Qualification.ProviderUkprn,
                         ukprn => _dataverseAdapter._cache.GetOrCreateAsync(
                             CacheKeys.GetOrganizationByUkprnKey(ukprn),
-                            _ => _dataverseAdapter.GetOrganizationByUkprn(ukprn, columnNames: Array.Empty<string>(), requestBuilder))) :
+                            _ => _dataverseAdapter.GetOrganizationsByUkprn(ukprn, columnNames: Array.Empty<string>(), requestBuilder)
+                                .ContinueWith(t => t.Result.SingleOrDefault()))) :
                     null;
 
                 var getQualificationCountryTask = !string.IsNullOrEmpty(_command.Qualification?.CountryCode) ?

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
@@ -250,7 +250,8 @@ namespace DqtApi.DataStore.Crm
                         Contact.Fields.dfeta_TRN
                     });
 
-                var getIttProviderTask = _dataverseAdapter.GetIttProviderOrganizationByUkprn(_ittProviderUkprn, true);
+                var getIttProviderTask = _dataverseAdapter.GetIttProviderOrganizationsByUkprn(_ittProviderUkprn, activeOnly: true)
+                    .ContinueWith(t => t.Result.SingleOrDefault());
 
                 var getIttRecordsTask = _dataverseAdapter.GetInitialTeacherTrainingByTeacher(
                     _teacherId,

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
@@ -463,14 +463,14 @@ namespace DqtApi.DataStore.Crm
                     _command.InitialTeacherTraining.ProviderUkprn,
                     ukprn => _dataverseAdapter._cache.GetOrCreateAsync(
                         CacheKeys.GetIttProviderOrganizationByUkprnKey(ukprn),
-                        _ => _dataverseAdapter.GetIttProviderOrganizationByUkprn(ukprn, true)));
+                        _ => _dataverseAdapter.GetIttProviderOrganizationsByUkprn(ukprn, true).ContinueWith(t => t.Result.SingleOrDefault())));
 
                 var getQualificationProviderTask = !string.IsNullOrEmpty(_command.Qualification?.ProviderUkprn) ?
                      Let(
                          _command.Qualification.ProviderUkprn,
                          ukprn => _dataverseAdapter._cache.GetOrCreateAsync(
                              CacheKeys.GetOrganizationByUkprnKey(ukprn),
-                             _ => _dataverseAdapter.GetOrganizationByUkprn(ukprn))) :
+                             _ => _dataverseAdapter.GetOrganizationsByUkprn(ukprn).ContinueWith(t => t.Result.SingleOrDefault()))) :
                      null;
 
                 var getIttCountryTask = Let(

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -337,10 +337,10 @@ namespace DqtApi.DataStore.Crm
             }
         }
 
-        public Task<Account> GetIttProviderOrganizationByName(string name, bool activeOnly, params string[] columnNames) =>
-            GetIttProviderOrganizationByName(name, activeOnly, columnNames, requestBuilder: null);
+        public Task<Account[]> GetIttProviderOrganizationsByName(string name, bool activeOnly, params string[] columnNames) =>
+            GetIttProviderOrganizationsByName(name, activeOnly, columnNames, requestBuilder: null);
 
-        public async Task<Account> GetIttProviderOrganizationByName(string name, bool activeOnly, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account[]> GetIttProviderOrganizationsByName(string name, bool activeOnly, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -364,13 +364,13 @@ namespace DqtApi.DataStore.Crm
 
             var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
 
-            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).ToArray();
         }
 
-        public Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, bool activeOnly, params string[] columnNames) =>
-            GetIttProviderOrganizationByUkprn(ukprn, activeOnly, columnNames, requestBuilder: null);
+        public Task<Account[]> GetIttProviderOrganizationsByUkprn(string ukprn, bool activeOnly, params string[] columnNames) =>
+            GetIttProviderOrganizationsByUkprn(ukprn, activeOnly, columnNames, requestBuilder: null);
 
-        public async Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, bool activeOnly, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account[]> GetIttProviderOrganizationsByUkprn(string ukprn, bool activeOnly, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -392,13 +392,13 @@ namespace DqtApi.DataStore.Crm
 
             var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
 
-            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).ToArray();
         }
 
-        public Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames) =>
-            GetOrganizationByUkprn(ukprn, columnNames, requestBuilder: null);
+        public Task<Account[]> GetOrganizationsByUkprn(string ukprn, params string[] columnNames) =>
+            GetOrganizationsByUkprn(ukprn, columnNames, requestBuilder: null);
 
-        public async Task<Account> GetOrganizationByUkprn(string ukprn, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account[]> GetOrganizationsByUkprn(string ukprn, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -417,7 +417,7 @@ namespace DqtApi.DataStore.Crm
 
             var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
 
-            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).ToArray();
         }
 
         public Task<dfeta_qtsregistration[]> GetQtsRegistrationsByTeacher(
@@ -654,10 +654,10 @@ namespace DqtApi.DataStore.Crm
             }
         }
 
-        public Task<Account> GetOrganizationByName(string name, bool activeOnly, params string[] columnNames) =>
-            GetOrganizationByName(name, activeOnly, columnNames, requestBuilder: null);
+        public Task<Account[]> GetOrganizationsByName(string name, bool activeOnly, params string[] columnNames) =>
+            GetOrganizationsByName(name, activeOnly, columnNames, requestBuilder: null);
 
-        public async Task<Account> GetOrganizationByName(string name, bool activeOnly, string[] columnNames, RequestBuilder requestBuilder)
+        public async Task<Account[]> GetOrganizationsByName(string name, bool activeOnly, string[] columnNames, RequestBuilder requestBuilder)
         {
             requestBuilder ??= RequestBuilder.CreateSingle(_service);
 
@@ -678,7 +678,7 @@ namespace DqtApi.DataStore.Crm
 
             var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
 
-            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).SingleOrDefault();
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<Account>()).ToArray();
         }
 
         public async Task<Contact[]> FindTeachers(FindTeachersQuery findTeachersQuery)
@@ -740,8 +740,9 @@ namespace DqtApi.DataStore.Crm
             }
 
             LinkEntity ittProviderLink = null;
+            var ittProviderOrganizationIdsArray = findTeachersQuery.IttProviderOrganizationIds?.ToArray() ?? Array.Empty<Guid>();
 
-            if (findTeachersQuery.IttProviderOrganizationId.HasValue)
+            if (ittProviderOrganizationIdsArray.Length > 0)
             {
                 ittProviderLink = new LinkEntity(
                     Contact.EntityLogicalName,
@@ -757,8 +758,8 @@ namespace DqtApi.DataStore.Crm
                     new ConditionExpression(
                         dfeta_initialteachertraining.EntityLogicalName,
                         dfeta_initialteachertraining.Fields.dfeta_EstablishmentId,
-                        ConditionOperator.Equal,
-                        findTeachersQuery.IttProviderOrganizationId));
+                        ConditionOperator.In,
+                        ittProviderOrganizationIdsArray.Cast<object>().ToArray()));  // https://community.dynamics.com/crm/b/crmbusiness/posts/crm-2011-odd-error-with-query-expression-and-conditionoperator-in
             }
 
             // If we still don't have at least 3 identifiers to match on then we're done

--- a/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
@@ -24,13 +24,13 @@ namespace DqtApi.DataStore.Crm
 
         Task<UpdateTeacherResult> UpdateTeacher(UpdateTeacherCommand command);
 
-        Task<Account> GetIttProviderOrganizationByName(string ukprn, bool activeOnly, params string[] columnNames);
+        Task<Account[]> GetIttProviderOrganizationsByName(string ukprn, bool activeOnly, params string[] columnNames);
 
-        Task<Account> GetIttProviderOrganizationByUkprn(string ukprn, bool activeOnly, params string[] columnNames);
+        Task<Account[]> GetIttProviderOrganizationsByUkprn(string ukprn, bool activeOnly, params string[] columnNames);
 
-        Task<Account> GetOrganizationByName(string providerName, bool activeOnly, params string[] columnNames);
+        Task<Account[]> GetOrganizationsByName(string providerName, bool activeOnly, params string[] columnNames);
 
-        Task<Account> GetOrganizationByUkprn(string ukprn, params string[] columnNames);
+        Task<Account[]> GetOrganizationsByUkprn(string ukprn, params string[] columnNames);
 
         Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, params string[] columnNames);
 

--- a/src/DqtApi/DataStore/Crm/Models/FindTeachersQuery.cs
+++ b/src/DqtApi/DataStore/Crm/Models/FindTeachersQuery.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace DqtApi.DataStore.Crm
 {
@@ -10,6 +11,6 @@ namespace DqtApi.DataStore.Crm
         public string PreviousLastName { get; set; }
         public DateOnly? DateOfBirth { get; set; }
         public string NationalInsuranceNumber { get; set; }
-        public Guid? IttProviderOrganizationId { get; set; }
+        public IEnumerable<Guid> IttProviderOrganizationIds { get; set; }
     }
 }

--- a/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
+++ b/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
@@ -23,22 +23,22 @@ namespace DqtApi.V2.Handlers
 
         public async Task<FindTeachersResponse> Handle(FindTeachersRequest request, CancellationToken cancellationToken)
         {
-            Account ittProvider = null;
+            var ittProviders = Array.Empty<Account>();
 
             if (!string.IsNullOrEmpty(request.IttProviderUkprn))
             {
-                ittProvider = await _dataverseAdapter.GetIttProviderOrganizationByUkprn(request.IttProviderUkprn, false);
+                ittProviders = await _dataverseAdapter.GetIttProviderOrganizationsByUkprn(request.IttProviderUkprn, false);
 
-                if (ittProvider == null)
+                if (ittProviders.Length == 0)
                 {
                     throw new ErrorException(ErrorRegistry.OrganisationNotFound());
                 }
             }
             else if (!string.IsNullOrEmpty(request.IttProviderName))
             {
-                ittProvider = await _dataverseAdapter.GetIttProviderOrganizationByName(request.IttProviderName, false);
+                ittProviders = await _dataverseAdapter.GetIttProviderOrganizationsByName(request.IttProviderName, false);
 
-                if (ittProvider == null)
+                if (ittProviders.Length == 0)
                 {
                     throw new ErrorException(ErrorRegistry.OrganisationNotFound());
                 }
@@ -52,7 +52,7 @@ namespace DqtApi.V2.Handlers
                 PreviousLastName = request.PreviousLastName,
                 NationalInsuranceNumber = request.NationalInsuranceNumber,
                 DateOfBirth = request.DateOfBirth,
-                IttProviderOrganizationId = ittProvider != null ? ittProvider.Id : null
+                IttProviderOrganizationIds = ittProviders.Select(a => a.Id)
             };
 
             var result = await _dataverseAdapter.FindTeachers(query);

--- a/tests/DqtApi.Tests/DataverseIntegration/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/FindTeachersTests.cs
@@ -96,7 +96,7 @@ namespace DqtApi.Tests.DataverseIntegration
                     }),
                 ((FindTeachersQuery q) => q.DateOfBirth = _findTeachersFixture.MatchingTeacherBirthDate, (FindTeachersQuery q) => q.DateOfBirth = _findTeachersFixture.MatchingTeacherBirthDate.AddDays(1)),
                 ((FindTeachersQuery q) => q.NationalInsuranceNumber = _findTeachersFixture.MatchingTeacherNino, (FindTeachersQuery q) => q.NationalInsuranceNumber = "ABC"),
-                ((FindTeachersQuery q) => q.IttProviderOrganizationId = _findTeachersFixture.MatchingTeacherIttProviderId, (FindTeachersQuery q) => q.IttProviderOrganizationId = Guid.NewGuid()),
+                ((FindTeachersQuery q) => q.IttProviderOrganizationIds = new[] { _findTeachersFixture.MatchingTeacherIttProviderId }, (FindTeachersQuery q) => q.IttProviderOrganizationIds = new[] { Guid.NewGuid() }),
             };
 
             var combinations = fields.GetCombinations(matchingFieldsCount);

--- a/tests/DqtApi.Tests/DataverseIntegration/GetOrganizationsByUkprnTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetOrganizationsByUkprnTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
-    public class GetOrganizationByUkprnTests : IAsyncLifetime
+    public class GetOrganizationsByUkprnTests : IAsyncLifetime
     {
         private readonly CrmClientFixture.TestDataScope _dataScope;
         private readonly DataverseAdapter _dataverseAdapter;
 
-        public GetOrganizationByUkprnTests(CrmClientFixture crmClientFixture)
+        public GetOrganizationsByUkprnTests(CrmClientFixture crmClientFixture)
         {
             _dataScope = crmClientFixture.CreateTestDataScope();
             _dataverseAdapter = _dataScope.CreateDataverseAdapter();
@@ -26,11 +26,12 @@ namespace DqtApi.Tests.DataverseIntegration
             var ukprn = "10044534";
 
             // Act
-            var result = await _dataverseAdapter.GetOrganizationByUkprn(ukprn, columnNames: Account.Fields.dfeta_UKPRN);
+            var result = await _dataverseAdapter.GetOrganizationsByUkprn(ukprn, columnNames: Account.Fields.dfeta_UKPRN);
 
             // Assert
-            Assert.NotNull(result);
-            Assert.Equal(ukprn, result.dfeta_UKPRN);
+            Assert.Collection(
+                result,
+                record => Assert.Equal(ukprn, record.dfeta_UKPRN));
         }
 
         [Fact]
@@ -40,10 +41,10 @@ namespace DqtApi.Tests.DataverseIntegration
             var ukprn = "xxx";
 
             // Act
-            var result = await _dataverseAdapter.GetOrganizationByUkprn(ukprn, columnNames: Account.Fields.dfeta_UKPRN);
+            var result = await _dataverseAdapter.GetOrganizationsByUkprn(ukprn, columnNames: Account.Fields.dfeta_UKPRN);
 
             // Assert
-            Assert.Null(result);
+            Assert.Empty(result);
         }
     }
 }

--- a/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
@@ -287,7 +287,7 @@ namespace DqtApi.Tests.DataverseIntegration
                 }
             });
 
-            var oldProvider = (await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn)).Id;
+            var oldProvider = (await _dataverseAdapter.GetOrganizationsByUkprn(ittProviderUkprn)).Single().Id;
 
             var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,
@@ -377,7 +377,7 @@ namespace DqtApi.Tests.DataverseIntegration
                 }
             });
 
-            var oldProvider = (await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn)).Id;
+            var oldProvider = (await _dataverseAdapter.GetOrganizationsByUkprn(ittProviderUkprn)).Single().Id;
 
             var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,
@@ -581,7 +581,7 @@ namespace DqtApi.Tests.DataverseIntegration
 
             var countryId = await _dataverseAdapter.GetCountry("XK");
             var qualificationSubject1Id = await _dataverseAdapter.GetHeSubjectByCode("100366");  // computer science
-            var providerId = await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn);
+            var providerId = (await _dataverseAdapter.GetOrganizationsByUkprn(ittProviderUkprn)).Single();
             var qualification = await _dataverseAdapter.GetHeQualificationByName("First Degree");
 
             var txnResponse = (ExecuteTransactionResponse)await _organizationService.ExecuteAsync(new ExecuteTransactionRequest()
@@ -777,7 +777,7 @@ namespace DqtApi.Tests.DataverseIntegration
             // Arrange
             var (teacherId, ittProviderUkprn) = await CreatePerson(earlyYears: true, hasActiveSanctions: false);
 
-            var providerId = await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn);
+            var providerId = (await _dataverseAdapter.GetOrganizationsByUkprn(ittProviderUkprn)).Single();
 
             // Create second Itt record
             await _organizationService.ExecuteAsync(new CreateRequest()
@@ -918,7 +918,7 @@ namespace DqtApi.Tests.DataverseIntegration
                 }
             });
 
-            var oldProvider = (await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn)).Id;
+            var oldProvider = (await _dataverseAdapter.GetOrganizationsByUkprn(ittProviderUkprn)).Single().Id;
 
             var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,
@@ -1101,8 +1101,8 @@ namespace DqtApi.Tests.DataverseIntegration
                 }
             });
 
-            var oldProvider = (await _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn)).Id;
-            var newProviderProvider = (await _dataverseAdapter.GetOrganizationByUkprn(newIttProviderUkprn)).Id;
+            var oldProvider = (await _dataverseAdapter.GetOrganizationsByUkprn(ittProviderUkprn)).Single().Id;
+            var newProviderProvider = (await _dataverseAdapter.GetOrganizationsByUkprn(newIttProviderUkprn)).Single().Id;
 
             var qualifications = await _dataverseAdapter.GetQualificationsForTeacher(
                 teacherId,

--- a/tests/DqtApi.Tests/TestDataHelper.CreatePerson.cs
+++ b/tests/DqtApi.Tests/TestDataHelper.CreatePerson.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm.Models;
 using Microsoft.Extensions.Caching.Memory;
@@ -38,7 +39,8 @@ namespace DqtApi.Tests
 
             var getIttProviderTask = _globalCache.GetOrCreateAsync(
                 CacheKeys.GetIttProviderOrganizationByUkprnKey(ittProviderUkprn),
-                _ => _dataverseAdapter.GetOrganizationByUkprn(ittProviderUkprn, columnNames: Array.Empty<string>(), lookupRequestBuilder));
+                _ => _dataverseAdapter.GetOrganizationsByUkprn(ittProviderUkprn, columnNames: Array.Empty<string>(), lookupRequestBuilder)
+                    .ContinueWith(t => t.Result.SingleOrDefault()));
 
             var earlyYearsStatus = "220"; // 220 == 'Early Years Trainee'
 

--- a/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -135,12 +135,12 @@ namespace DqtApi.Tests.V2.Operations
             var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 1, 1), dfeta_TRN = "someReference" };
 
             ApiFixture.DataverseAdapter
-                .Setup(mock => mock.GetIttProviderOrganizationByName(It.IsAny<string>(), false))
-                .ReturnsAsync(account);
+                .Setup(mock => mock.GetIttProviderOrganizationsByName(It.IsAny<string>(), false))
+                .ReturnsAsync(new[] { account });
 
             ApiFixture.DataverseAdapter
-                 .Setup(mock => mock.GetIttProviderOrganizationByUkprn(It.IsAny<string>(), false))
-                 .ReturnsAsync(account);
+                 .Setup(mock => mock.GetIttProviderOrganizationsByUkprn(It.IsAny<string>(), false))
+                 .ReturnsAsync(new[] { account });
 
             ApiFixture.DataverseAdapter
                 .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))


### PR DESCRIPTION
In some cases there are multiple providers for a given set of criteria
(now we're returning Inactive records too).

### Context

https://sentry.io/organizations/dfe-teacher-services/issues/3278065486/?project=6165440&referrer=slack

### Changes proposed in this pull request

Change `GetOrganization*` methods to return `Account[]` instead of `Account`.

### Checklist

~~-   [ ] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
