### PR TITLE
Only return active records from v1 Get Teacher endpoint

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -319,6 +319,10 @@ namespace DqtApi.DataStore.Crm
 
                 initialTeacherTrainingLink.EntityAlias = nameof(dfeta_initialteachertraining);
 
+                var filter = new FilterExpression();
+                filter.AddCondition(dfeta_initialteachertraining.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_initialteachertrainingState.Active);
+                initialTeacherTrainingLink.LinkCriteria = filter;
+
                 AddSubjectLinks(initialTeacherTrainingLink);
             }
 
@@ -342,6 +346,10 @@ namespace DqtApi.DataStore.Crm
                 subjectLink.Columns = new ColumnSet(dfeta_ittsubject.Fields.dfeta_Value);
 
                 subjectLink.EntityAlias = alias;
+
+                var filter = new FilterExpression();
+                filter.AddCondition(dfeta_ittsubject.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_ittsubjectState.Active);
+                subjectLink.LinkCriteria = filter;
             }
 
             static void AddInductionLink(QueryExpression query)
@@ -361,6 +369,10 @@ namespace DqtApi.DataStore.Crm
                 );
 
                 inductionLink.EntityAlias = nameof(dfeta_induction);
+
+                var filter = new FilterExpression();
+                filter.AddCondition(dfeta_induction.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_inductionState.Active);
+                inductionLink.LinkCriteria = filter;
             }
 
             static void AddQualifiedTeacherStatusLink(QueryExpression query)
@@ -381,7 +393,7 @@ namespace DqtApi.DataStore.Crm
                 qualifiedTeacherStatusLink.EntityAlias = nameof(dfeta_qtsregistration);
 
                 var filter = new FilterExpression();
-                filter.AddCondition(dfeta_initialteachertraining.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_initialteachertrainingState.Active);
+                filter.AddCondition(dfeta_qtsregistration.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_qtsregistrationState.Active);
                 qualifiedTeacherStatusLink.LinkCriteria = filter;
             }
         }


### PR DESCRIPTION
### Context

https://trello.com/c/t4OHWRvz/731-stop-returning-inactive-data-on-the-v1-get-teachers-endpoint

### Changes proposed in this pull request

Add a `state == 'Active'` filter to all the joined records in the V1 Get Teacher endpoint.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
