### PR TITLE
Handle a missing Address block on the TRN endpoint

### DIFF
--- a/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -83,12 +83,12 @@ namespace DqtApi.V2.Handlers
                     EmailAddress = request.EmailAddress,
                     Address = new CreateTeacherCommandAddress()
                     {
-                        AddressLine1 = request.Address.AddressLine1,
-                        AddressLine2 = request.Address.AddressLine2,
-                        AddressLine3 = request.Address.AddressLine3,
-                        City = request.Address.City,
-                        PostalCode = request.Address.PostalCode,
-                        Country = request.Address.Country
+                        AddressLine1 = request.Address?.AddressLine1,
+                        AddressLine2 = request.Address?.AddressLine2,
+                        AddressLine3 = request.Address?.AddressLine3,
+                        City = request.Address?.City,
+                        PostalCode = request.Address?.PostalCode,
+                        Country = request.Address?.Country
                     },
                     GenderCode = request.GenderCode.ConvertToContact_GenderCode(),
                     InitialTeacherTraining = new CreateTeacherCommandInitialTeacherTraining()

--- a/src/DqtApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
+++ b/src/DqtApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
@@ -44,22 +44,28 @@ namespace DqtApi.V2.Validators
                 .MaximumLength(AttributeConstraints.Contact.EMailAddress1MaxLength);
 
             RuleFor(r => r.Address.AddressLine1)
-                .MaximumLength(AttributeConstraints.Contact.Address1_Line1MaxLength);
+                .MaximumLength(AttributeConstraints.Contact.Address1_Line1MaxLength)
+                .When(r => r.Address != null);
 
             RuleFor(r => r.Address.AddressLine2)
-                .MaximumLength(AttributeConstraints.Contact.Address1_Line2MaxLength);
+                .MaximumLength(AttributeConstraints.Contact.Address1_Line2MaxLength)
+                .When(r => r.Address != null);
 
             RuleFor(r => r.Address.AddressLine3)
-                .MaximumLength(AttributeConstraints.Contact.Address1_Line3MaxLength);
+                .MaximumLength(AttributeConstraints.Contact.Address1_Line3MaxLength)
+                .When(r => r.Address != null);
 
             RuleFor(r => r.Address.City)
-                .MaximumLength(AttributeConstraints.Contact.Address1_CityMaxLength);
+                .MaximumLength(AttributeConstraints.Contact.Address1_CityMaxLength)
+                .When(r => r.Address != null);
 
             RuleFor(r => r.Address.Country)
-                .MaximumLength(AttributeConstraints.Contact.Address1_CountryMaxLength);
+                .MaximumLength(AttributeConstraints.Contact.Address1_CountryMaxLength)
+                .When(r => r.Address != null);
 
             RuleFor(r => r.Address.PostalCode)
-                .MaximumLength(AttributeConstraints.Contact.Address1_PostalCodeLength);
+                .MaximumLength(AttributeConstraints.Contact.Address1_PostalCodeLength)
+                .When(r => r.Address != null);
 
             RuleFor(r => r.GenderCode)
                 .IsInEnum();


### PR DESCRIPTION
### Context

We currently explode if the `address` property isn't provided. None of the address fields are mandatory so the `address` block itself shouldn't be mandatory either.

### Changes proposed in this pull request

Handle when the `address` block is not provided (or is `null`).

### Checklist

~~-   [ ] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
