### PR TITLE
Managed terraform providers with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     directory: /
     schedule:
       interval: 'daily'
+
+  - package-ecosystem: terraform
+    directory: /terraform/
+    schedule:
+      interval: 'daily'

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ restore-data-from-backup: read-deployment-config # make production restore-data-
 terraform-init:
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	[[ "${SP_AUTH}" != "true" ]] && az account set -s $(AZURE_SUBSCRIPTION) || true
-	terraform -chdir=terraform init -backend-config ${DEPLOY_ENV}.backend.tfvars -upgrade -reconfigure
+	terraform -chdir=terraform init -backend-config ${DEPLOY_ENV}.backend.tfvars -reconfigure
 
 terraform-plan: terraform-init
 	terraform -chdir=terraform plan -var-file ${DEPLOY_ENV}.tfvars.json

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "1.0.10"
 
   backend "azurerm" {
     container_name = "dqtapi-tfstate"
@@ -8,12 +8,12 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.84"
+      version = "2.99.0"
     }
 
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "~> 0.15"
+      version = "0.50.2"
     }
 
     statuscake = {


### PR DESCRIPTION
### Context

Provider versions are changed inadvertently when `terraform plan` is ran locally.  It is preferable to manage this with dependabot.

### Changes proposed in this pull request

- remove the upgrade arg from terraform init to prevent inadvertent upgrades when running plan locally
- pin providers to current patch version
- enable dependabot for terraform

### Guidance to review

Running `make dev terraform-plan` locally should result in no changes to `.terraform.lock.hcl` file

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
