### PR TITLE
Handle missing InductionStatus on Get Teacher endpoint

### DIFF
--- a/src/DqtApi/V1/Handlers/GetTeacherHandler.cs
+++ b/src/DqtApi/V1/Handlers/GetTeacherHandler.cs
@@ -89,7 +89,9 @@ namespace DqtApi.V1.Handlers
                     {
                         StartDate = induction.dfeta_StartDate,
                         CompletionDate = induction.dfeta_CompletionDate,
-                        InductionStatusName = induction.FormattedValues[dfeta_induction.Fields.dfeta_InductionStatus],
+                        InductionStatusName = induction.FormattedValues.ContainsKey(dfeta_induction.Fields.dfeta_InductionStatus) ?
+                            induction.FormattedValues[dfeta_induction.Fields.dfeta_InductionStatus] :
+                            null,
                         State = induction.StateCode.Value,
                         StateName = induction.FormattedValues[dfeta_induction.Fields.StateCode]
                     } :


### PR DESCRIPTION
We have some errors in Sentry where a `contact` has an `Induction` but that `Induction` doesn't have an `InductionStatus`. This change is to handle that case and return null for `InductionStatusName`.