### PR TITLE
Return whether a teacher was actually unlocked

### DIFF
--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -607,8 +607,15 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "No Content"
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnlockTeacherResponse"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found"
@@ -1326,6 +1333,16 @@
           "Completed"
         ],
         "type": "string"
+      },
+      "UnlockTeacherResponse": {
+        "type": "object",
+        "properties": {
+          "hasBeenUnlocked": {
+            "type": "boolean",
+            "description": "Whether the account has been unlocked"
+          }
+        },
+        "additionalProperties": false
       },
       "UpdateTeacherRequest": {
         "required": [

--- a/src/DqtApi/V2/Controllers/UnlockTeacherController.cs
+++ b/src/DqtApi/V2/Controllers/UnlockTeacherController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using DqtApi.V2.Requests;
+using DqtApi.V2.Responses;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -20,14 +21,13 @@ namespace DqtApi.V2.Controllers
 
         [HttpPut("{teacherId}")]
         [SwaggerOperation(description: "Unlocks the teacher record allowing the teacher to sign in to the portals")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(UnlockTeacherResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
         public async Task<IActionResult> UnlockTeacher([FromRoute] UnlockTeacherRequest request)
         {
             try
             {
-                await _mediator.Send(request);
-                return NoContent();
+                return Ok(await _mediator.Send(request));
             }
             catch (NotFoundException)
             {

--- a/src/DqtApi/V2/Handlers/UnlockTeacherHandler.cs
+++ b/src/DqtApi/V2/Handlers/UnlockTeacherHandler.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm;
 using DqtApi.DataStore.Crm.Models;
 using DqtApi.V2.Requests;
+using DqtApi.V2.Responses;
 using DqtApi.Validation;
 using MediatR;
 
 namespace DqtApi.V2.Handlers
 {
-    public class UnlockTeacherHandler : IRequestHandler<UnlockTeacherRequest>
+    public class UnlockTeacherHandler : IRequestHandler<UnlockTeacherRequest, UnlockTeacherResponse>
     {
         private readonly IDataverseAdapter _dataverseAdapter;
 
@@ -18,25 +18,39 @@ namespace DqtApi.V2.Handlers
             _dataverseAdapter = dataverseAdapter;
         }
 
-        public async Task<Unit> Handle(UnlockTeacherRequest request, CancellationToken cancellationToken)
+        public async Task<UnlockTeacherResponse> Handle(UnlockTeacherRequest request, CancellationToken cancellationToken)
         {
             var contact = await _dataverseAdapter.GetTeacher(request.TeacherId, columnNames: new[]
             {
                 Contact.Fields.dfeta_ActiveSanctions,
-                Contact.Fields.dfeta_TRN
+                Contact.Fields.dfeta_TRN,
+                Contact.Fields.dfeta_loginfailedcounter
             });
-            if (contact?.dfeta_ActiveSanctions == true)
-            {
-                throw new ErrorException(ErrorRegistry.TeacherHasActiveSanctions());
-            }
 
-            var found = await _dataverseAdapter.UnlockTeacherRecord(request.TeacherId);
-            if (!found)
+            if (contact is null)
             {
                 throw new NotFoundException(resourceName: Contact.EntityLogicalName, request.TeacherId);
             }
 
-            return Unit.Value;
+            if (contact.dfeta_ActiveSanctions == true)
+            {
+                throw new ErrorException(ErrorRegistry.TeacherHasActiveSanctions());
+            }
+
+            if (contact.dfeta_loginfailedcounter is null || contact.dfeta_loginfailedcounter < 3)
+            {
+                return new UnlockTeacherResponse()
+                {
+                    HasBeenUnlocked = false
+                };
+            }
+
+            await _dataverseAdapter.UnlockTeacherRecord(request.TeacherId);
+
+            return new UnlockTeacherResponse()
+            {
+                HasBeenUnlocked = true
+            };
         }
     }
 }

--- a/src/DqtApi/V2/Requests/UnlockTeacherRequest.cs
+++ b/src/DqtApi/V2/Requests/UnlockTeacherRequest.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using DqtApi.V2.Responses;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace DqtApi.V2.Requests
 {
-    public class UnlockTeacherRequest : IRequest
+    public class UnlockTeacherRequest : IRequest<UnlockTeacherResponse>
     {
         [FromRoute(Name = "teacherId")]
         [SwaggerParameter(description: "The ID of the teacher record to unlock")]

--- a/src/DqtApi/V2/Responses/UnlockTeacherResponse.cs
+++ b/src/DqtApi/V2/Responses/UnlockTeacherResponse.cs
@@ -1,0 +1,10 @@
+﻿using Swashbuckle.AspNetCore.Annotations;
+
+namespace DqtApi.V2.Responses
+{
+    public class UnlockTeacherResponse
+    {
+        [SwaggerSchema(description: "Whether the account has been unlocked")]
+        public bool HasBeenUnlocked { get; set; }
+    }
+}


### PR DESCRIPTION
Also changed behavior to leave the loginfailedcounter as-is unless it's over the locked threshold.

### Context

https://trello.com/c/sCZ4KJ5F/670-log-dqt-accounts-unlocked-by-find

### Changes proposed in this pull request

Return a flag indicating whether the teacher was actually unlocked.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
