### PR TITLE
Integrate trn generation api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,8 @@ jobs:
           -e IntegrationTests_CrmClientSecret="${{ secrets.INTEGRATIONTESTS_CRMCLIENTSECRET }}"
           -e IntegrationTests_BuildEnvLockBlobUri="${{ secrets.INTEGRATIONTESTS_BUILDENVLOCKBLOBURI }}"
           -e IntegrationTests_BuildEnvLockBlobSasToken="${{ secrets.INTEGRATIONTESTS_BUILDENVLOCKBLOBSASTOKEN }}"
+          -e IntegrationTests_TrnGenerationApi__BaseAddress="${{ secrets.INTEGRATIONTESTS_BUILDENVTRNGENERATIONAPIBASEADDRESS }}"
+          -e IntegrationTests_TrnGenerationApi__ApiKey="${{ secrets.INTEGRATIONTESTS_BUILDENVTRNGENERATIONAPIAPIKEY }}"
           -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=${{ secrets.POSTGRES_PASSWORD }};Database=dqt"
 
     # TODO Use migration bundles when https://github.com/dotnet/efcore/issues/25555 is fixed

--- a/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -38,6 +38,15 @@ namespace DqtApi.DataStore.Crm
                 return (CreateTeacherResult.Failed(failedReasons), null);
             }
 
+            var newContact = helper.CreateContactEntity();
+            string trn = null;
+            bool isUseTrnGenerationApiFeatureEnabled = await _featureManager.IsEnabledAsync(FeatureFlags.UseTrnGenerationApi);
+            if (isUseTrnGenerationApiFeatureEnabled)
+            {
+                trn = await _trnGenerationApiClient.GenerateTrnAsync();
+                newContact.dfeta_TRN= trn;
+            }
+
             // Send a single Transaction request with all the data changes in.
             // This is important for atomicity; we really do not want torn writes here.
             var txnRequest = new ExecuteTransactionRequest()
@@ -45,7 +54,7 @@ namespace DqtApi.DataStore.Crm
                 ReturnResponses = true,
                 Requests = new()
                 {
-                    new CreateRequest() { Target = helper.CreateContactEntity() },
+                    new CreateRequest() { Target = newContact },
                     new CreateRequest() { Target = helper.CreateInitialTeacherTrainingEntity(referenceData) },
                     new CreateRequest() { Target = helper.CreateQualificationEntity(referenceData) }
                 }
@@ -58,23 +67,26 @@ namespace DqtApi.DataStore.Crm
 
             if (allocateTrn)
             {
-                // Set the flag to allocate a TRN
-                // N.B. setting this attribute has to be in an Update, setting it in the initial Create doesn't work
-                txnRequest.Requests.Add(new UpdateRequest()
+                if (!isUseTrnGenerationApiFeatureEnabled)
                 {
-                    Target = new Contact()
+                    // Set the flag to allocate a TRN
+                    // N.B. setting this attribute has to be in an Update, setting it in the initial Create doesn't work
+                    txnRequest.Requests.Add(new UpdateRequest()
                     {
-                        Id = helper.TeacherId,
-                        dfeta_TRNAllocateRequest = _clock.UtcNow
-                    }
-                });
+                        Target = new Contact()
+                        {
+                            Id = helper.TeacherId,
+                            dfeta_TRNAllocateRequest = _clock.UtcNow
+                        }
+                    });
 
