### PR TITLE
Fix TRN endpoint when qualification has no date

### DIFF
--- a/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -102,7 +102,7 @@ namespace DqtApi.V2.Handlers
                         ProviderUkprn = request.InitialTeacherTraining.ProviderUkprn,
                         ProgrammeStartDate = request.InitialTeacherTraining.ProgrammeStartDate.Value,
                         ProgrammeEndDate = request.InitialTeacherTraining.ProgrammeEndDate.Value,
-                        ProgrammeType = request.InitialTeacherTraining.ProgrammeType.Value.ConvertToIttProgrammeType(),
+                        //ProgrammeType = request.InitialTeacherTraining.ProgrammeType.Value.ConvertToIttProgrammeType(),
                         Subject1 = request.InitialTeacherTraining.Subject1,
                         Subject2 = request.InitialTeacherTraining.Subject2,
                         Subject3 = request.InitialTeacherTraining.Subject3,
@@ -118,7 +118,7 @@ namespace DqtApi.V2.Handlers
                             CountryCode = request.Qualification.CountryCode,
                             Subject = request.Qualification.Subject,
                             Class = request.Qualification.Class?.ConvertToClassDivision(),
-                            Date = request.Qualification.Date.Value,
+                            Date = request.Qualification.Date,
                             HeQualificationValue = request.Qualification.HeQualificationType?.GetHeQualificationValue(),
                             Subject2 = request.Qualification.Subject2,
                             Subject3 = request.Qualification.Subject3


### PR DESCRIPTION
We have an error in Sentry caused by us doing `.Value` on an optional `DateOnly?` property. This removes the `.Value` call.

### Checklist

~~-   [] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
