### PR TITLE
Always split FirstName into first & middle name

### DIFF
--- a/DqtApi/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/DqtApi/src/DqtApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -70,17 +70,10 @@ namespace DqtApi.V2.Handlers
             }
             else
             {
-                var firstName = request.FirstName;
-                var middleName = request.MiddleName ?? string.Empty;
                 var lastName = request.LastName;
-
-                var isHesaTrainee = !string.IsNullOrEmpty(request.HusId);
-                if (isHesaTrainee)
-                {
-                    var firstAndMiddleNames = $"{firstName} {middleName}".Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                    firstName = firstAndMiddleNames[0];
-                    middleName = string.Join(" ", firstAndMiddleNames.Skip(1));
-                }
+                var firstAndMiddleNames = $"{request.FirstName} {request.MiddleName}".Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var firstName = firstAndMiddleNames[0];
+                var middleName = string.Join(" ", firstAndMiddleNames.Skip(1));
 
                 var createTeacherResult = await _dataverseAdapter.CreateTeacher(new CreateTeacherCommand()
                 {

--- a/DqtApi/tests/DqtApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/DqtApi/tests/DqtApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -534,11 +534,9 @@ namespace DqtApi.Tests.V2.Operations
         }
 
         [Theory]
-        [InlineData("", "Joe Xavier", "Andre", "Joe Xavier", "Andre")]
-        [InlineData("123", "Joe Xavier", "Andre", "Joe", "Xavier Andre")]
-        [InlineData("123", "Joe Xavier", "", "Joe", "Xavier")]
+        [InlineData("Joe Xavier", "Andre", "Joe", "Xavier Andre")]
+        [InlineData("Joe Xavier", "", "Joe", "Xavier")]
         public async Task Given_trainee_with_multiple_first_names_populates_middlename_field(
-            string husid,
             string firstName,
             string middleName,
             string expectedFirstName,
@@ -555,7 +553,6 @@ namespace DqtApi.Tests.V2.Operations
 
             var request = CreateRequest(cmd =>
             {
-                cmd.HusId = husid;
                 cmd.FirstName = firstName;
                 cmd.MiddleName = middleName;
             });


### PR DESCRIPTION
We have logic in place for HESA trainees to split the `FirstName` into `FirstName` and `Middlename` since we get all given names in a single field. This change extends the logic to work with overseas qualified teachers.