### PR TITLE
Revert "Disable tests on CI until build environment issues are fixed"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,25 +68,25 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release
 
-#    - name: Test
-#      id: test
-#      run: dotnet test tests/DqtApi.Tests --configuration Release --no-build --logger trx
-#      if: github.event_name == 'pull_request'
-#      env:
-#        IntegrationTests_CrmUrl: ${{ secrets.INTEGRATIONTESTS_CRMURL }}
-#        IntegrationTests_CrmClientId: ${{ secrets.INTEGRATIONTESTS_CRMCLIENTID }}
-#        IntegrationTests_CrmClientSecret: ${{ secrets.INTEGRATIONTESTS_CRMCLIENTSECRET }}
-#        IntegrationTests_BuildEnvLockBlobUri: ${{ secrets.INTEGRATIONTESTS_BUILDENVLOCKBLOBURI }}
-#        IntegrationTests_BuildEnvLockBlobSasToken: ${{ secrets.INTEGRATIONTESTS_BUILDENVLOCKBLOBSASTOKEN }}
-#        ConnectionStrings__DefaultConnection: "Host=localhost;Username=postgres;Password=${{ secrets.POSTGRES_PASSWORD }};Database=dqt"
-#
-#    - name: Test report
-#      uses: dorny/test-reporter@v1
-#      if: always() && github.event_name == 'pull_request'
-#      with:
-#        name: Test results
-#        path: "**/*.trx"
-#        reporter: dotnet-trx
+    - name: Test
+      id: test
+      run: dotnet test tests/DqtApi.Tests --configuration Release --no-build --logger trx
+      if: github.event_name == 'pull_request'
+      env:
+        IntegrationTests_CrmUrl: ${{ secrets.INTEGRATIONTESTS_CRMURL }}
+        IntegrationTests_CrmClientId: ${{ secrets.INTEGRATIONTESTS_CRMCLIENTID }}
+        IntegrationTests_CrmClientSecret: ${{ secrets.INTEGRATIONTESTS_CRMCLIENTSECRET }}
+        IntegrationTests_BuildEnvLockBlobUri: ${{ secrets.INTEGRATIONTESTS_BUILDENVLOCKBLOBURI }}
+        IntegrationTests_BuildEnvLockBlobSasToken: ${{ secrets.INTEGRATIONTESTS_BUILDENVLOCKBLOBSASTOKEN }}
+        ConnectionStrings__DefaultConnection: "Host=localhost;Username=postgres;Password=${{ secrets.POSTGRES_PASSWORD }};Database=dqt"
+
+    - name: Test report
+      uses: dorny/test-reporter@v1
+      if: always() && github.event_name == 'pull_request'
+      with:
+        name: Test results
+        path: "**/*.trx"
+        reporter: dotnet-trx
 
     # TODO Use migration bundles when https://github.com/dotnet/efcore/issues/25555 is fixed
     - name: Generate migrations artifact


### PR DESCRIPTION
This reverts commit bd85c4b51cbda1339d1d3574f6e2564417027256.

Issues were caused by old test data that had TRNs allocated that were *ahead* of the autonumber range, hence the collisions.