### PR TITLE
Add permissions to build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  checks: write
+  deployments: write
+  packages: write
+  pull-requests: write
+
 jobs:
   generate_postgres_password:
     name: Generate Postgres password


### PR DESCRIPTION
### Context

The default permissions for GitHub Actions and dependabot triggered jobs are different, Actions have broader write permissions, dependabot has read-only.  Explicitly setting the required permissions ensures that jobs triggered by either service will not encounter permissions errors.

### Changes proposed in this pull request

Set permissions for build job.

### Guidance to review

- PR will trigger a GitHub Actions run, logs can be reviewed
- It won't be possible to test whether this change fixes dependabot PRs until it is merged, though if the explicit permissions work for GitHub Actions they should also work for dependabot

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