-                // Retrieve the generated TRN
-                txnRequest.Requests.Add(new RetrieveRequest()
-                {
-                    Target = helper.TeacherId.ToEntityReference(Contact.EntityLogicalName),
-                    ColumnSet = new ColumnSet(Contact.Fields.dfeta_TRN)
-                });
+                    // Retrieve the generated TRN
+                    txnRequest.Requests.Add(new RetrieveRequest()
+                    {
+                        Target = helper.TeacherId.ToEntityReference(Contact.EntityLogicalName),
+                        ColumnSet = new ColumnSet(Contact.Fields.dfeta_TRN)
+                    });
+                }
             }
             else
             {
@@ -113,10 +125,11 @@ namespace DqtApi.DataStore.Crm
 
             var txnResponse = (ExecuteTransactionResponse)await _service.ExecuteAsync(txnRequest);
 
-            // If a TRN was allocated we have a RetrieveResponse that contains the value
-            string trn = allocateTrn ?
-                txnResponse.Responses.OfType<RetrieveResponse>().Single().Entity.ToEntity<Contact>().dfeta_TRN :
-                null;
+            // If a TRN was allocated via CRM we have a RetrieveResponse that contains the value otherwise it should already be set from the TRN Generation API
+            if (allocateTrn && !isUseTrnGenerationApiFeatureEnabled)
+            {
+                trn = txnResponse.Responses.OfType<RetrieveResponse>().Single().Entity.ToEntity<Contact>().dfeta_TRN;
+            }
 
             return (CreateTeacherResult.Success(helper.TeacherId, trn), txnRequest);
         }

--- a/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
+++ b/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.cs
@@ -6,7 +6,9 @@ using System.Net;
 using System.ServiceModel;
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm.Models;
+using DqtApi.Services.TrnGenerationApi;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.FeatureManagement;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.PowerPlatform.Dataverse.Client.Utils;
 using Microsoft.Xrm.Sdk;
@@ -20,15 +22,21 @@ namespace DqtApi.DataStore.Crm
         private readonly IOrganizationServiceAsync _service;
         private readonly IClock _clock;
         private readonly IMemoryCache _cache;
+        private readonly IFeatureManager _featureManager;
+        private readonly ITrnGenerationApiClient _trnGenerationApiClient;
 
         public DataverseAdapter(
             IOrganizationServiceAsync organizationServiceAsync,
             IClock clock,
-            IMemoryCache cache)
+            IMemoryCache cache,
+            IFeatureManager featureManager,
+            ITrnGenerationApiClient trnGenerationApiClient)
         {
             _service = organizationServiceAsync;
             _clock = clock;
             _cache = cache;
+            _featureManager = featureManager;
+            _trnGenerationApiClient = trnGenerationApiClient;
         }
 
         public Task<dfeta_country> GetCountry(string value) => GetCountry(value, requestBuilder: null);

--- a/DqtApi/src/DqtApi/DqtApi.csproj
+++ b/DqtApi/src/DqtApi/DqtApi.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.8" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.9" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="1.0.9" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.6" />

--- a/DqtApi/src/DqtApi/FeatureFlags.cs
+++ b/DqtApi/src/DqtApi/FeatureFlags.cs
@@ -1,0 +1,7 @@
+﻿namespace DqtApi
+{
+    public static class FeatureFlags
+    {
+        public const string UseTrnGenerationApi = "UseTrnGenerationApi";
+    }
+}

--- a/DqtApi/src/DqtApi/Program.cs
+++ b/DqtApi/src/DqtApi/Program.cs
@@ -13,6 +13,7 @@ using DqtApi.Logging;
 using DqtApi.ModelBinding;
 using DqtApi.Security;
 using DqtApi.Services;
+using DqtApi.Services.TrnGenerationApi;
 using DqtApi.Swagger;
 using DqtApi.Validation;
 using FluentValidation;
@@ -31,6 +32,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 using Microsoft.OpenApi.Models;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Npgsql;
@@ -66,6 +68,8 @@ namespace DqtApi
 
             builder.Services.AddApplicationInsightsTelemetry()
                 .AddApplicationInsightsTelemetryProcessor<RedactedUrlTelemetryProcessor>();
+
+            builder.Services.AddFeatureManagement();
 
             if (env.IsProduction())
             {
@@ -217,6 +221,8 @@ namespace DqtApi
             });
 
             services.AddDatabaseDeveloperPageExceptionFilter();
