### PR TITLE
Revert "Allow tests to fail for now"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
         IntegrationTests_BuildEnvLockBlobUri: ${{ secrets.INTEGRATIONTESTS_BUILDENVLOCKBLOBURI }}
         IntegrationTests_BuildEnvLockBlobSasToken: ${{ secrets.INTEGRATIONTESTS_BUILDENVLOCKBLOBSASTOKEN }}
         ConnectionStrings__DefaultConnection: "Host=localhost;Username=postgres;Password=${{ secrets.POSTGRES_PASSWORD }};Database=dqt"
-      continue-on-error: true
 
     - name: Test report
       uses: dorny/test-reporter@v1
@@ -88,7 +87,6 @@ jobs:
         name: Test results
         path: "**/*.trx"
         reporter: dotnet-trx
-      continue-on-error: true
 
     # TODO Use migration bundles when https://github.com/dotnet/efcore/issues/25555 is fixed
     - name: Generate migrations artifact


### PR DESCRIPTION
This reverts commit a51192638ffcfe941ef2f06d6fd279c871c8adab.

### Context

Include relevant motivation and context.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
