### PR TITLE
support multiple apikeys

### DIFF
--- a/src/DqtApi/Security/ApiClient.cs
+++ b/src/DqtApi/Security/ApiClient.cs
@@ -1,8 +1,10 @@
-﻿namespace DqtApi.Security
+﻿using System.Collections.Generic;
+
+namespace DqtApi.Security
 {
     public class ApiClient
     {
         public string ClientId { get; set; }
-        public string ApiKey { get; set; }
+        public List<string> ApiKey { get; set; }
     }
 }

--- a/src/DqtApi/Security/ConfigurationApiClientRepository.cs
+++ b/src/DqtApi/Security/ConfigurationApiClientRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 
 namespace DqtApi.Security
@@ -14,22 +15,25 @@ namespace DqtApi.Security
             _clients = GetClientsFromConfiguration(configuration);
         }
 
-        public ApiClient GetClientByKey(string apiKey) => _clients.SingleOrDefault(c => c.ApiKey == apiKey);
+        public ApiClient GetClientByKey(string apiKey) => _clients.SingleOrDefault(c => c.ApiKey.Any(x => x == apiKey));
 
         private static ApiClient[] GetClientsFromConfiguration(IConfiguration configuration)
         {
             var section = configuration.GetSection(ConfigurationSection);
-
             return section.GetChildren().AsEnumerable()
-                .Select(kvp =>
+                .Select((kvp, value) =>
                 {
                     var clientId = kvp.Key;
-
+                    var apiKey = kvp.GetSection("apiKey").Value;
                     var client = new ApiClient()
                     {
-                        ClientId = clientId
+                        ClientId = clientId,
+                        ApiKey = new List<string>()
+
                     };
                     kvp.Bind(client);
+                    if (!client.ApiKey.Any() && !string.IsNullOrEmpty(apiKey))
+                        client.ApiKey.Add(apiKey);
 
                     return client;
                 })

--- a/src/DqtApi/appsettings.Development.json
+++ b/src/DqtApi/appsettings.Development.json
@@ -15,7 +15,7 @@
   },
   "ApiClients": {
     "developer": {
-      "ApiKey": "developer"
+      "ApiKey": [ "developer" ] 
     }
   }
 }

--- a/src/DqtApi/appsettings.Testing.json
+++ b/src/DqtApi/appsettings.Testing.json
@@ -1,7 +1,7 @@
 {
   "ApiClients": {
     "tests": {
-      "ApiKey": "tests"
+      "ApiKey": [ "tests" ]
     }
   }
 }


### PR DESCRIPTION
### Context

Support multiple api keys

https://trello.com/c/fBsebtXB/451-support-multiple-keys-per-client-in-dqt

### Changes proposed in this pull request

Allow multiple api keys so that keys can be pulled/swapped out.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
