### PR TITLE
Tighten logic on ITT record matching

### DIFF
--- a/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
+++ b/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
@@ -317,7 +317,7 @@ namespace DqtApi.DataStore.Crm
                 // in which case the status should be UnderAssessment.
 
                 var inTrainingForProvider = ittRecords
-                    .Where(r => r.dfeta_Result == dfeta_ITTResult.InTraining ||
+                    .Where(r => (r.dfeta_ProgrammeType != dfeta_ITTProgrammeType.AssessmentOnlyRoute && r.dfeta_Result == dfeta_ITTResult.InTraining) ||
                         (r.dfeta_ProgrammeType == dfeta_ITTProgrammeType.AssessmentOnlyRoute && r.dfeta_Result == dfeta_ITTResult.UnderAssessment))
                     .Where(r => r.dfeta_EstablishmentId.Id == ittProviderId)
                     .Where(r => r.StateCode == dfeta_initialteachertrainingState.Active)

--- a/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
+++ b/DqtApi/src/DqtApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
@@ -163,7 +163,7 @@ namespace DqtApi.DataStore.Crm
                 // in which case the status should be UnderAssessment.
 
                 var inTrainingForProvider = ittRecords
-                    .Where(r => r.dfeta_Result == dfeta_ITTResult.InTraining ||
+                    .Where(r => (r.dfeta_ProgrammeType != dfeta_ITTProgrammeType.AssessmentOnlyRoute && r.dfeta_Result == dfeta_ITTResult.InTraining) ||
                         (r.dfeta_ProgrammeType == dfeta_ITTProgrammeType.AssessmentOnlyRoute && r.dfeta_Result == dfeta_ITTResult.UnderAssessment))
                     .Where(r => r.StateCode == dfeta_initialteachertrainingState.Active && r.dfeta_EstablishmentId.Id == ittProviderId)
                     .ToArray();


### PR DESCRIPTION
Ensure we don't select an InTraining ITT record for an Assessment Only programme type.