### PR TITLE
Amend HUSID duplicate check to look at ID instead of TRN

### DIFF
--- a/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -666,11 +666,9 @@ namespace DqtApi.DataStore.Crm
                             _ => _dataverseAdapter.GetTeacherStatus(teacherStatusId, qtsDateRequired, requestBuilder))) :
                     Task.FromResult<dfeta_teacherstatus>(null);
 
-                var existingTeachersWithHusIdTask = !string.IsNullOrEmpty(_command.HusId) ? _dataverseAdapter.GetTeachersByHusId(_command.HusId, columnNames: new[]
-                {
-                    Contact.Fields.dfeta_TRN,
-                    Contact.Fields.dfeta_HUSID,
-                }) : Task.FromResult<Contact[]>(null);
+                var existingTeachersWithHusIdTask = !string.IsNullOrEmpty(_command.HusId) ?
+                    _dataverseAdapter.GetTeachersByHusId(_command.HusId) :
+                    Task.FromResult<Contact[]>(null);
 
                 var lookupTasks = new Task[]
                 {
@@ -714,7 +712,7 @@ namespace DqtApi.DataStore.Crm
                     TeacherStatusId = getTeacherStatusTask?.Result?.Id,
                     QualificationSubject2Id = getQualificationSubjectTask2?.Result?.Id,
                     QualificationSubject3Id = getQualificationSubjectTask3?.Result?.Id,
-                    HaveExistingTeacherWithHusId = existingTeachersWithHusIdTask?.Result?.Count() > 0
+                    HaveExistingTeacherWithHusId = existingTeachersWithHusIdTask?.Result?.Length > 0
                 };
             }
 

--- a/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
+++ b/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
@@ -147,10 +147,11 @@ namespace DqtApi.DataStore.Crm
                 _dataverseAdapter = dataverseAdapter;
                 _command = command;
                 TeacherId = command.TeacherId;
-                Trn = command.TRN;
+                Trn = command.Trn;
             }
 
             public Guid TeacherId { get; }
+
             public string Trn { get; }
 
             public (dfeta_initialteachertraining Result, UpdateTeacherFailedReasons? FailedReason) SelectIttRecord(
@@ -650,7 +651,7 @@ namespace DqtApi.DataStore.Crm
                     Qualifications = getQualifications.Result,
                     TeacherHasActiveSanctions = getTeacherTask.Result?.dfeta_ActiveSanctions == true,
                     TeacherHusId = getTeacherTask.Result?.dfeta_HUSID,
-                    HaveExistingTeacherWithHusId = existingTeachersWithHusIdTask?.Result != null && existingTeachersWithHusIdTask?.Result.Select(x => x.dfeta_TRN != _command.TRN).Count() > 0
+                    HaveExistingTeacherWithHusId = existingTeachersWithHusIdTask?.Result != null && existingTeachersWithHusIdTask.Result.Count(x => x.Id != _command.TeacherId) > 0
                 };
             }
         }

--- a/DqtApi/src/DqtApi/DataStore/Crm/UpdateTeacherCommand.cs
+++ b/DqtApi/src/DqtApi/DataStore/Crm/UpdateTeacherCommand.cs
@@ -8,7 +8,7 @@ namespace DqtApi.DataStore.Crm
         public Guid TeacherId { get; set; }
         public UpdateTeacherCommandInitialTeacherTraining InitialTeacherTraining { get; set; }
         public UpdateTeacherCommandQualification Qualification { get; set; }
-        public string TRN { get; set; }
+        public string Trn { get; set; }
         public string HusId { get; set; }
     }
 

--- a/DqtApi/src/DqtApi/V2/Handlers/UpdateTeacherHandler.cs
+++ b/DqtApi/src/DqtApi/V2/Handlers/UpdateTeacherHandler.cs
@@ -50,7 +50,7 @@ namespace DqtApi.V2.Handlers
             var updateTeacherResult = await _dataverseAdapter.UpdateTeacher(new UpdateTeacherCommand()
             {
                 TeacherId = teachers[0].Id,
-                TRN = request.Trn,
+                Trn = request.Trn,
                 InitialTeacherTraining = new UpdateTeacherCommandInitialTeacherTraining()
                 {
                     ProviderUkprn = request.InitialTeacherTraining.ProviderUkprn,

--- a/DqtApi/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
+++ b/DqtApi/tests/DqtApi.Tests/DataverseIntegration/UpdateTeacherTests.cs
@@ -880,7 +880,7 @@ namespace DqtApi.Tests.DataverseIntegration
             // Arrange
             var teacherId = Guid.NewGuid();
             var trn = "1234567";
-            var updateCommand = new UpdateTeacherCommand() { TRN = trn, TeacherId = teacherId };
+            var updateCommand = new UpdateTeacherCommand() { Trn = trn, TeacherId = teacherId };
             var helper = new DataverseAdapter.UpdateTeacherHelper(_dataverseAdapter, updateCommand);
 
             // Act
@@ -896,7 +896,7 @@ namespace DqtApi.Tests.DataverseIntegration
             // Arrange
             var teacherId = Guid.NewGuid();
             var trn = "1234567";
-            var updateCommand = new UpdateTeacherCommand() { TRN = trn, TeacherId = teacherId };
+            var updateCommand = new UpdateTeacherCommand() { Trn = trn, TeacherId = teacherId };
             var helper = new DataverseAdapter.UpdateTeacherHelper(_dataverseAdapter, updateCommand);
 
             // Act
@@ -918,7 +918,7 @@ namespace DqtApi.Tests.DataverseIntegration
             var date = new DateOnly(1990, 01, 05);
             var ProviderUkprn = "12345";
             var qualification = new UpdateTeacherCommandQualification() { Subject = subject, Class = classdivision, CountryCode = countrycode, Date = date, ProviderUkprn = ProviderUkprn };
-            var updateCommand = new UpdateTeacherCommand() { Qualification = qualification, TRN = trn, TeacherId = teacherId };
+            var updateCommand = new UpdateTeacherCommand() { Qualification = qualification, Trn = trn, TeacherId = teacherId };
             var helper = new DataverseAdapter.UpdateTeacherHelper(_dataverseAdapter, updateCommand);
 
             // Act


### PR DESCRIPTION
Previously we looked at TRN to know if the matched record was the same one as we're updating. This amends that check to look at ID instead. That's little more robust as IDs don't change and move around like TRNs do.