### PR TITLE
Fix type of programmeType field on v2 Get Teacher endpoint

### DIFF
--- a/DqtApi/src/DqtApi/V2/Handlers/GetTeacherHandler.cs
+++ b/DqtApi/src/DqtApi/V2/Handlers/GetTeacherHandler.cs
@@ -102,7 +102,7 @@ namespace DqtApi.V2.Handlers
                 {
                     ProgrammeEndDate = i.dfeta_ProgrammeEndDate.ToDateOnly(),
                     ProgrammeStartDate = i.dfeta_ProgrammeStartDate.ToDateOnly(),
-                    ProgrammeType = i.dfeta_ProgrammeType?.ToString(),
+                    ProgrammeType = i.dfeta_ProgrammeType?.ConvertToEnum<dfeta_ITTProgrammeType, IttProgrammeType>(),
                     Result = i.dfeta_Result.HasValue ? i.dfeta_Result.Value.ConvertFromITTResult() : null,
                     Provider = new()
                     {

--- a/DqtApi/src/DqtApi/V2/Responses/GetTeacherResponse.cs
+++ b/DqtApi/src/DqtApi/V2/Responses/GetTeacherResponse.cs
@@ -28,7 +28,7 @@ namespace DqtApi.V2.Responses
     {
         public DateOnly? ProgrammeStartDate { get; set; }
         public DateOnly? ProgrammeEndDate { get; set; }
-        public string ProgrammeType { get; set; }
+        public IttProgrammeType? ProgrammeType { get; set; }
         public IttOutcome? Result { get; set; }
         public GetTeacherResponseInitialTeacherTrainingProvider Provider { get; set; }
     }

--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -911,8 +911,7 @@
             "nullable": true
           },
           "programmeType": {
-            "type": "string",
-            "nullable": true
+            "$ref": "#/components/schemas/IttProgrammeType"
           },
           "result": {
             "$ref": "#/components/schemas/IttOutcome"


### PR DESCRIPTION
We don't want internal CRM enums exposed on API endpoints. This fixes the v2 Get Teacher endpoint to use the `IttProgrammeType` API model, like we use elsewhere instead of the internal CRM `dfeta_ITTProgrammeType`.
