### PR TITLE
reject trn requests with duplicate husids

### DIFF
--- a/src/DqtApi/DataStore/Crm/CreateTeacherResult.cs
+++ b/src/DqtApi/DataStore/Crm/CreateTeacherResult.cs
@@ -38,5 +38,6 @@ namespace DqtApi.DataStore.Crm
         QualificationNotFound = 256,
         QualificationSubject2NotFound = 512,
         QualificationSubject3NotFound = 1024,
+        DuplicateHusId = 2048
     }
 }

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -655,6 +655,23 @@ namespace DqtApi.DataStore.Crm
             bool qtsDateRequired) =>
                 GetTeacherStatus(value, qtsDateRequired, requestBuilder: null);
 
+        public async Task<Contact> GetTeacherByHusId(string husId, params string[] columnNames)
+        {
+            var filter = new FilterExpression(LogicalOperator.And);
+            filter.AddCondition(Contact.Fields.dfeta_HUSID, ConditionOperator.Equal, husId);
+            filter.AddCondition(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active);
+
+            var query = new QueryExpression(Contact.EntityLogicalName)
+            {
+                ColumnSet = new(columnNames),
+                Criteria = filter
+            };
+
+            var result = await _service.RetrieveMultipleAsync(query);
+
+            return result.Entities.Select(e => e.ToEntity<Contact>()).SingleOrDefault();
+        }
+
         public async Task<dfeta_teacherstatus> GetTeacherStatus(
             string value,
             bool qtsDateRequired,

--- a/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/IDataverseAdapter.cs
@@ -51,5 +51,7 @@ namespace DqtApi.DataStore.Crm
         Task SetTsPersonId(Guid teacherId, string tsPersonId);
 
         Task<bool> UnlockTeacherRecord(Guid teacherId);
+
+        Task<Contact> GetTeacherByHusId(string husId, params string[] columnNames);
     }
 }

--- a/src/DqtApi/DataStore/Crm/UpdateTeacherResult.cs
+++ b/src/DqtApi/DataStore/Crm/UpdateTeacherResult.cs
@@ -41,6 +41,7 @@ namespace DqtApi.DataStore.Crm
         Subject3NotFound = 8192,
         IttQualificationNotFound = 16384,
         QualificationSubject2NotFound = 32768,
-        QualificationSubject3NotFound = 65536
+        QualificationSubject3NotFound = 65536,
+        DuplicateHusId = 131072
     }
 }

