### PR TITLE
Restore the email field on the Find endpoint

### DIFF
--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -210,6 +210,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "description": "Email of person",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -721,6 +721,7 @@ namespace DqtApi.DataStore.Crm
 
             AddEqualCondition(Contact.Fields.BirthDate, findTeachersQuery.DateOfBirth?.ToDateTime());
             AddEqualCondition(Contact.Fields.dfeta_NINumber, findTeachersQuery.NationalInsuranceNumber);
+            AddEqualCondition(Contact.Fields.EMailAddress1, findTeachersQuery.EmailAddress);
 
             {
                 // Find all the permutations of names to match on

--- a/src/DqtApi/DataStore/Crm/Models/FindTeachersQuery.cs
+++ b/src/DqtApi/DataStore/Crm/Models/FindTeachersQuery.cs
@@ -12,5 +12,6 @@ namespace DqtApi.DataStore.Crm
         public DateOnly? DateOfBirth { get; set; }
         public string NationalInsuranceNumber { get; set; }
         public IEnumerable<Guid> IttProviderOrganizationIds { get; set; }
+        public string EmailAddress { get; set; }
     }
 }

--- a/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
+++ b/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
@@ -52,7 +52,8 @@ namespace DqtApi.V2.Handlers
                 PreviousLastName = request.PreviousLastName,
                 NationalInsuranceNumber = request.NationalInsuranceNumber,
                 DateOfBirth = request.DateOfBirth,
-                IttProviderOrganizationIds = ittProviders.Select(a => a.Id)
+                IttProviderOrganizationIds = ittProviders.Select(a => a.Id),
+                EmailAddress = request.EmailAddress
             };
 
             var result = await _dataverseAdapter.FindTeachers(query);

--- a/src/DqtApi/V2/Requests/FindTeachersRequest.cs
+++ b/src/DqtApi/V2/Requests/FindTeachersRequest.cs
@@ -40,5 +40,9 @@ namespace DqtApi.V2.Requests
         [SwaggerParameter(Description = "UKPRN of teacher training provider")]
         [FromQuery(Name = "ittProviderUkprn")]
         public string IttProviderUkprn { get; set; }
+
+        [SwaggerParameter(Description = "Email of person")]
+        [FromQuery(Name = "email")]
+        public string EmailAddress { get; set; }
     }
 }


### PR DESCRIPTION
### Context

https://trello.com/c/K7eLDbBh/563-re-enable-email-match-in-the-dqt-api

### Changes proposed in this pull request

Restore the `email` field on the 'find' endpoint.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
