### PR TITLE
Add workflow_dispatch trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
     - main
+  workflow_dispatch:
+    inputs:
+      deploy_to_prod:
+        type: boolean
+        description: 'Deploy to production'
+        default: false
 
 env:
   CONTAINER_REGISTRY: ghcr.io
@@ -161,7 +167,7 @@ jobs:
     name: Deploy to dev environment
     needs: [build, validate_terraform]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
     environment:
       name: dev
       url: ${{ steps.deploy.outputs.environment_url }}
@@ -237,7 +243,7 @@ jobs:
     name: Deploy to test environment
     needs: [build, validate_terraform]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     environment:
       name: test
       url: ${{ steps.deploy.outputs.environment_url }}
@@ -262,7 +268,7 @@ jobs:
     name: Deploy to pre-production environment
     needs: [build, deploy_test]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     environment:
       name: pre-production
       url: ${{ steps.deploy.outputs.environment_url }}
@@ -287,7 +293,7 @@ jobs:
     name: Deploy to production environment
     needs: [build, deploy_preprod]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_to_prod == 'true')
     environment:
       name: production
       url: ${{ steps.deploy.outputs.environment_url }}


### PR DESCRIPTION
This is to aid testing changes up to the pre-prod environment.

Deploying to production is controlled by an option ('false' by default).