### PR TITLE
Use Redis instead of Postgres for locking

### DIFF
--- a/src/DqtApi/DqtApi.csproj
+++ b/src/DqtApi/DqtApi.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="1.0.9" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.6" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
+    <PackageReference Include="RedLock.net" Version="2.3.2" />
     <PackageReference Include="Scrutor" Version="4.2.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="3.20.1" />
     <PackageReference Include="Sentry.Serilog" Version="3.20.1" />

--- a/src/DqtApi/NoopAsyncDisposable.cs
+++ b/src/DqtApi/NoopAsyncDisposable.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace DqtApi
+{
+    public sealed class NoopAsyncDisposable : IAsyncDisposable
+    {
+        private NoopAsyncDisposable()
+        {
+        }
+
+        public static NoopAsyncDisposable Instance { get; } = new NoopAsyncDisposable();
+
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/src/DqtApi/Services/IDistributedLockService.cs
+++ b/src/DqtApi/Services/IDistributedLockService.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DqtApi.Services
+{
+    public interface IDistributedLockService
+    {
+        System.Threading.Tasks.Task<IAsyncDisposable> AcquireLock(string key, TimeSpan timeout);
+    }
+}

--- a/src/DqtApi/Services/LocalDistributedLockService.cs
+++ b/src/DqtApi/Services/LocalDistributedLockService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DqtApi.Services
+{
+    public class LocalDistributedLockService : IDistributedLockService
+    {
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+
+        public async Task<IAsyncDisposable> AcquireLock(string key, TimeSpan timeout)
+        {
+            var sem = _locks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+            if (!await sem.WaitAsync(timeout))
+            {
+                throw new Exception($"Failed to acquire lock for key: '{key}' after {timeout.TotalSeconds}s.");
+            }
+            return new LockDisposableWrapper(sem);
+        }
+
+        private sealed class LockDisposableWrapper : IAsyncDisposable
+        {
+            private readonly SemaphoreSlim _semaphore;
+
+            public LockDisposableWrapper(SemaphoreSlim semaphore)
+            {
+                _semaphore = semaphore;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                _semaphore.Release();
+                return default;
+            }
+        }
+    }
+}

--- a/src/DqtApi/Services/RedisDistributedLockService.cs
+++ b/src/DqtApi/Services/RedisDistributedLockService.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using RedLockNet.SERedis;
+
+namespace DqtApi.Services
+{
+    public class RedisDistributedLockService : IDistributedLockService
+    {
+        private static readonly TimeSpan _lifetime = TimeSpan.FromHours(1);
+        private static readonly TimeSpan _retryPeriod = TimeSpan.FromSeconds(2);
+
+        private readonly RedLockFactory _redLockFactory;
+
+        public RedisDistributedLockService(RedLockFactory redLockFactory)
+        {
+            _redLockFactory = redLockFactory;
+        }
+
+        public async System.Threading.Tasks.Task<IAsyncDisposable> AcquireLock(string key, TimeSpan timeout)
+        {
+            var @lock = await _redLockFactory.CreateLockAsync(key, _lifetime, waitTime: timeout, retryTime: _retryPeriod);
+
+            if (!@lock.IsAcquired)
+            {
+                await @lock.DisposeAsync();
+                throw new Exception($"Failed to acquire lock for key: '{key}' after {timeout.TotalSeconds}s.");
+            }
+
+            return @lock;
+        }
+    }
+}

--- a/src/DqtApi/V2/Handlers/SetIttOutcomeHandler.cs
+++ b/src/DqtApi/V2/Handlers/SetIttOutcomeHandler.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm;
-using DqtApi.DataStore.Sql;
+using DqtApi.Services;
 using DqtApi.V2.ApiModels;
 using DqtApi.V2.Requests;
 using DqtApi.V2.Responses;
@@ -14,20 +14,20 @@ namespace DqtApi.V2.Handlers
 {
     public class SetIttOutcomeHandler : IRequestHandler<SetIttOutcomeRequest, SetIttOutcomeResponse>
     {
-        private readonly IDataverseAdapter _dataverseAdapter;
-        private readonly DqtContext _dqtContext;
+        private static readonly TimeSpan _lockTimeout = TimeSpan.FromMinutes(1);
 
-        public SetIttOutcomeHandler(IDataverseAdapter dataverseAdapter, DqtContext dqtContext)
+        private readonly IDataverseAdapter _dataverseAdapter;
+        private readonly IDistributedLockService _distributedLockService;
+
+        public SetIttOutcomeHandler(IDataverseAdapter dataverseAdapter, IDistributedLockService distributedLockService)
         {
             _dataverseAdapter = dataverseAdapter;
-            _dqtContext = dqtContext;
+            _distributedLockService = distributedLockService;
         }
 
         public async Task<SetIttOutcomeResponse> Handle(SetIttOutcomeRequest request, CancellationToken cancellationToken)
         {
-            using var transaction = await _dqtContext.Database.BeginTransactionAsync();
-
-            await transaction.AcquireAdvisoryLock(request.Trn);
+            await using var trnLock = await _distributedLockService.AcquireLock(request.Trn, _lockTimeout);
 
             var teachers = (await _dataverseAdapter.GetTeachersByTrnAndDoB(request.Trn, request.BirthDate.Value, activeOnly: true)).ToArray();
 


### PR DESCRIPTION
We're seeing various API issues that seem to come from Postgres' advisory locks not behaving as we expect them to. Until we understand why this replaces PG advisory locks with Redis and its Redlock algorithm.