### PR TITLE
Stop allowing a teacher to be unlocked when it has active sanctions

### DIFF
--- a/src/DqtApi/Properties/StringResources.Designer.cs
+++ b/src/DqtApi/Properties/StringResources.Designer.cs
@@ -248,5 +248,14 @@ namespace DqtApi.Properties {
                 return ResourceManager.GetString("Errors.10013.Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to unlock teacher with active sanctions.
+        /// </summary>
+        public static string Errors_10014_Title {
+            get {
+                return ResourceManager.GetString("Errors.10014.Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/DqtApi/Properties/StringResources.resx
+++ b/src/DqtApi/Properties/StringResources.resx
@@ -180,4 +180,7 @@
   <data name="Errors.10013.Title" xml:space="preserve">
     <value>HE qualification not found</value>
   </data>
+  <data name="Errors.10014.Title" xml:space="preserve">
+    <value>Unable to unlock teacher with active sanctions</value>
+  </data>
 </root>

--- a/src/DqtApi/Validation/ErrorRegistry.cs
+++ b/src/DqtApi/Validation/ErrorRegistry.cs
@@ -19,7 +19,8 @@ namespace DqtApi.Validation
             ErrorDescriptor.Create(10010),  // County not found,
             ErrorDescriptor.Create(10011),  // Cannot change Programme Type 
             ErrorDescriptor.Create(10012),  // ITT qualification not found
-            ErrorDescriptor.Create(10013),  // HE qualification not found
+            ErrorDescriptor.Create(10013),  // HE qualification not found,
+            ErrorDescriptor.Create(10014),  // teacher has active sanctions
         }.ToDictionary(d => d.ErrorCode, d => d);
 
         public static Error TeacherWithSpecifiedTrnNotFound() => CreateError(10001);
@@ -47,6 +48,8 @@ namespace DqtApi.Validation
         public static Error IttQualificationNotFound() => CreateError(10012);
 
         public static Error HeQualificationNotFound() => CreateError(10013);
+
+        public static Error TeacherHasActiveSanctions() => CreateError(10014);
 
         private static Error CreateError(int errorCode)
         {

--- a/tests/DqtApi.Tests/V2/Operations/UnlockTeacherTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/UnlockTeacherTests.cs
@@ -2,6 +2,9 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using DqtApi.DataStore.Crm.Models;
+using DqtApi.TestCommon;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
 
@@ -51,6 +54,26 @@ namespace DqtApi.Tests.V2.Operations
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
             ApiFixture.DataverseAdapter.Verify();
+        }
+
+        [Fact]
+        public async Task Given_a_teacher_that_has_activesanctions_returns_error()
+        {
+            // Arrange
+            var teacherId = Guid.NewGuid();
+            var teacher = new Contact() { dfeta_ActiveSanctions = true };
+
+            ApiFixture.DataverseAdapter
+                .Setup(mock => mock.GetTeacher(teacherId, It.IsAny<bool>(), It.IsAny<string[]>()))
+                .ReturnsAsync(teacher);
+
+            var request = new HttpRequestMessage(HttpMethod.Put, $"v2/unlock-teacher/{teacherId}");
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            await AssertEx.ResponseIsError(response, errorCode: 10014, expectedStatusCode: StatusCodes.Status400BadRequest);
         }
     }
 }


### PR DESCRIPTION
### Context
https://trello.com/c/o7Zr0VuL/605-prevent-unlocking-a-teacher-with-active-sanctions

Stop allowing a teacher account to be unlocked when there are active sanctions.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
