### PR TITLE
Adding missing security headers

### DIFF
--- a/src/DqtApi/Middleware/AppendSecurityResponseHeadersMiddleware.cs
+++ b/src/DqtApi/Middleware/AppendSecurityResponseHeadersMiddleware.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace DqtApi.Middleware
+{
+    public class AppendSecurityResponseHeadersMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public AppendSecurityResponseHeadersMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+            var response = context.Response;
+
+            if (!response.HasStarted)
+            {
+                response.Headers["X-Frame-Options"] = "DENY";
+                response.Headers["X-Xss-Protection"] = "1; mode=block";
+                response.Headers["X-Content-Type-Options"] = "nosniff";
+                response.Headers["X-Permitted-Cross-Domain-Policies"] = "none";
+                response.Headers["Referrer-Policy"] = "no-referrer";
+                response.Headers["Content-Security-Policy"] = "default-src 'self'";
+            }
+
+            return _next(context);
+        }
+    }
+}

--- a/src/DqtApi/Program.cs
+++ b/src/DqtApi/Program.cs
@@ -10,6 +10,7 @@ using DqtApi.DataStore.Sql;
 using DqtApi.Filters;
 using DqtApi.Json;
 using DqtApi.Logging;
+using DqtApi.Middleware;
 using DqtApi.ModelBinding;
 using DqtApi.Security;
 using DqtApi.Services;
@@ -254,14 +255,8 @@ namespace DqtApi
                 app.UseMiddleware<RateLimitMiddleware>();
             }
 
-            app.Use((ctx, next) =>
-            {
-                ctx.Response.Headers.Add("X-Frame-Options", "deny");
-                ctx.Response.Headers.Add("X-Content-Type-Options", "nosniff");
-                ctx.Response.Headers.Add("X-XSS-Protection", "0");
+            app.UseMiddleware<AppendSecurityResponseHeadersMiddleware>();
 
-                return next();
-            });
 
             app.UseEndpoints(endpoints =>
             {

--- a/tests/DqtApi.Tests/Middleware/AppendSecurityResponseHeadersMiddlewareTests.cs
+++ b/tests/DqtApi.Tests/Middleware/AppendSecurityResponseHeadersMiddlewareTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Net.Http;
+using Xunit;
+
+namespace DqtApi.Tests.Middleware
+{
+    public class AppendSecurityResponseHeadersMiddlewareTests : ApiTestBase
+    {
+        public AppendSecurityResponseHeadersMiddlewareTests(ApiFixture apiFixture) : base(apiFixture)
+        {
+        }
+
+
+        [Fact]
+        public async Task Given_a_request_response_contains_correct_headers()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "/v2/itt-providers");
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            //Assert
+            Assert.Contains("DENY", response.Headers.GetValues("X-Frame-Options"));
+            Assert.Contains("1; mode=block", response.Headers.GetValues("X-Xss-Protection"));
+            Assert.Contains("nosniff", response.Headers.GetValues("X-Content-Type-Options"));
+            Assert.Contains("none", response.Headers.GetValues("X-Permitted-Cross-Domain-Policies"));
+            Assert.Contains("no-referrer", response.Headers.GetValues("Referrer-Policy"));
+            Assert.Contains("default-src 'self'", response.Headers.GetValues("Content-Security-Policy"));
+        }
+    }
+}


### PR DESCRIPTION
### Context

https://trello.com/c/7XPcTNxQ/628-add-missing-security-headers-on-dqt-portals

### Changes proposed in this pull request

missing security headers

- X-Frame-Options
- X-Xss-Protection
- X-Content-Type-Options
- X-Permitted-Cross-Domain-Policies
- Referrer-Policy
- Content-Security-Policy;

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