+
+            services.AddTrnGenerationApi(configuration);
 
             if (env.EnvironmentName != "Testing")
             {

--- a/DqtApi/src/DqtApi/Services/TrnGenerationApi/ITrnGenerationApiClient.cs
+++ b/DqtApi/src/DqtApi/Services/TrnGenerationApi/ITrnGenerationApiClient.cs
@@ -1,9 +1,9 @@
-﻿namespace DqtApi.Services.TrnGenerationApi
-{
-    using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
+namespace DqtApi.Services.TrnGenerationApi
+{
     public interface ITrnGenerationApiClient
     {
-        Task<string> GenerateTrnAsync();
+        Task<string> GenerateTrn();
     }
 }

--- a/DqtApi/src/DqtApi/Services/TrnGenerationApi/ITrnGenerationApiClient.cs
+++ b/DqtApi/src/DqtApi/Services/TrnGenerationApi/ITrnGenerationApiClient.cs
@@ -1,0 +1,9 @@
+﻿namespace DqtApi.Services.TrnGenerationApi
+{
+    using System.Threading.Tasks;
+
+    public interface ITrnGenerationApiClient
+    {
+        Task<string> GenerateTrnAsync();
+    }
+}

--- a/DqtApi/src/DqtApi/Services/TrnGenerationApi/NoopTrnGenerationApiClient.cs
+++ b/DqtApi/src/DqtApi/Services/TrnGenerationApi/NoopTrnGenerationApiClient.cs
@@ -1,13 +1,12 @@
-﻿namespace DqtApi.Services.TrnGenerationApi
-{
-    using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
-    public class NoopTrnGenerationApiClient : ITrnGenerationApiClient
+namespace DqtApi.Services.TrnGenerationApi;
+
+public class NoopTrnGenerationApiClient : ITrnGenerationApiClient
+{
+    public Task<string> GenerateTrn()
     {
-        public Task<string> GenerateTrnAsync()
-        {
-            string trn = null;
-            return Task.FromResult(trn);
-        }
+        string trn = null;
+        return Task.FromResult(trn);
     }
 }

--- a/DqtApi/src/DqtApi/Services/TrnGenerationApi/NoopTrnGenerationApiClient.cs
+++ b/DqtApi/src/DqtApi/Services/TrnGenerationApi/NoopTrnGenerationApiClient.cs
@@ -1,0 +1,13 @@
+﻿namespace DqtApi.Services.TrnGenerationApi
+{
+    using System.Threading.Tasks;
+
+    public class NoopTrnGenerationApiClient : ITrnGenerationApiClient
+    {
+        public Task<string> GenerateTrnAsync()
+        {
+            string trn = null;
+            return Task.FromResult(trn);
+        }
+    }
+}

--- a/DqtApi/src/DqtApi/Services/TrnGenerationApi/ServiceCollectionExtensions.cs
+++ b/DqtApi/src/DqtApi/Services/TrnGenerationApi/ServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace DqtApi.Services.TrnGenerationApi;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddTrnGenerationApi(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddOptions<TrnGenerationApiOptions>()
+                .Bind(configuration.GetSection("TrnGenerationApi"))
+                .ValidateDataAnnotations();
+
+        services
+            .AddHttpClient<ITrnGenerationApiClient, TrnGenerationApiClient>((sp, httpClient) =>
+            {
+                var options = sp.GetRequiredService<IOptions<TrnGenerationApiOptions>>();
+                httpClient.BaseAddress = new Uri(options.Value.BaseAddress);
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.Value.ApiKey);
+            });
+
+        services
+            .AddSingleton<ITrnGenerationApiClient>(sp =>
+            {
+                var featureManager = sp.GetRequiredService<IFeatureManager>();
+                var isUseTrnGenerationApiEnabled = featureManager.IsEnabledAsync(FeatureFlags.UseTrnGenerationApi).GetAwaiter().GetResult();
+                if (isUseTrnGenerationApiEnabled)
+                {
+                    var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+                    var httpClient = httpClientFactory.CreateClient(nameof(ITrnGenerationApiClient));
+                    return new TrnGenerationApiClient(httpClient);
+                }
+                else
+                {
+                    return new NoopTrnGenerationApiClient();
+                }
+            });
+
+        return services;
+    }
+}

--- a/DqtApi/src/DqtApi/Services/TrnGenerationApi/TrnGenerationApiClient.cs
+++ b/DqtApi/src/DqtApi/Services/TrnGenerationApi/TrnGenerationApiClient.cs
@@ -1,0 +1,30 @@
+﻿namespace DqtApi.Services.TrnGenerationApi
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    public class TrnGenerationApiClient : ITrnGenerationApiClient
+    {
+        private readonly HttpClient _httpClient;
+
+        public TrnGenerationApiClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<string> GenerateTrnAsync()
+        {
+            string nextTrn = null;
+            var response = await _httpClient.PostAsync("/api/v1/trn-requests", null);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorMessage = $"Error calling REST API to generate a TRN, Status Code {response.StatusCode}, Reason {response.ReasonPhrase}.";
+                throw new InvalidOperationException(errorMessage);
+            }
+
+            nextTrn = await response.Content.ReadAsStringAsync();
+            return nextTrn;
+        }
+    }
+}

