### PR TITLE
Fix clearing down test data

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -588,7 +588,6 @@ namespace DqtApi.DataStore.Crm
 
                 Debug.Assert(!isEarlyYears || getEarlyYearsStatusTask.Result != null, "Early years status lookup failed.");
                 Debug.Assert(isEarlyYears || getTeacherStatusTask.Result != null, "Teacher status lookup failed.");
-                Debug.Assert(getQualificationTask.Result != null);
 
                 return new()
                 {

--- a/tests/DqtApi.Tests/DataverseIntegration/GetTeachersByTrnAndDobTests.cs
+++ b/tests/DqtApi.Tests/DataverseIntegration/GetTeachersByTrnAndDobTests.cs
@@ -85,7 +85,8 @@ namespace DqtApi.Tests.DataverseIntegration
                         Target = new Microsoft.Xrm.Sdk.EntityReference(Contact.EntityLogicalName, teacherId),
                         ColumnSet = new(Contact.Fields.dfeta_TRN)
                     }
-                }
+                },
+                ReturnResponses = true
             };
 
             var response = (ExecuteTransactionResponse)await _organizationService.ExecuteAsync(request);


### PR DESCRIPTION
This makes the task to extract the created entities from CRM responses a parent of the method result rather than a sibling. As such, any exceptions thrown by that extraction process are observed by the caller.