### PR TITLE
Split FirstName for HESA trainees

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -400,7 +400,7 @@ namespace DqtApi.DataStore.Crm
                     }.ToList();
 
                     // If fields are null in the input then don't try to match them (typically MiddleName)
-                    fields.RemoveAll(f => f.Value == null);
+                    fields.RemoveAll(f => f.Value == null || (f.Value is string stringValue && string.IsNullOrEmpty(stringValue)));
 
                     var combinations = fields.GetCombinations(length: 3).ToArray();
 

--- a/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm;
@@ -61,11 +62,23 @@ namespace DqtApi.V2.Handlers
             }
             else
             {
+                var firstName = request.FirstName;
+                var middleName = request.MiddleName ?? string.Empty;
+                var lastName = request.LastName;
+
+                var isHesaTrainee = !string.IsNullOrEmpty(request.HusId);
+                if (isHesaTrainee)
+                {
+                    var firstAndMiddleNames = $"{firstName} {middleName}".Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    firstName = firstAndMiddleNames[0];
+                    middleName = string.Join(" ", firstAndMiddleNames.Skip(1));
+                }
+
                 var createTeacherResult = await _dataverseAdapter.CreateTeacher(new CreateTeacherCommand()
                 {
-                    FirstName = request.FirstName,
-                    MiddleName = request.MiddleName,
-                    LastName = request.LastName,
+                    FirstName = firstName,
+                    MiddleName = middleName,
+                    LastName = lastName,
                     BirthDate = request.BirthDate.ToDateTime(),
                     EmailAddress = request.EmailAddress,
                     Address = new CreateTeacherCommandAddress()


### PR DESCRIPTION
### Context

https://trello.com/c/95M3M2vB/635-split-forenames-into-first-and-middle-names-for-hesa-trainees

The name passed from HESA is in a single field and Register split it into first & last name (they don't have middle name). This splits first name to populate middle name.

### Changes proposed in this pull request

Split first name and populate middle name for HESA trainees.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
