### PR TITLE
Don't return an error if the ITT provider lookup returns no results

### DIFF
--- a/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
+++ b/src/DqtApi/V2/Handlers/FindTeachersHandler.cs
@@ -9,16 +9,19 @@ using DqtApi.V2.Requests;
 using DqtApi.V2.Responses;
 using DqtApi.Validation;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace DqtApi.V2.Handlers
 {
     public class FindTeachersHandler : IRequestHandler<FindTeachersRequest, FindTeachersResponse>
     {
         private readonly IDataverseAdapter _dataverseAdapter;
+        private readonly ILogger<FindTeachersHandler> _logger;
 
-        public FindTeachersHandler(IDataverseAdapter dataverseAdapter)
+        public FindTeachersHandler(IDataverseAdapter dataverseAdapter, ILogger<FindTeachersHandler> logger)
         {
             _dataverseAdapter = dataverseAdapter;
+            _logger = logger;
         }
 
         public async Task<FindTeachersResponse> Handle(FindTeachersRequest request, CancellationToken cancellationToken)
@@ -31,7 +34,7 @@ namespace DqtApi.V2.Handlers
 
                 if (ittProviders.Length == 0)
                 {
-                    throw new ErrorException(ErrorRegistry.OrganisationNotFound());
+                    _logger.LogDebug("Failed to find an ITT provider by UKPRN: '{IttProviderUkprn}'.", request.IttProviderUkprn);
                 }
             }
             else if (!string.IsNullOrEmpty(request.IttProviderName))
@@ -40,7 +43,7 @@ namespace DqtApi.V2.Handlers
 
                 if (ittProviders.Length == 0)
                 {
-                    throw new ErrorException(ErrorRegistry.OrganisationNotFound());
+                    _logger.LogDebug("Failed to find an ITT provider by name: '{IttProviderName}'.", request.IttProviderName);
                 }
             }
 

--- a/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/tests/DqtApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -102,28 +102,6 @@ namespace DqtApi.Tests.V2.Operations
                 expectedStatusCode: StatusCodes.Status200OK);
         }
 
-
-        [Theory]
-        [InlineData("someProvider", "")]
-        [InlineData(null, "1005811506")]
-        public async Task Given_provider_does_not_exist_returns_error(string providerName, string providerUkprn)
-        {
-            // Arrange
-            var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 1, 1), dfeta_TRN = "someReference" };
-
-            ApiFixture.DataverseAdapter
-                .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
-                .ReturnsAsync(new[] { contact1 });
-
-            var request = new HttpRequestMessage(HttpMethod.Get, $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}&IttProviderUkPrn={providerUkprn}&IttProviderName={providerName}");
-
-            // Act
-            var response = await HttpClient.SendAsync(request);
-
-            // Assert
-            Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        }
-
         [Theory]
         [InlineData("someProvider", "")]
         [InlineData(null, "1005811506")]


### PR DESCRIPTION
### Context

The current `find` operation will return an error if either the ITT provider UKPRN or name is specified but the lookup doesn't return a successful result. This effectively means a non-exact match on the ITT provider name will fail the lookup completely. That's not desirable.

https://trello.com/c/VhsP8hmX/206-amend-find-api-to-not-return-an-error-if-the-itt-provider-lookup-fails

### Changes proposed in this pull request

Don't return an error if the ITT provider lookup returns no results.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
