### PR TITLE
Don't filter out inactive subjects in Get Teacher endpoint

### DIFF
--- a/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -346,10 +346,6 @@ namespace DqtApi.DataStore.Crm
                 subjectLink.Columns = new ColumnSet(dfeta_ittsubject.Fields.dfeta_Value);
 
                 subjectLink.EntityAlias = alias;
-
-                var filter = new FilterExpression();
-                filter.AddCondition(dfeta_ittsubject.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_ittsubjectState.Active);
-                subjectLink.LinkCriteria = filter;
             }
 
             static void AddInductionLink(QueryExpression query)


### PR DESCRIPTION
### Context

Previous change to ignore all inactive data was too aggressive; we do want to return subjects even if they're inactive.

### Changes proposed in this pull request

Return inactive subjects from Get Teacher endpoint

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