--- a/src/DqtApi/Properties/StringResources.Designer.cs
+++ b/src/DqtApi/Properties/StringResources.Designer.cs
@@ -250,6 +250,7 @@ namespace DqtApi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to unlock teacher with active sanctions.
         /// </summary>
         public static string Errors_10014_Title {
             get {
@@ -275,10 +276,21 @@ namespace DqtApi.Properties {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Teacher already has TsPersonId defined.
         /// </summary>
         public static string Errors_10017_Title {
             get {
                 return ResourceManager.GetString("Errors.10017.Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Husid registered for an existing teacher.
+        /// </summary>
+        public static string Errors_10018_Title {
+            get {
+                return ResourceManager.GetString("Errors.10018.Title", resourceCulture);
             }
         }
     }

--- a/src/DqtApi/Properties/StringResources.resx
+++ b/src/DqtApi/Properties/StringResources.resx
@@ -192,4 +192,7 @@
   <data name="Errors.10017.Title" xml:space="preserve">
     <value>Teacher already has TsPersonId defined</value>
   </data>
+  <data name="Errors.10018.Title" xml:space="preserve">
+    <value>Husid registered for an existing teacher</value>
+  </data>
 </root>

--- a/src/DqtApi/V2/Handlers/UpdateTeacherHandler.cs
+++ b/src/DqtApi/V2/Handlers/UpdateTeacherHandler.cs
@@ -32,6 +32,9 @@ namespace DqtApi.V2.Handlers
 
             await transaction.AcquireAdvisoryLock(request.Trn);
 
+            if (!string.IsNullOrEmpty(request.HusId))
+                await transaction.AcquireAdvisoryLock(request.HusId);
+
             var teachers = (await _dataverseAdapter.GetTeachersByTrnAndDoB(request.Trn, request.BirthDate.Value, activeOnly: true)).ToArray();
 
             if (teachers.Length == 0)
@@ -153,6 +156,11 @@ namespace DqtApi.V2.Handlers
                 UpdateTeacherFailedReasons.IttProviderNotFound,
                 $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.ProviderUkprn)}",
                 ErrorRegistry.OrganisationNotFound().Title);
+
+            ConsumeReason(
+                UpdateTeacherFailedReasons.DuplicateHusId,
+                $"{nameof(UpdateTeacherRequest.HusId)}.{nameof(UpdateTeacherRequest.HusId)}",
+                ErrorRegistry.ExistingTeacherAlreadyHasHusId().Title);
 
             if (failedReasons != UpdateTeacherFailedReasons.None)
             {

--- a/src/DqtApi/Validation/ErrorRegistry.cs
+++ b/src/DqtApi/Validation/ErrorRegistry.cs
@@ -25,6 +25,7 @@ namespace DqtApi.Validation
             ErrorDescriptor.Create(10015),  // Teacher with specified TsPersonId not found
             ErrorDescriptor.Create(10016),  // Another teacher has the specified TsPersonId assigned
             ErrorDescriptor.Create(10017),  // Teacher already has a TsPersonId defined
+            ErrorDescriptor.Create(10018),  // Husid already being used for an existing teacher
         }.ToDictionary(d => d.ErrorCode, d => d);
 
         public static Error TeacherWithSpecifiedTrnNotFound() => CreateError(10001);
@@ -60,6 +61,8 @@ namespace DqtApi.Validation
         public static Error AnotherTeacherHasTheSpecifiedTsPersonIdAssigned() => CreateError(10016);
 
         public static Error TeacherAlreadyHasTsPersonIdDefined() => CreateError(10017);
+
+        public static Error ExistingTeacherAlreadyHasHusId() => CreateError(10018);
 
         private static Error CreateError(int errorCode)
         {

--- a/tests/DqtApi.Tests/DataverseIntegration/GetTeacherByHusIdTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetTeacherByHusIdTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
+using Microsoft.Xrm.Sdk.Messages;
+using Xunit;
+
+namespace DqtApi.Tests.DataverseIntegration
+{
+    public class GetTeacherByHusIdTests : IAsyncLifetime
+    {
+        private readonly CrmClientFixture.TestDataScope _dataScope;
+        private readonly DataverseAdapter _dataverseAdapter;
+        private readonly ITrackedEntityOrganizationService _organizationService;
+        private readonly TestableClock _clock;
+
+        public GetTeacherByHusIdTests(CrmClientFixture crmClientFixture)
+        {
+            _dataScope = crmClientFixture.CreateTestDataScope();
+            _dataverseAdapter = _dataScope.CreateDataverseAdapter();
+            _organizationService = _dataScope.OrganizationService;
+            _clock = crmClientFixture.Clock;
+        }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+
+        [Fact]
+        public async Task Given_existing_teacher_matches_on_husid_return_teacher()
+        {
+            // Arrange
+            var husId = "9876543211461";
+            var (_, _) = await CreateTeacher(husId);
+
+            // Act
+            var result = await _dataverseAdapter.GetTeacherByHusId(husId, columnNames: Contact.Fields.dfeta_HUSID);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(husId, result.dfeta_HUSID);
+        }
+
+        [Fact]
+        public async Task Given_teacher_for_husid_does_not_exist_return_empty_array()
+        {
+            // Arrange
+            var husId = "9876543213";
+            var (_, _) = await CreateTeacher(husId);
+
+            // Act
+            var result = await _dataverseAdapter.GetTeacherByHusId("SOME_NONE_EXISTENT_HUSID", columnNames: Contact.Fields.dfeta_HUSID);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        private async Task<(Guid TeacherId, string Trn)> CreateTeacher(string husId)
+        {
+            var teacherId = Guid.NewGuid();
+            var birthDate = new DateOnly(1980, 01, 01);
+
+            var request = new ExecuteTransactionRequest()
+            {
+                Requests = new Microsoft.Xrm.Sdk.OrganizationRequestCollection()
+                {
+                    new CreateRequest()
+                    {
+                        Target = new Contact()
+                        {
+                            Id = teacherId,
+                            BirthDate = birthDate.ToDateTime(),
+                            dfeta_HUSID = husId
+                        }
+                    },
+                    new UpdateRequest()
+                    {
+                        Target = new Contact()
+                        {
+                            Id = teacherId,
+                            dfeta_TRNAllocateRequest = _clock.UtcNow
+                        }
+                    },
+                    new RetrieveRequest()
+                    {
+                        Target = new Microsoft.Xrm.Sdk.EntityReference(Contact.EntityLogicalName, teacherId),
+                        ColumnSet = new(Contact.Fields.dfeta_TRN)
+                    }
+                },
+                ReturnResponses = true
+            };
+
+            var response = (ExecuteTransactionResponse)await _organizationService.ExecuteAsync(request);
+            var retrieveResponse = (RetrieveResponse)response.Responses.Last();
+
+            return (teacherId, retrieveResponse.Entity.ToEntity<Contact>().dfeta_TRN);
+        }
+    }
+}

--- a/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
@@ -1148,7 +1148,7 @@ namespace DqtApi.Tests.DataverseIntegration
             var updateIttSubject1Id = await _dataverseAdapter.GetIttSubjectByCode("100403");  // mathematics
             var updateIttSubject2Id = await _dataverseAdapter.GetIttSubjectByCode("100366");  // computer science
             var updateIttSubject3Id = await _dataverseAdapter.GetIttSubjectByCode("100302");  // history
-            var husId = "1234567890123";
+            var husId = "12345678901233411";
             var updateHeSubject2Id = await _dataverseAdapter.GetHeSubjectByCode("X300");  // Academic Studies in Education
             var updateHeSubject3Id = await _dataverseAdapter.GetHeSubjectByCode("N400");  // Accounting
 
@@ -1295,7 +1295,7 @@ namespace DqtApi.Tests.DataverseIntegration
         {
             // Arrange
             var (teacherId, ittProviderUkprn) = await CreatePerson(earlyYears: false, hasActiveSanctions: false);
-            var husId = "1234567890123";
+            var husId = "1234567890123156";
 
             // Act
             var (_, txnRequest) = await _dataverseAdapter.UpdateTeacherImpl(new UpdateTeacherCommand()

--- a/tests/DqtApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -560,6 +560,26 @@ namespace DqtApi.Tests.V2.Operations
                 .Verify(mock => mock.CreateTeacher(It.Is<CreateTeacherCommand>(cmd => cmd.FirstName == expectedFirstName && cmd.MiddleName == expectedMiddleName)));
         }
 
+        [Fact]
+        public async Task Given_request_with_existing_husid_returns_error()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var request = CreateRequest();
+            ApiFixture.DataverseAdapter
+                .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
+                .ReturnsAsync(CreateTeacherResult.Failed(CreateTeacherFailedReasons.DuplicateHusId));
+
+            // Act
+            var response = await HttpClient.PutAsync($"v2/trn-requests/{requestId}", request);
+
+            // Assert
+            await AssertEx.ResponseIsValidationErrorForProperty(
+                response,
+                $"{nameof(GetOrCreateTrnRequest.HusId)}.{nameof(GetOrCreateTrnRequest.HusId)}",
+                StringResources.Errors_10018_Title);
+        }
+
         public static TheoryData<int?, int?, string, string> InvalidAgeCombinationsData { get; } = new()
         {
             {


### PR DESCRIPTION
### Context

https://trello.com/c/AVwiSVbZ/649-reject-trn-requests-with-duplicate-husids-in-the-dqt-api

Reject creating a teacher when husid is being used for another teacher.

Endpoints that have been updated to reject duplicate husids
- UpdateTeacher
- GetOrCreateTrn

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
