### PR TITLE
Add support for specifying TRN in Find operation

### DIFF
--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -218,6 +218,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "trn",
+            "in": "query",
+            "description": "TRN of person",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -747,6 +747,7 @@ namespace DqtApi.DataStore.Crm
             AddEqualCondition(Contact.Fields.BirthDate, findTeachersQuery.DateOfBirth?.ToDateTime());
             AddEqualCondition(Contact.Fields.dfeta_NINumber, findTeachersQuery.NationalInsuranceNumber);
             AddEqualCondition(Contact.Fields.EMailAddress1, findTeachersQuery.EmailAddress);
+            AddEqualCondition(Contact.Fields.dfeta_TRN, findTeachersQuery.Trn);
 
             {
                 // Find all the permutations of names to match on

--- a/src/DqtApi/DataStore/Crm/Models/FindTeachersByTrnBirthDateAndNinoQuery.cs
+++ b/src/DqtApi/DataStore/Crm/Models/FindTeachersByTrnBirthDateAndNinoQuery.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace DqtApi.DataStore.Crm
+namespace DqtApi.DataStore.Crm.Models
 {
     public class FindTeachersByTrnBirthDateAndNinoQuery
     {

--- a/src/DqtApi/DataStore/Crm/Models/FindTeachersQuery.cs
+++ b/src/DqtApi/DataStore/Crm/Models/FindTeachersQuery.cs
@@ -13,5 +13,6 @@ namespace DqtApi.DataStore.Crm
         public string NationalInsuranceNumber { get; set; }
         public IEnumerable<Guid> IttProviderOrganizationIds { get; set; }
         public string EmailAddress { get; set; }
+        public string Trn { get; set; }
     }
 }

--- a/src/DqtApi/V2/Requests/FindTeachersRequest.cs
+++ b/src/DqtApi/V2/Requests/FindTeachersRequest.cs
@@ -44,5 +44,9 @@ namespace DqtApi.V2.Requests
         [SwaggerParameter(Description = "Email of person")]
         [FromQuery(Name = "emailAddress")]
         public string EmailAddress { get; set; }
+
+        [SwaggerParameter(Description = "TRN of person")]
+        [FromQuery(Name = "trn")]
+        public string Trn { get; set; }
     }
 }

--- a/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersFixture.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersFixture.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk.Query;

--- a/tests/DqtApi.Tests/V1/Operations/GetTeacherTests.cs
+++ b/tests/DqtApi.Tests/V1/Operations/GetTeacherTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Net.Http;
-using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using DqtApi.Properties;
 using DqtApi.TestCommon;


### PR DESCRIPTION
### Context

https://trello.com/c/wUKo1HUn/648-allow-specifying-a-trn-when-looking-up-a-trn

### Changes proposed in this pull request

Adds the `trn` field to the Find API operation.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
