### PR TITLE
Shorten CRM timeouts

### DIFF
--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -301,15 +301,21 @@ namespace DqtApi
 
             app.Run();
 
-            ServiceClient GetCrmServiceClient() =>
-                new ServiceClient(
+            ServiceClient GetCrmServiceClient()
+            {
+                ServiceClient.MaxConnectionTimeout = TimeSpan.FromSeconds(30);
+
+                return new ServiceClient(
                     new Uri(configuration["CrmUrl"]),
                     configuration["CrmClientId"],
                     configuration["CrmClientSecret"],
                     useUniqueInstance: true)
                 {
-                    EnableAffinityCookie = false
+                    EnableAffinityCookie = false,
+                    MaxRetryCount = 2,
+                    RetryPauseTime = TimeSpan.FromSeconds(1)
                 };
+            }
 
             void ConfigureRateLimitServices()
             {


### PR DESCRIPTION
We have several errors in our logs around timeouts, many of which are in
excess of 5 minutes. We don't want requests running for anywhere near
that long as many clients will timeout long before that.

This shortens the connection timeout and reduces the retry count and
pause between each retry in order that we fail faster.