--- a/DqtApi/src/DqtApi/Services/TrnGenerationApi/TrnGenerationApiClient.cs
+++ b/DqtApi/src/DqtApi/Services/TrnGenerationApi/TrnGenerationApiClient.cs
@@ -1,30 +1,29 @@
-﻿namespace DqtApi.Services.TrnGenerationApi
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DqtApi.Services.TrnGenerationApi;
+
+public class TrnGenerationApiClient : ITrnGenerationApiClient
 {
-    using System;
-    using System.Net.Http;
-    using System.Threading.Tasks;
+    private readonly HttpClient _httpClient;
 
-    public class TrnGenerationApiClient : ITrnGenerationApiClient
+    public TrnGenerationApiClient(HttpClient httpClient)
     {
-        private readonly HttpClient _httpClient;
+        _httpClient = httpClient;
+    }
 
-        public TrnGenerationApiClient(HttpClient httpClient)
+    public async Task<string> GenerateTrn()
+    {
+        string nextTrn = null;
+        var response = await _httpClient.PostAsync("/api/v1/trn-requests", null);
+        if (!response.IsSuccessStatusCode)
         {
-            _httpClient = httpClient;
+            var errorMessage = $"Error calling REST API to generate a TRN, Status Code {response.StatusCode}, Reason {response.ReasonPhrase}.";
+            throw new InvalidOperationException(errorMessage);
         }
 
-        public async Task<string> GenerateTrnAsync()
-        {
-            string nextTrn = null;
-            var response = await _httpClient.PostAsync("/api/v1/trn-requests", null);
-            if (!response.IsSuccessStatusCode)
-            {
-                var errorMessage = $"Error calling REST API to generate a TRN, Status Code {response.StatusCode}, Reason {response.ReasonPhrase}.";
-                throw new InvalidOperationException(errorMessage);
-            }
-
-            nextTrn = await response.Content.ReadAsStringAsync();
-            return nextTrn;
-        }
+        nextTrn = await response.Content.ReadAsStringAsync();
+        return nextTrn;
     }
 }

--- a/DqtApi/src/DqtApi/Services/TrnGenerationApi/TrnGenerationApiOptions.cs
+++ b/DqtApi/src/DqtApi/Services/TrnGenerationApi/TrnGenerationApiOptions.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeacherIdentity.AuthServer.Services.DqtApi;
+
+public class TrnGenerationApiOptions
+{
+    [Required]
+    public string ApiKey { get; init; }
+
+    [Required]
+    public string BaseAddress { get; init; }
+}

