### PR TITLE
Add new itt programmetypes

### DIFF
--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -846,7 +846,9 @@
           "EYITTUndergraduate",
           "EYITTSchoolDirectEarlyYears",
           "Apprenticeship",
-          "FutureTeachingScholars"
+          "FutureTeachingScholars",
+          "ProviderLedPostgrad",
+          "ProviderLedUndergrad"
         ],
         "type": "string"
       },

--- a/src/DqtApi/DataStore/Crm/Models/GeneratedOptionSets.cs
+++ b/src/DqtApi/DataStore/Crm/Models/GeneratedOptionSets.cs
@@ -1485,6 +1485,19 @@ namespace DqtApi.DataStore.Crm.Models
 	}
 	
 	[System.Runtime.Serialization.DataContractAttribute()]
+	public enum dfeta_ittqualification_StatusCode
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Active", 0)]
+		Active = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Inactive", 1)]
+		Inactive = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
 	public enum dfeta_ITTQualificationAim
 	{
 		

--- a/src/DqtApi/V2/ApiModels/IttProgrammeType.cs
+++ b/src/DqtApi/V2/ApiModels/IttProgrammeType.cs
@@ -67,6 +67,12 @@ namespace DqtApi.V2.ApiModels
 
         [Description("Undergraduate Opt In")]
         UndergraduateOptIn = 389040013,
+
+        [Description("Provider-led (postgrad)")]
+        ProviderLedPostgrad = 389040021,
+
+        [Description("Provider-led (undergrad)")]
+        ProviderLedUndergrad = 389040022,
     }
 
     public static class IttProgrammeTypeExtensions

--- a/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -249,6 +249,8 @@ namespace DqtApi.Tests.DataverseIntegration
         [InlineData(dfeta_ITTProgrammeType.TeachFirstProgramme, dfeta_ITTResult.InTraining)]
         [InlineData(dfeta_ITTProgrammeType.TeachFirstProgramme_CC, dfeta_ITTResult.InTraining)]
         [InlineData(dfeta_ITTProgrammeType.UndergraduateOptIn, dfeta_ITTResult.InTraining)]
+        [InlineData(dfeta_ITTProgrammeType.Providerled_postgrad, dfeta_ITTResult.InTraining)]
+        [InlineData(dfeta_ITTProgrammeType.Providerled_undergrad, dfeta_ITTResult.InTraining)]
         public void CreateInitialTeacherTrainingEntity_maps_entity_from_command_correctly(
             dfeta_ITTProgrammeType programmeType,
             dfeta_ITTResult expectedResult)

--- a/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
@@ -545,6 +545,8 @@ namespace DqtApi.Tests.DataverseIntegration
         [InlineData(dfeta_ITTProgrammeType.TeachFirstProgramme)]
         [InlineData(dfeta_ITTProgrammeType.TeachFirstProgramme_CC)]
         [InlineData(dfeta_ITTProgrammeType.UndergraduateOptIn)]
+        [InlineData(dfeta_ITTProgrammeType.Providerled_postgrad)]
+        [InlineData(dfeta_ITTProgrammeType.Providerled_undergrad)]
         public async Task Given_earlyyears_itt_cannot_change_eyts_programmetype_to_qts(dfeta_ITTProgrammeType programmeType)
         {
             // Arrange
@@ -710,6 +712,8 @@ namespace DqtApi.Tests.DataverseIntegration
         [InlineData(dfeta_ITTProgrammeType.TeachFirstProgramme, dfeta_ITTResult.InTraining)]
         [InlineData(dfeta_ITTProgrammeType.TeachFirstProgramme_CC, dfeta_ITTResult.InTraining)]
         [InlineData(dfeta_ITTProgrammeType.UndergraduateOptIn, dfeta_ITTResult.InTraining)]
+        [InlineData(dfeta_ITTProgrammeType.Providerled_postgrad, dfeta_ITTResult.InTraining)]
+        [InlineData(dfeta_ITTProgrammeType.Providerled_undergrad, dfeta_ITTResult.InTraining)]
         public async Task Given_there_are_no_records_matched_create_new_itt_with_correct_result_and_warning_crm_task(dfeta_ITTProgrammeType programmeType, dfeta_ITTResult ittResult)
         {
             // Arrange


### PR DESCRIPTION
### Context

https://trello.com/c/4lSfYUNW/485-create-new-itt-programme-types-in-dqt-for-provider-led-postgrad-and-provider-led-undergrad

added new programme type for itt provider in crm and generated option sets.

- provider-led (postgrad)
- provider-led (undergrad)

### Changes proposed in this pull request

added new programme type for itt provider in crm and generated option sets.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
