### PR TITLE
Add additional values for gender

### DIFF
--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -544,7 +544,9 @@
         "enum": [
           "Male",
           "Female",
-          "Other"
+          "Other",
+          "NotProvided",
+          "NotAvailable"
         ],
         "type": "string"
       },

--- a/src/DqtApi/DataStore/Crm/Models/GeneratedOptionSets.cs
+++ b/src/DqtApi/DataStore/Crm/Models/GeneratedOptionSets.cs
@@ -739,6 +739,14 @@ namespace DqtApi.DataStore.Crm.Models
 		Male = 1,
 		
 		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Not available", 4, "#0000ff")]
+		Notavailable = 389040002,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Not provided", 3, "#0000ff")]
+		Notprovided = 389040001,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
 		[OptionSetMetadataAttribute("Other", 2)]
 		Other = 389040000,
 	}
@@ -1748,6 +1756,32 @@ namespace DqtApi.DataStore.Crm.Models
 	}
 	
 	[System.Runtime.Serialization.DataContractAttribute()]
+	public enum dfeta_sanction_StatusCode
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Active", 0)]
+		Active = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Inactive", 1)]
+		Inactive = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	public enum dfeta_sanctioncode_StatusCode
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Active", 0)]
+		Active = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Inactive", 1)]
+		Inactive = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
 	public enum dfeta_teacherstatus_StatusCode
 	{
 		
@@ -1821,5 +1855,43 @@ namespace DqtApi.DataStore.Crm.Models
 		[System.Runtime.Serialization.EnumMemberAttribute()]
 		[OptionSetMetadataAttribute("Mail App", 2, "#0000ff")]
 		MailApp = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	public enum msdyn_forecastsettingsandsummary_msdyn_ForecastJobStatus
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Success", 0, "#0000ff")]
+		Success = 192350000,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Data Failure", 1, "#0000ff")]
+		DataFailure = 192350001,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Pipeline Failure", 2, "#0000ff")]
+		PipelineFailure = 192350002,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	public enum msdyn_knowledgemanagementsetting_msdyn_actionlist
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Link / unlink article", 0, "#0000ff")]
+		Linkunlinkarticle = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Copy URL", 1, "#0000ff")]
+		CopyURL = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Link article and email URL", 2, "#0000ff")]
+		LinkarticleandemailURL = 2,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Link article and send article content", 3, "#0000ff")]
+		Linkarticleandsendarticlecontent = 3,
 	}
 }

--- a/src/DqtApi/V2/ApiModels/Gender.cs
+++ b/src/DqtApi/V2/ApiModels/Gender.cs
@@ -6,7 +6,9 @@ namespace DqtApi.V2.ApiModels
     {
         Male = 1,
         Female = 2,
-        Other = 389040000
+        Other = 389040000,
+        NotAvailable = 389040002,
+        NotProvided = 389040001,
     }
 
     public static class GenderExtensions


### PR DESCRIPTION
### Context

https://trello.com/c/GnZ9EmFw/268-align-dqt-values-for-gender-with-register-and-hesa

### Changes proposed in this pull request

Adds two additional values for `gender` - `NotProvided` and `NotAvailable`.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