--- a/DqtApi/src/DqtApi/appsettings.json
+++ b/DqtApi/src/DqtApi/appsettings.json
@@ -21,5 +21,8 @@
     ],
     "Enrich": [ "FromLogContext" ]
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "FeatureManagement": {
+    "UseTrnGenerationApi":  false
+  }
 }

--- a/DqtApi/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/DqtApi/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -9,6 +9,7 @@ namespace DqtApi.Tests.DataverseIntegration
     public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLifetime
     {
         private readonly CreateTeacherFixture _createTeacherFixture;
+        private readonly CrmClientFixture _crmClientFixture;
         private readonly TestableClock _clock;
         private readonly CrmClientFixture.TestDataScope _dataScope;
         private readonly DataverseAdapter _dataverseAdapter;
@@ -17,6 +18,7 @@ namespace DqtApi.Tests.DataverseIntegration
         public CreateTeacherTests(CreateTeacherFixture createTeacherFixture, CrmClientFixture crmClientFixture)
         {
             _createTeacherFixture = createTeacherFixture;
+            _crmClientFixture = crmClientFixture;
             _clock = crmClientFixture.Clock;
             _dataScope = crmClientFixture.CreateTestDataScope();
             _dataverseAdapter = _dataScope.CreateDataverseAdapter();
@@ -103,6 +105,36 @@ namespace DqtApi.Tests.DataverseIntegration
 
             // Act
             var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command);
+
+            // Assert
+            Assert.True(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task Given_minimal_details_request_and_feature_to_generate_trn_via_api_is_enabled_succeeds()
+        {
+            // Arrange
+            var command = new CreateTeacherCommand()
+            {
+                FirstName = "Minnie",
+                LastName = "Ryder",
+                BirthDate = new(1990, 5, 23),
+                GenderCode = Contact_GenderCode.Female,
+                InitialTeacherTraining = new()
+                {
+                    ProviderUkprn = "10044534",  // ARK Teacher Training
+                    ProgrammeStartDate = new(2020, 4, 1),
+                    ProgrammeEndDate = new(2020, 10, 10),
+                    ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
+                    IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
+                }
+            };
+
+            await using var localDataScope = _crmClientFixture.CreateTestDataScope(isUseTrnGenerationApiEnabled: true);
+            var localDataverseAdapter = localDataScope.CreateDataverseAdapter();
+
+            // Act
+            var (result, transactionRequest) = await localDataverseAdapter.CreateTeacherImpl(command);
 
             // Assert
             Assert.True(result.Succeeded);

--- a/DqtApi/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/DqtApi/tests/DqtApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -130,7 +130,7 @@ namespace DqtApi.Tests.DataverseIntegration
                 }
             };
 
-            await using var localDataScope = _crmClientFixture.CreateTestDataScope(isUseTrnGenerationApiEnabled: true);
+            await using var localDataScope = _crmClientFixture.CreateTestDataScope(useTrnGenerationApi: true);
             var localDataverseAdapter = localDataScope.CreateDataverseAdapter();
 
             // Act

--- a/DqtApi/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
+++ b/DqtApi/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
@@ -1,14 +1,19 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
 using DqtApi.DataStore.Crm;
+using DqtApi.Services.TrnGenerationApi;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
 using Microsoft.PowerPlatform.Dataverse.Client;
+using Moq;
 
 namespace DqtApi.Tests.DataverseIntegration
 {
@@ -18,12 +23,21 @@ namespace DqtApi.Tests.DataverseIntegration
         private readonly CancellationTokenSource _completedCts;
         private readonly EnvironmentLockManager _lockManager;
         private readonly IMemoryCache _memoryCache;
+        private readonly IFeatureManager _featureIsEnabledFeatureManager;
+        private readonly IFeatureManager _featureIsNotEnabledFeatureManager;
+        private readonly ITrnGenerationApiClient _realTrnGenerationApiClient;
+        private readonly ITrnGenerationApiClient _noopTrnGenerationApiClient;
 
         public CrmClientFixture(IMemoryCache memoryCache)
         {
             Clock = new();
             Configuration = GetConfiguration();
             _baseServiceClient = GetCrmServiceClient();
+
+            _featureIsEnabledFeatureManager = GetFeatureManager(true);
+            _featureIsNotEnabledFeatureManager = GetFeatureManager(false);
+            _realTrnGenerationApiClient = GetTrnGenerationApiClient(true);
+            _noopTrnGenerationApiClient = GetTrnGenerationApiClient(false);
 
             _completedCts = new CancellationTokenSource();
             _lockManager = new EnvironmentLockManager(Configuration);
@@ -39,9 +53,14 @@ namespace DqtApi.Tests.DataverseIntegration
         /// Creates a scope that owns an implementation of <see cref="IOrganizationServiceAsync2"/> that tracks the entities created through it.
         /// When <see cref="IAsyncDisposable.DisposeAsync"/> is called the created entities will be deleted from CRM.
         /// </summary>
-        public TestDataScope CreateTestDataScope() => new(
+        public TestDataScope CreateTestDataScope(bool isUseTrnGenerationApiEnabled = false) => new(
             _baseServiceClient,
-            orgService => new DataverseAdapter(orgService, Clock, _memoryCache),
+            orgService => new DataverseAdapter(
+                orgService,
+                Clock,
+                _memoryCache,
+                isUseTrnGenerationApiEnabled ? _featureIsEnabledFeatureManager : _featureIsNotEnabledFeatureManager,
+                isUseTrnGenerationApiEnabled ? _realTrnGenerationApiClient : _noopTrnGenerationApiClient),
             _memoryCache);
 
         public void Dispose()
@@ -64,6 +83,33 @@ namespace DqtApi.Tests.DataverseIntegration
                 Configuration["CrmClientId"],
                 Configuration["CrmClientSecret"],
                 useUniqueInstance: true)).Result;
+
+        private IFeatureManager GetFeatureManager(bool isUseTrnGenerationApiEnabled)
+        {
+            var featureManager = Mock.Of<IFeatureManager>();
+            Mock.Get(featureManager)
+                .Setup(f => f.IsEnabledAsync(FeatureFlags.UseTrnGenerationApi))
+                .ReturnsAsync(isUseTrnGenerationApiEnabled);
+            return featureManager;
+        }
+
+        private ITrnGenerationApiClient GetTrnGenerationApiClient(bool isUseTrnGenerationApiEnabled)
+        {
+            ITrnGenerationApiClient trnGenerationApiClient;
+            if (isUseTrnGenerationApiEnabled)
+            {
+                var httpClient = new HttpClient();
+                httpClient.BaseAddress = new Uri(Configuration["TrnGenerationApi:BaseAddress"]);
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Configuration["TrnGenerationApi:ApiKey"]);
+                trnGenerationApiClient = new TrnGenerationApiClient(httpClient);
+            }
+            else
+            {
+                trnGenerationApiClient = new NoopTrnGenerationApiClient();
+            }
+
+            return trnGenerationApiClient;
+        }
 
         public sealed class TestDataScope : IAsyncDisposable
         {

--- a/DqtApi/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
+++ b/DqtApi/tests/DqtApi.Tests/DataverseIntegration/CrmClientFixture.cs
@@ -53,14 +53,14 @@ namespace DqtApi.Tests.DataverseIntegration
         /// Creates a scope that owns an implementation of <see cref="IOrganizationServiceAsync2"/> that tracks the entities created through it.
         /// When <see cref="IAsyncDisposable.DisposeAsync"/> is called the created entities will be deleted from CRM.
         /// </summary>
-        public TestDataScope CreateTestDataScope(bool isUseTrnGenerationApiEnabled = false) => new(
+        public TestDataScope CreateTestDataScope(bool useTrnGenerationApi = false) => new(
             _baseServiceClient,
             orgService => new DataverseAdapter(
                 orgService,
                 Clock,
                 _memoryCache,
-                isUseTrnGenerationApiEnabled ? _featureIsEnabledFeatureManager : _featureIsNotEnabledFeatureManager,
-                isUseTrnGenerationApiEnabled ? _realTrnGenerationApiClient : _noopTrnGenerationApiClient),
+                useTrnGenerationApi ? _featureIsEnabledFeatureManager : _featureIsNotEnabledFeatureManager,
+                useTrnGenerationApi ? _realTrnGenerationApiClient : _noopTrnGenerationApiClient),
             _memoryCache);
 
         public void Dispose()

--- a/DqtApi/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
+++ b/DqtApi/tests/DqtApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Linq;
 using DqtApi.DataStore.Crm;
+using DqtApi.Services.TrnGenerationApi;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
+using Moq;
 using Xunit;
 using static DqtApi.Tests.DataverseIntegration.GetMatchingTeachersFixture.MatchFixture;
 
@@ -16,7 +19,19 @@ namespace DqtApi.Tests.DataverseIntegration
         public GetMatchingTeachersTests(GetMatchingTeachersFixture fixture)
         {
             _fixture = fixture;
-            _dataverseAdapter = new DataverseAdapter(_fixture.Service, new TestableClock(), new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
+
+            var featureManager = Mock.Of<IFeatureManager>();
+            Mock.Get(featureManager)
+                .Setup(f => f.IsEnabledAsync(FeatureFlags.UseTrnGenerationApi))
+                .ReturnsAsync(false);
+            var trnGenerationApiClient = new NoopTrnGenerationApiClient();
+
+            _dataverseAdapter = new DataverseAdapter(
+                _fixture.Service,
+                new TestableClock(),
+                new MemoryCache(Options.Create<MemoryCacheOptions>(new())),
+                featureManager,
+                trnGenerationApiClient);
         }
 
         [Fact]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ dotnet user-secrets --id DqtApiTests set ConnectionStrings:DefaultConnection "Ho
 
 The databases will be created automatically when running the API or tests in development mode.
 
+### External API setup
+
+The DQT API can be configured to call a TRN Generation REST API to generate a TRN.
+The is a feature which can be toggled on and off via config (it will default to being toggled off).
+There are tests with this feature toggled on and off so it does not need to be set in config for tests.
+
+```shell
+dotnet user-secrets --id DqtApi set FeatureManagement:UseTrnGenerationApi true|false
+dotnet user-secrets --id DqtApi set TrnGenerationApi:BaseAddress "base_address_for_trn_generation_api"
+dotnet user-secrets --id DqtApi set TrnGenerationApi:ApiKey "api_key_for_trn_generation_api"
+dotnet user-secrets --id DqtApiTests set TrnGenerationApi:BaseAddress "base_address_for_trn_generation_api"
+dotnet user-secrets --id DqtApiTests set TrnGenerationApi:ApiKey "api_key_for_trn_generation_api"
+```
+Where `base_address_for_trn_generation_api` is the base address URL to access the TRN Generation API e.g. locally or deployed to Build/Dev.
+Where `api_key_for_trn_generation_api` is an API Key to be able to access the TRN Generation API e.g. locally or deployed to Build/Dev.
+
+
 ### CRM connection
 
 The `build` CRM environment is used for local development. Connection information is stored in user secrets in the `CrmUrl`, `CrmClientId` and `CrmClientSecret` keys.


### PR DESCRIPTION
### Context

Generate TRN from a REST API to be able to assign it immediately when creating a new teacher in DQT
rather than the Create / Update overhead which happens at the moment

### Changes proposed in this pull request

A feature management controlled feature to be able to generate a TRN by calling the TRN Generation API.

### Guidance to review

To use the TRN Generation API to generete a TRN requires an appropriate deployment for that API + the feature to be enabled in DQT API.

### Checklist

-   [ x] Attach to Trello card
-   [ x] Rebased master
-   [x ] Cleaned commit history
-   [ x] Tested by running locally
