### PR TITLE
Add a v2 Get Teacher endpoint including EYTS

### DIFF
--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -244,6 +244,56 @@
         }
       }
     },
+    "/v2/teachers/{trn}": {
+      "get": {
+        "tags": [
+          "Teachers"
+        ],
+        "summary": "Teacher",
+        "description": "Get an individual teacher by their TRN",
+        "parameters": [
+          {
+            "name": "trn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "birthdate",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTeacherResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/teachers/update/{trn}": {
       "patch": {
         "tags": [
@@ -840,6 +890,93 @@
         },
         "additionalProperties": false
       },
+      "GetTeacherResponse": {
+        "type": "object",
+        "properties": {
+          "trn": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "nationalInsuranceNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "hasActiveSanctions": {
+            "type": "boolean"
+          },
+          "qtsDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "eytsDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "earlyYearsStatus": {
+            "$ref": "#/components/schemas/GetTeacherResponseEarlyYearsStatus"
+          },
+          "initialTeacherTraining": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GetTeacherResponseInitialTeacherTraining"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetTeacherResponseEarlyYearsStatus": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetTeacherResponseInitialTeacherTraining": {
+        "type": "object",
+        "properties": {
+          "programmeStartDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "programmeEndDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "programmeType": {
+            "type": "string",
+            "nullable": true
+          },
+          "result": {
+            "$ref": "#/components/schemas/IttOutcome"
+          }
+        },
+        "additionalProperties": false
+      },
       "HeQualificationType": {
         "enum": [
           "BEd",
@@ -939,7 +1076,14 @@
           "Fail",
           "Withdrawn",
           "Deferred",
-          "DeferredForSkillsTests"
+          "DeferredForSkillsTests",
+          "ApplicationReceived",
+          "ApplicationUnsuccessful",
+          "Approved",
+          "Info",
+          "InTraining",
+          "NoResultSubmitted",
+          "UnderAssessment"
         ],
         "type": "string"
       },

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -12,6 +12,7 @@ using Microsoft.PowerPlatform.Dataverse.Client.Utils;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
+using Newtonsoft.Json.Linq;
 
 namespace DqtApi.DataStore.Crm
 {
@@ -53,6 +54,30 @@ namespace DqtApi.DataStore.Crm
             var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
 
             return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_country>()).FirstOrDefault();
+        }
+
+        public Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(Guid earlyYearsStatusId) => GetEarlyYearsStatus(earlyYearsStatusId, requestBuilder: null);
+
+        public async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(Guid earlyYearsStatusId, RequestBuilder requestBuilder)
+        {
+            requestBuilder ??= RequestBuilder.CreateSingle(_service);
+
+            var query = new QueryByAttribute(dfeta_earlyyearsstatus.EntityLogicalName)
+            {
+                ColumnSet = new() { AllColumns = true }
+            };
+
+            query.AddAttributeValue(dfeta_earlyyearsstatus.PrimaryIdAttribute, earlyYearsStatusId);
+            query.AddAttributeValue(dfeta_earlyyearsstatus.Fields.StateCode, (int)dfeta_earlyyearsStatusState.Active);
+
+            var request = new RetrieveMultipleRequest()
+            {
+                Query = query
+            };
+
+            var result = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+
+            return result.EntityCollection.Entities.Select(entity => entity.ToEntity<dfeta_earlyyearsstatus>()).FirstOrDefault();
         }
 
         public Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(string value) => GetEarlyYearsStatus(value, requestBuilder: null);

--- a/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
@@ -12,6 +12,10 @@ namespace DqtApi.DataStore.Crm
 
         Task<Contact[]> FindTeachers(FindTeachersByTrnBirthDateAndNinoQuery query);
 
+        Task<dfeta_earlyyearsstatus> GetEarlyYearsStatus(Guid earlyYearsStatusId);
+
+        Task<dfeta_initialteachertraining[]> GetInitialTeacherTrainingByTeacher(Guid teacherId, params string[] columnNames);
+
         Task<dfeta_qualification[]> GetQualificationsForTeacher(Guid teacherId, params string[] columnNames);
 
         Task<Contact> GetTeacher(Guid teacherId, bool resolveMerges = true, params string[] columnNames);
@@ -21,6 +25,8 @@ namespace DqtApi.DataStore.Crm
         Task<Contact[]> GetTeachersByTrnAndDoB(string trn, DateOnly birthDate, bool activeOnly = true, params string[] columnNames);
 
         Task<Contact> GetTeacherByTsPersonId(string tsPersonId, params string[] columnNames);
+
+        Task<dfeta_qtsregistration[]> GetQtsRegistrationsByTeacher(Guid teacherId, params string[] columnNames);
 
         Task<Contact[]> FindTeachers(FindTeachersQuery query);
 

--- a/src/DqtApi/DateOnlyExtensions.cs
+++ b/src/DqtApi/DateOnlyExtensions.cs
@@ -5,5 +5,13 @@ namespace DqtApi
     public static class DateOnlyExtensions
     {
         public static DateTime ToDateTime(this DateOnly dateOnly) => dateOnly.ToDateTime(new());
+
+        public static DateTime? ToDateTime(this DateOnly? dateOnly) =>
+            dateOnly.HasValue ? dateOnly.Value.ToDateTime(new()) : null;
+
+        public static DateOnly ToDateOnly(this DateTime dateTime) => DateOnly.FromDateTime(dateTime);
+
+        public static DateOnly? ToDateOnly(this DateTime? dateTime) =>
+            dateTime.HasValue ? DateOnly.FromDateTime(dateTime.Value) : null;
     }
 }

--- a/src/DqtApi/V2/ApiModels/IttOutcome.cs
+++ b/src/DqtApi/V2/ApiModels/IttOutcome.cs
@@ -9,11 +9,28 @@ namespace DqtApi.V2.ApiModels
         Fail = 2,
         Withdrawn = 3,
         Deferred = 4,
-        DeferredForSkillsTests = 5
+        DeferredForSkillsTests = 5,
+        ApplicationReceived = 6,
+        ApplicationUnsuccessful = 7,
+        Approved = 8,
+        Info = 9,
+        InTraining = 10,
+        NoResultSubmitted = 11,
+        UnderAssessment = 12
     }
 
     public static class IttOutcomeExtensions
     {
+        public static IttOutcome ConvertFromITTResult(this dfeta_ITTResult input)
+        {
+            if (!TryConvertFromITTResult(input, out var result))
+            {
+                throw new FormatException($"Unknown {typeof(dfeta_ITTResult).Name}: '{input}'.");
+            }
+
+            return result;
+        }
+
         public static dfeta_ITTResult ConvertToITTResult(this IttOutcome input)
         {
             if (!TryConvertToITTResult(input, out var result))
@@ -22,6 +39,37 @@ namespace DqtApi.V2.ApiModels
             }
 
             return result;
+        }
+
+        public static bool TryConvertFromITTResult(this dfeta_ITTResult input, out IttOutcome result)
+        {
+            var mapped = input switch
+            {
+                dfeta_ITTResult.Pass => IttOutcome.Pass,
+                dfeta_ITTResult.Fail => IttOutcome.Fail,
+                dfeta_ITTResult.Withdrawn => IttOutcome.Withdrawn,
+                dfeta_ITTResult.Deferred => IttOutcome.Deferred,
+                dfeta_ITTResult.DeferredforSkillsTests => IttOutcome.DeferredForSkillsTests,
+                dfeta_ITTResult.ApplicationReceived => IttOutcome.ApplicationReceived,
+                dfeta_ITTResult.ApplicationUnsuccessful => IttOutcome.ApplicationUnsuccessful,
+                dfeta_ITTResult.Approved => IttOutcome.Approved,
+                dfeta_ITTResult.Info => IttOutcome.Info,
+                dfeta_ITTResult.InTraining => IttOutcome.InTraining,
+                dfeta_ITTResult.NoResultSubmitted => IttOutcome.NoResultSubmitted,
+                dfeta_ITTResult.UnderAssessment => IttOutcome.UnderAssessment,
+                _ => (IttOutcome?)null
+            };
+
+            if (mapped.HasValue)
+            {
+                result = mapped.Value;
+                return true;
+            }
+            else
+            {
+                result = default;
+                return false;
+            }
         }
 
         public static bool TryConvertToITTResult(this IttOutcome input, out dfeta_ITTResult result)
@@ -33,6 +81,13 @@ namespace DqtApi.V2.ApiModels
                 IttOutcome.Withdrawn => dfeta_ITTResult.Withdrawn,
                 IttOutcome.Deferred => dfeta_ITTResult.Deferred,
                 IttOutcome.DeferredForSkillsTests => dfeta_ITTResult.DeferredforSkillsTests,
+                IttOutcome.ApplicationReceived => dfeta_ITTResult.ApplicationReceived,
+                IttOutcome.ApplicationUnsuccessful => dfeta_ITTResult.ApplicationUnsuccessful,
+                IttOutcome.Approved => dfeta_ITTResult.Approved,
+                IttOutcome.Info => dfeta_ITTResult.Info,
+                IttOutcome.InTraining => dfeta_ITTResult.InTraining,
+                IttOutcome.NoResultSubmitted => dfeta_ITTResult.NoResultSubmitted,
+                IttOutcome.UnderAssessment => dfeta_ITTResult.UnderAssessment,
                 _ => (dfeta_ITTResult?)null
             };
 

--- a/src/DqtApi/V2/Controllers/TeachersController.cs
+++ b/src/DqtApi/V2/Controllers/TeachersController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using DqtApi.Filters;
+using DqtApi.Logging;
 using DqtApi.V2.Requests;
 using DqtApi.V2.Responses;
 using MediatR;
@@ -27,6 +28,18 @@ namespace DqtApi.V2.Controllers
         {
             var response = await _mediator.Send(request);
             return Ok(response);
+        }
+
+        [HttpGet("{trn}")]
+        [SwaggerOperation(
+            summary: "Teacher",
+            description: "Get an individual teacher by their TRN")]
+        [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
+        [RedactQueryParam("birthdate")]
+        public async Task<IActionResult> GetTeacher([FromRoute] GetTeacherRequest request)
+        {
+            var response = await _mediator.Send(request);
+            return response != null ? Ok(response) : NotFound();
         }
 
         [HttpPatch("update/{trn}")]

--- a/src/DqtApi/V2/Handlers/GetTeacherHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetTeacherHandler.cs
@@ -1,0 +1,105 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
+using DqtApi.V2.ApiModels;
+using DqtApi.V2.Requests;
+using DqtApi.V2.Responses;
+using DqtApi.Validation;
+using MediatR;
+
+namespace DqtApi.V2.Handlers
+{
+    public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherResponse>
+    {
+        private readonly IDataverseAdapter _dataverseAdapter;
+
+        public GetTeacherHandler(IDataverseAdapter dataverseAdapter)
+        {
+            _dataverseAdapter = dataverseAdapter;
+        }
+
+        public async Task<GetTeacherResponse> Handle(GetTeacherRequest request, CancellationToken cancellationToken)
+        {
+            var teachers = await _dataverseAdapter.GetTeachersByTrnAndDoB(
+                request.Trn,
+                request.BirthDate.Value,
+                activeOnly: true,
+                columnNames: new[]
+                {
+                    Contact.Fields.FirstName,
+                    Contact.Fields.LastName,
+                    Contact.Fields.BirthDate,
+                    Contact.Fields.dfeta_EYTSDate,
+                    Contact.Fields.dfeta_QTSDate,
+                    Contact.Fields.dfeta_ActiveSanctions,
+                    Contact.Fields.dfeta_NINumber,
+                    Contact.Fields.dfeta_TRN
+                });
+
+            if (teachers.Length == 0)
+            {
+                return null;
+            }
+            else if (teachers.Length > 1)
+            {
+                throw new ErrorException(ErrorRegistry.MultipleTeachersFoundWithSpecifiedTrn());
+            }
+
+            var teacher = teachers[0];
+
+            var qtsRegistrations = await _dataverseAdapter.GetQtsRegistrationsByTeacher(
+                teacher.Id,
+                columnNames: new[]
+                {
+                    dfeta_qtsregistration.Fields.dfeta_QTSDate,
+                    dfeta_qtsregistration.Fields.dfeta_EYTSDate,
+                    dfeta_qtsregistration.Fields.dfeta_EarlyYearsStatusId
+                });
+
+            dfeta_earlyyearsstatus earlyYearsStatus = null;
+            var earlyYearsQtsRegistration = qtsRegistrations.SingleOrDefault(qts => qts.dfeta_EarlyYearsStatusId is not null);
+            if (earlyYearsQtsRegistration is not null)
+            {
+                earlyYearsStatus = await _dataverseAdapter.GetEarlyYearsStatus(earlyYearsQtsRegistration.dfeta_EarlyYearsStatusId.Id);
+            }
+
+            var itt = await _dataverseAdapter.GetInitialTeacherTrainingByTeacher(
+                teacher.Id,
+                columnNames: new string[]
+                {
+                    dfeta_initialteachertraining.Fields.dfeta_ProgrammeEndDate,
+                    dfeta_initialteachertraining.Fields.dfeta_ProgrammeStartDate,
+                    dfeta_initialteachertraining.Fields.dfeta_ProgrammeType,
+                    dfeta_initialteachertraining.Fields.dfeta_Result
+                });
+
+            return new GetTeacherResponse()
+            {
+                DateOfBirth = teacher.BirthDate.ToDateOnly(),
+                FirstName = teacher.FirstName,
+                HasActiveSanctions = teacher.dfeta_ActiveSanctions == true,
+                LastName = teacher.LastName,
+                NationalInsuranceNumber = teacher.dfeta_NINumber,
+                Trn = teacher.dfeta_TRN,
+                QtsDate = teacher.dfeta_QTSDate.ToDateOnly(),
+                EytsDate = teacher.dfeta_EYTSDate.ToDateOnly(),
+                EarlyYearsStatus = earlyYearsStatus is not null ?
+                    new GetTeacherResponseEarlyYearsStatus()
+                    {
+                        Name = earlyYearsStatus.dfeta_name,
+                        Value = earlyYearsStatus.dfeta_Value
+                    } :
+                    null,
+                InitialTeacherTraining = itt.Select(i => new GetTeacherResponseInitialTeacherTraining()
+                {
+                    ProgrammeEndDate = i.dfeta_ProgrammeEndDate.ToDateOnly(),
+                    ProgrammeStartDate = i.dfeta_ProgrammeStartDate.ToDateOnly(),
+                    ProgrammeType = i.dfeta_ProgrammeType.Value.ToString(),
+                    Result = i.dfeta_Result.HasValue ? i.dfeta_Result.Value.ConvertFromITTResult() : null
+                })
+            };
+        }
+    }
+}

--- a/src/DqtApi/V2/Requests/GetTeacherRequest.cs
+++ b/src/DqtApi/V2/Requests/GetTeacherRequest.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using DqtApi.V2.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace DqtApi.V2.Requests
+{
+    public class GetTeacherRequest : IRequest<GetTeacherResponse>
+    {
+        [FromRoute(Name = "trn")]
+        public string Trn { get; set; }
+
+        [FromQuery(Name = "birthdate"), SwaggerParameter(Required = true), ModelBinder(typeof(ModelBinding.DateModelBinder))]
+        public DateOnly? BirthDate { get; set; }
+    }
+}

--- a/src/DqtApi/V2/Responses/GetTeacherResponse.cs
+++ b/src/DqtApi/V2/Responses/GetTeacherResponse.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using DqtApi.V2.ApiModels;
+
+namespace DqtApi.V2.Responses
+{
+    public class GetTeacherResponse
+    {
+        public string Trn { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public DateOnly? DateOfBirth { get; set; }
+        public string NationalInsuranceNumber { get; set; }
+        public bool HasActiveSanctions { get; set; }
+        public DateOnly? QtsDate { get; set; }
+        public DateOnly? EytsDate { get; set; }
+        public GetTeacherResponseEarlyYearsStatus EarlyYearsStatus { get; set; }
+        public IEnumerable<GetTeacherResponseInitialTeacherTraining> InitialTeacherTraining { get; set; }
+    }
+
+    public class GetTeacherResponseEarlyYearsStatus
+    {
+        public string Value { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class GetTeacherResponseInitialTeacherTraining
+    {
+        public DateOnly? ProgrammeStartDate { get; set; }
+        public DateOnly? ProgrammeEndDate { get; set; }
+        public string ProgrammeType { get; set; }
+        public IttOutcome? Result { get; set; }
+    }
+}

--- a/src/DqtApi/V2/Validators/GetTeacherRequestValidator.cs
+++ b/src/DqtApi/V2/Validators/GetTeacherRequestValidator.cs
@@ -1,0 +1,21 @@
+﻿using DqtApi.V2.Requests;
+using DqtApi.Validation;
+using FluentValidation;
+
+namespace DqtApi.V2.Validators
+{
+    public class GetTeacherRequestValidator : AbstractValidator<GetTeacherRequest>
+    {
+        public GetTeacherRequestValidator()
+        {
+            RuleFor(x => x.Trn)
+                .Matches(@"^\d{7}$")
+                .WithMessage(Properties.StringResources.ErrorMessages_TRNMustBe7Digits);
+
+            RuleFor(x => x.BirthDate)
+                .NotEmpty()
+                .Must(value => value is null || value.Value.ToDateTime() >= Constants.MinCrmDateTime)
+                    .WithMessage(Properties.StringResources.ErrorMessages_BirthDateIsOutOfRange);
+        }
+    }
+}

--- a/tests/DqtApi.TestCommon/AssertEx.Http.cs
+++ b/tests/DqtApi.TestCommon/AssertEx.Http.cs
@@ -32,7 +32,7 @@ namespace DqtApi.TestCommon
         public static async Task JsonResponseEquals(HttpResponseMessage response, object expected, int expectedStatusCode = StatusCodes.Status200OK)
         {
             var jsonResponse = await JsonResponse<JObject>(response, expectedStatusCode);
-            JsonObjectEquals(JToken.FromObject(expected), jsonResponse);
+            JsonObjectEquals(jsonResponse, JToken.FromObject(expected));
         }
 
         public static async Task ResponseIsError(HttpResponseMessage response, int errorCode, int expectedStatusCode)

--- a/tests/DqtApi.Tests/V2/Operations/GetTeacherTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/GetTeacherTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Net.Http;
+using DqtApi.DataStore.Crm.Models;
+using DqtApi.Properties;
+using DqtApi.TestCommon;
+using DqtApi.V2.ApiModels;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace DqtApi.Tests.V2.Operations
+{
+    public class GetTeacherTests : ApiTestBase
+    {
+        public GetTeacherTests(ApiFixture apiFixture)
+            : base(apiFixture)
+        {
+        }
+
+        [Theory]
+        [InlineData("123456")]
+        [InlineData("12345678")]
+        [InlineData("xxx")]
+        public async Task Given_invalid_trn_returns_error(string trn)
+        {
+            // Arrange
+            var birthDate = "1990-04-01";
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/v2/teachers/{trn}?birthdate={birthDate}");
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            await AssertEx.ResponseIsValidationErrorForProperty(response, "trn", expectedError: StringResources.ErrorMessages_TRNMustBe7Digits);
+        }
+
+        [Theory]
+        [InlineData("xxx")]
+        public async Task Given_invalid_birthdate_returns_error(string birthDate)
+        {
+            // Arrange
+            var trn = "1234567";
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/v2/teachers/{trn}?birthdate={birthDate}");
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            await AssertEx.ResponseIsValidationErrorForProperty(response, "birthdate", expectedError: $"The value '{birthDate}' is not valid for BirthDate.");
+        }
+
+        [Fact]
+        public async Task Given_no_match_found_returns_notfound()
+        {
+            // Arrange
+            var trn = "1234567";
+            var birthDate = "1990-04-01";
+
+            ApiFixture.DataverseAdapter
+                .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, DateOnly.Parse(birthDate), true, It.IsAny<string[]>()))
+                .ReturnsAsync(Array.Empty<Contact>());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/v2/teachers/{trn}?birthdate={birthDate}");
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Given_match_returns_ok()
+        {
+            // Arrange
+            var trn = "1234567";
+            var birthDate = "1990-04-01";
+            var firstName = Faker.Name.First();
+            var lastName = Faker.Name.Last();
+            var nino = Faker.Identification.UkNationalInsuranceNumber();
+            var qtsDate = (DateOnly?)null;
+            var eytsDate = (DateOnly?)new DateOnly(2022, 7, 7);
+            var teacherId = Guid.NewGuid();
+            var earlyYearsStatusId = Guid.NewGuid();
+            var earlyYearsStatusName = "Early Years Teacher Status";
+            var earlyYearsStatusValue = "221";
+            var ittStartDate = new DateOnly(2021, 9, 7);
+            var ittEndDate = new DateOnly(2022, 7, 29);
+            var ittProgrammeType = IttProgrammeType.EYITTGraduateEntry;
+            var ittResult = IttOutcome.Pass;
+
+            var contact = new Contact()
+            {
+                Id = teacherId,
+                BirthDate = DateTime.Parse(birthDate),
+                FirstName = firstName,
+                LastName = lastName,
+                dfeta_TRN = trn,
+                dfeta_NINumber = nino,
+                StateCode = ContactState.Active,
+                dfeta_EYTSDate = eytsDate.ToDateTime()
+            };
+
+            var qtsRegistration = new dfeta_qtsregistration()
+            {
+                dfeta_PersonId = new Microsoft.Xrm.Sdk.EntityReference(Contact.EntityLogicalName, teacherId),
+                dfeta_EarlyYearsStatusId = new Microsoft.Xrm.Sdk.EntityReference(dfeta_earlyyearsstatus.EntityLogicalName, earlyYearsStatusId),
+                dfeta_EYTSDate = eytsDate.ToDateTime()
+            };
+
+            var earlyYearsStatus = new dfeta_earlyyearsstatus()
+            {
+                Id = earlyYearsStatusId,
+                dfeta_name = earlyYearsStatusName,
+                dfeta_Value = earlyYearsStatusValue
+            };
+
+            var itt = new dfeta_initialteachertraining()
+            {
+                dfeta_PersonId = new Microsoft.Xrm.Sdk.EntityReference(Contact.EntityLogicalName, teacherId),
+                dfeta_ProgrammeStartDate = ittStartDate.ToDateTime(),
+                dfeta_ProgrammeEndDate = ittEndDate.ToDateTime(),
+                dfeta_ProgrammeType = ittProgrammeType.ConvertToIttProgrammeType(),
+                dfeta_Result = ittResult.ConvertToITTResult()
+            };
+
+            ApiFixture.DataverseAdapter
+                .Setup(mock => mock.GetTeachersByTrnAndDoB(trn, DateOnly.Parse(birthDate), true, /* columnNames: */ It.IsAny<string[]>()))
+                .ReturnsAsync(new[] { contact });
+
+            ApiFixture.DataverseAdapter
+                .Setup(mock => mock.GetQtsRegistrationsByTeacher(teacherId, /* columnNames: */ It.IsAny<string[]>()))
+                .ReturnsAsync(new[] { qtsRegistration });
+
+            ApiFixture.DataverseAdapter
+                .Setup(mock => mock.GetEarlyYearsStatus(earlyYearsStatusId))
+                .ReturnsAsync(earlyYearsStatus);
+
+            ApiFixture.DataverseAdapter
+                .Setup(mock => mock.GetInitialTeacherTrainingByTeacher(teacherId, /* columnNames: */ It.IsAny<string[]>()))
+                .ReturnsAsync(new[] { itt });
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/v2/teachers/{trn}?birthdate={birthDate}");
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            await AssertEx.JsonResponseEquals(
+                response,
+                new
+                {
+                    trn = trn,
+                    firstName = firstName,
+                    lastName = lastName,
+                    dateOfBirth = birthDate,
+                    nationalInsuranceNumber = nino,
+                    hasActiveSanctions = false,
+                    qtsDate = qtsDate?.ToString("yyyy-MM-dd"),
+                    eytsDate = eytsDate?.ToString("yyyy-MM-dd"),
+                    earlyYearsStatus = new
+                    {
+                        name = earlyYearsStatusName,
+                        value = earlyYearsStatusValue
+                    },
+                    initialTeacherTraining = new[]
+                    {
+                        new
+                        {
+                            programmeStartDate = ittStartDate.ToString("yyyy-MM-dd"),
+                            programmeEndDate = ittEndDate.ToString("yyyy-MM-dd"),
+                            programmeType = ittProgrammeType.ToString(),
+                            result = ittResult.ToString()
+                        }
+                    }
+                });
+        }
+    }
+}


### PR DESCRIPTION
### Context

https://trello.com/c/Ng9O2kzc/647-add-eyts-date-and-early-years-teacher-status-to-the-api

Current v1 API doesn't include Early Years info, which is required by Register.

This adds a v2 'get teacher' endpoint including this information. (The V1 API has some quirks and we don't really want to extend it.)

### Changes proposed in this pull request

Add a `GET /v2/teachers/{trn}` endpoint.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
