### PR TITLE
Add IdentityUserId to getorcreate teacher endpoint & add background service to sync with get-an-identity

### DIFF
--- a/DqtApi/src/DqtApi/DataStore/Crm/CreateTeacherResult.cs
+++ b/DqtApi/src/DqtApi/DataStore/Crm/CreateTeacherResult.cs
@@ -39,6 +39,7 @@ namespace DqtApi.DataStore.Crm
         QualificationSubject2NotFound = 512,
         QualificationSubject3NotFound = 1024,
         DuplicateHusId = 2048,
-        TrainingCountryNotFound = 4096
+        TrainingCountryNotFound = 4096,
+        IdentityUserNotFound = 8192,
     }
 }

--- a/DqtApi/src/DqtApi/DataStore/Sql/Models/TrnRequest.cs
+++ b/DqtApi/src/DqtApi/DataStore/Sql/Models/TrnRequest.cs
@@ -13,5 +13,7 @@ namespace DqtApi.DataStore.Sql.Models
         public string ClientId { get; set; }
         public string RequestId { get; set; }
         public Guid? TeacherId { get; set; }
+        public Guid? IdentityUserId { get; set; }
+        public bool LinkedToIdentity { get; set; }
     }
 }

--- a/DqtApi/src/DqtApi/DqtApi.csproj
+++ b/DqtApi/src/DqtApi/DqtApi.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
     <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.1" />
+    <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.3" />

--- a/DqtApi/src/DqtApi/Migrations/20230208143135_AddIdentityUserIdAndLinkedToIdentity.Designer.cs
+++ b/DqtApi/src/DqtApi/Migrations/20230208143135_AddIdentityUserIdAndLinkedToIdentity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DqtApi.DataStore.Sql;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DqtApi.Migrations
 {
     [DbContext(typeof(DqtContext))]
-    partial class DqtContextModelSnapshot : ModelSnapshot
+    [Migration("20230208143135_AddIdentityUserIdAndLinkedToIdentity")]
+    partial class AddIdentityUserIdAndLinkedToIdentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DqtApi/src/DqtApi/Migrations/20230208143135_AddIdentityUserIdAndLinkedToIdentity.cs
+++ b/DqtApi/src/DqtApi/Migrations/20230208143135_AddIdentityUserIdAndLinkedToIdentity.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DqtApi.Migrations
+{
+    public partial class AddIdentityUserIdAndLinkedToIdentity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "identity_user_id",
+                table: "trn_requests",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "linked_to_identity",
+                table: "trn_requests",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "identity_user_id",
+                table: "trn_requests");
+
+            migrationBuilder.DropColumn(
+                name: "linked_to_identity",
+                table: "trn_requests");
+        }
+    }
+}

--- a/DqtApi/src/DqtApi/Program.cs
+++ b/DqtApi/src/DqtApi/Program.cs
@@ -13,6 +13,7 @@ using DqtApi.Logging;
 using DqtApi.ModelBinding;
 using DqtApi.Security;
 using DqtApi.Services;
+using DqtApi.Services.GetAnIdentityApi;
 using DqtApi.Services.TrnGenerationApi;
 using DqtApi.Swagger;
 using DqtApi.Validation;
@@ -223,6 +224,7 @@ namespace DqtApi
             services.AddDatabaseDeveloperPageExceptionFilter();
 
             services.AddTrnGenerationApi(configuration);
+            services.AddIdentityApi(configuration, env);
 
             if (env.EnvironmentName != "Testing")
             {
@@ -261,6 +263,7 @@ namespace DqtApi
                 services.AddSingleton<IDistributedLockService, LocalDistributedLockService>();
             }
 
+            services.AddTransient<IHostedService, LinkTrnToIdentityUserService>();
             MetricLabels.ConfigureLabels(builder.Configuration);
 
             var app = builder.Build();

--- a/DqtApi/src/DqtApi/Properties/StringResources.resx
+++ b/DqtApi/src/DqtApi/Properties/StringResources.resx
@@ -207,4 +207,7 @@
   <data name="Errors.10022.Title" xml:space="preserve">
     <value>Completed date cannot be before 1/11/2021</value>
   </data>
+  <data name="Errors.10023.Title" xml:space="preserve">
+    <value>User with specified UserId not found</value>
+  </data>
 </root>

--- a/DqtApi/src/DqtApi/Services/GetAnIdentityApi/ClientCredentialsBearerTokenDelegatingHandler.cs
+++ b/DqtApi/src/DqtApi/Services/GetAnIdentityApi/ClientCredentialsBearerTokenDelegatingHandler.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using IdentityModel.Client;
+using Microsoft.Extensions.Options;
+
+namespace DqtApi.Services.GetAnIdentityApi
+{
+    public class ClientCredentialsBearerTokenDelegatingHandler : DelegatingHandler
+    {
+        private TokenResponse _accessToken { get; set; }
+        private DateTime _expiryTime { get; set; }
+        private GetAnIdentityApiOptions _options { get; set; }
+        private IClock _clock;
+
+        public ClientCredentialsBearerTokenDelegatingHandler(IOptions<GetAnIdentityApiOptions> options, IClock clock)
+        {
+            _options = options.Value;
+            _clock = clock;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await EnsureToken();
+            request.SetBearerToken(_accessToken.AccessToken);
+            var response = await base.SendAsync(request, cancellationToken);
+            return response;
+        }
+
+        private async Task EnsureToken()
+        {
+            if (_accessToken != null && _expiryTime > DateTime.UtcNow)
+            {
+                return;
+            }
+
+            var tokenClient = new HttpClient();
+            _accessToken = await tokenClient.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+            {
+                Address = _options.TokenEndpoint,
+                ClientId = _options.ClientId,
+                ClientSecret = _options.ClientSecret,
+                Scope = "user:write user:read"
+            });
+            _expiryTime = _clock.UtcNow.AddSeconds(_accessToken.ExpiresIn);
+        }
+    }
+}

--- a/DqtApi/src/DqtApi/Services/GetAnIdentityApi/GetAnIdentityApiClient.cs
+++ b/DqtApi/src/DqtApi/Services/GetAnIdentityApi/GetAnIdentityApiClient.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using DqtApi.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace DqtApi.Services.GetAnIdentityApi;
+
+public class GetAnIdentityApiClient : IGetAnIdentityApiClient
+{
+    private readonly HttpClient _httpClient;
+    private System.Text.Json.JsonSerializerOptions _jsonOptions { get; set; }
+
+    public GetAnIdentityApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _jsonOptions = new System.Text.Json.JsonSerializerOptions().AddConverters();
+    }
+
+    public async Task<GetAnIdentityApiUser> GetUserById(Guid userId)
+    {
+        var response = await _httpClient.GetAsync($"api/v1/users/{userId}");
+        if (response.IsSuccessStatusCode)
+        {
+            var user = await response.Content.ReadFromJsonAsync<GetAnIdentityApiUser>();
+            return user;
+        }
+        return null;
+    }
+
+    public async Task SetTeacherTrn(Guid userId, string trn)
+    {
+        var request = new SetTeacherTrnRequestBody { Trn = trn };
+        var content = JsonContent.Create(request, options: _jsonOptions);
+        var response = await _httpClient.PutAsync($"api/v1/users/{userId}/trn", content);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private class SetTeacherTrnRequestBody
+    {
+        public string Trn { get; set; }
+    }
+}
+

--- a/DqtApi/src/DqtApi/Services/GetAnIdentityApi/GetAnIdentityApiOptions.cs
+++ b/DqtApi/src/DqtApi/Services/GetAnIdentityApi/GetAnIdentityApiOptions.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace DqtApi.Services.GetAnIdentityApi
+{
+    public class GetAnIdentityApiOptions
+    {
+        [Required]
+        public string TokenEndpoint { get; set; }
+
+        [Required]
+        public string ClientSecret { get; init; }
+
+        [Required]
+        public string ClientId { get; init; }
+
+        [Required]
+        public string BaseAddress { get; init; }
+    }
+}

--- a/DqtApi/src/DqtApi/Services/GetAnIdentityApi/GetAnIdentityApiUser.cs
+++ b/DqtApi/src/DqtApi/Services/GetAnIdentityApi/GetAnIdentityApiUser.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace DqtApi.Services.GetAnIdentityApi
+{
+    public class GetAnIdentityApiUser
+    {
+        public Guid UserId { get; init; }
+        public string FirstName { get; init; }
+        public string LastName { get; init; }
+    }
+}

--- a/DqtApi/src/DqtApi/Services/GetAnIdentityApi/IGetAnIdentityApiClient.cs
+++ b/DqtApi/src/DqtApi/Services/GetAnIdentityApi/IGetAnIdentityApiClient.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace DqtApi.Services.GetAnIdentityApi
+{
+    public interface IGetAnIdentityApiClient
+    {
+        Task<GetAnIdentityApiUser> GetUserById(Guid userId);
+
+        Task SetTeacherTrn(Guid userId, string trn);
+    }
+}

--- a/DqtApi/src/DqtApi/Services/GetAnIdentityApi/ServiceCollectionExtensions.cs
+++ b/DqtApi/src/DqtApi/Services/GetAnIdentityApi/ServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace DqtApi.Services.GetAnIdentityApi;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddIdentityApi(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IWebHostEnvironment environment)
+    {
+        if (!environment.IsUnitTests() && !environment.IsEndToEndTests())
+        {
+            services.AddOptions<GetAnIdentityApiOptions>()
+                .Bind(configuration.GetSection("GetAnIdentity"))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            services
+                .AddTransient<ClientCredentialsBearerTokenDelegatingHandler>()
+                .AddHttpClient<IGetAnIdentityApiClient, GetAnIdentityApiClient>((sp, httpClient) =>
+                {
+                    var options = sp.GetRequiredService<IOptions<GetAnIdentityApiOptions>>();
+                    httpClient.BaseAddress = new Uri(options.Value.BaseAddress);
+                })
+                .AddHttpMessageHandler<ClientCredentialsBearerTokenDelegatingHandler>(); ;
+        }
+        return services;
+    }
+}

--- a/DqtApi/src/DqtApi/Services/LinkTrnToIdentityUserService.cs
+++ b/DqtApi/src/DqtApi/Services/LinkTrnToIdentityUserService.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
+using DqtApi.DataStore.Sql;
+using DqtApi.Services.GetAnIdentityApi;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace DqtApi.Services
+{
+    public class LinkTrnToIdentityUserService : BackgroundService
+    {
+        private static readonly TimeSpan _pollInterval = TimeSpan.FromMinutes(1);
+        private readonly IDataverseAdapter _dataverseAdapter;
+        private readonly ILogger<LinkTrnToIdentityUserService> _logger;
+        private readonly IGetAnIdentityApiClient _identityApiClient;
+        private readonly IServiceProvider _serviceProvider;
+
+        public LinkTrnToIdentityUserService(IDataverseAdapter dataverse, ILogger<LinkTrnToIdentityUserService> logger, IServiceProvider serviceProvider, IGetAnIdentityApiClient client)
+        {
+            _dataverseAdapter = dataverse;
+            _logger = logger;
+            _identityApiClient = client;
+            _serviceProvider = serviceProvider;
+        }
+
+        public async Task AssociateTrnsNotLinkedToIdentities()
+        {
+            using (var scope = _serviceProvider.CreateScope())
+            {
+                var dqtContext = scope.ServiceProvider.GetRequiredService<DqtContext>();
+                var trnsNotLinkedToIndentities = await dqtContext.TrnRequests.Where(x => x.LinkedToIdentity == false && x.IdentityUserId.HasValue).ToListAsync();
+                foreach (var trn in trnsNotLinkedToIndentities)
+                {
+                    var teacher = await _dataverseAdapter.GetTeacher(
+                        trn.TeacherId.Value,
+                        columnNames: new[]
+                        {
+                                    Contact.Fields.dfeta_TRN
+                        });
+
+                    if (teacher is not null)
+                    {
+                        try
+                        {
+                            //call api to link account to trn
+                            await _identityApiClient.SetTeacherTrn(trn.IdentityUserId.Value, teacher.dfeta_TRN);
+                            trn.LinkedToIdentity = true;
+                            await dqtContext.SaveChangesAsync();
+
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, $"Error occurred while linking an identity {trn.IdentityUserId} to {teacher.dfeta_TRN}");
+                        }
+                    }
+                    else
+                    {
+                        _logger.LogError($"{trn.TeacherId.Value} teacher not found!");
+                    }
+                }
+            }
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var timer = new PeriodicTimer(_pollInterval);
+            do
+            {
+                try
+                {
+                    await AssociateTrnsNotLinkedToIdentities();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed linking DQT contacts to Identity users.");
+                }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+    }
+}

--- a/DqtApi/src/DqtApi/V2/Requests/GetOrCreateTrnRequest.cs
+++ b/DqtApi/src/DqtApi/V2/Requests/GetOrCreateTrnRequest.cs
@@ -39,6 +39,7 @@ namespace DqtApi.V2.Requests
         public CreateTeacherRecognitionRoute? RecognitionRoute { get; set; }
         public DateOnly? QtsDate { get; set; }
         public bool? InductionRequired { get; set; }
+        public Guid? IdentityUserId { get; set; }
     }
 
     public class GetOrCreateTrnRequestAddress

--- a/DqtApi/src/DqtApi/Validation/ErrorRegistry.cs
+++ b/DqtApi/src/DqtApi/Validation/ErrorRegistry.cs
@@ -27,7 +27,8 @@ namespace DqtApi.Validation
             ErrorDescriptor.Create(10018),  // Husid already being used for an existing teacher
             ErrorDescriptor.Create(10019),  // Qualification completion date cannot be in the future
             ErrorDescriptor.Create(10020),  // Multiple npq qualiications for Qualification Type
-            ErrorDescriptor.Create(10021)  // Npq Qualification not created by api
+            ErrorDescriptor.Create(10021),  // Npq Qualification not created by api
+            ErrorDescriptor.Create(10022),  // Identity user not found
         }.ToDictionary(d => d.ErrorCode, d => d);
 
         public static Error TeacherWithSpecifiedTrnNotFound() => CreateError(10001);
@@ -69,7 +70,10 @@ namespace DqtApi.Validation
         public static Error QualificationCompletionDateInTheFuture() => CreateError(10019);
 
         public static Error MultipleNpqQualificationWithQualificationType() => CreateError(10020);
+
         public static Error NpqQualificationNotCreatedByApi() => CreateError(10021);
+
+        public static Error IdentityUserNotFound() => CreateError(10022);
 
         private static Error CreateError(int errorCode)
         {

--- a/DqtApi/src/DqtApi/WebhostEnvironmentExtensions.cs
+++ b/DqtApi/src/DqtApi/WebhostEnvironmentExtensions.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Hosting;
+
+namespace DqtApi
+{
+    public static class WebHostEnvironmentExtensions
+    {
+        public static bool IsEndToEndTests(this IWebHostEnvironment environment) =>
+            environment.EnvironmentName.Equals("EndToEndTests");
+
+        public static bool IsUnitTests(this IWebHostEnvironment environment) =>
+            environment.EnvironmentName.Equals("Testing");
+    }
+}

--- a/DqtApi/tests/DqtApi.Tests/ApiFixture.cs
+++ b/DqtApi/tests/DqtApi.Tests/ApiFixture.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using DqtApi.DataStore.Crm;
+using DqtApi.Services.GetAnIdentityApi;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
@@ -14,6 +15,8 @@ namespace DqtApi.Tests
         public DbHelper DbHelper => Services.GetRequiredService<DbHelper>();
 
         public Mock<IDataverseAdapter> DataverseAdapter { get; } = new Mock<IDataverseAdapter>();
+
+        public Mock<IGetAnIdentityApiClient> IdentityApiClient { get; } = new Mock<IGetAnIdentityApiClient>();
 
         public async Task InitializeAsync()
         {
@@ -39,6 +42,7 @@ namespace DqtApi.Tests
                 services.AddMvc().AddApplicationPart(typeof(ApiFixture).Assembly);
 
                 services.AddSingleton(DataverseAdapter.Object);
+                services.AddSingleton(IdentityApiClient.Object);
                 services.AddSingleton<IClock, TestableClock>();
 
                 services.AddSingleton(sp =>

--- a/DqtApi/tests/DqtApi.Tests/Services/LinkTrnToIdentityUserServiceTests.cs
+++ b/DqtApi/tests/DqtApi.Tests/Services/LinkTrnToIdentityUserServiceTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using Castle.Components.DictionaryAdapter.Xml;
+using DqtApi.DataStore.Crm;
+using DqtApi.DataStore.Crm.Models;
+using DqtApi.DataStore.Sql.Models;
+using DqtApi.Services;
+using DqtApi.Services.GetAnIdentityApi;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace DqtApi.Tests.Services
+{
+    public class LinkTrnToIdentityUserServiceTests : ApiTestBase
+    {
+        public LinkTrnToIdentityUserServiceTests(ApiFixture apiFixture)
+            : base(apiFixture)
+        {
+        }
+
+        [Fact]
+        public async Task Given_teacher_not_found_in_crm_logger_error()
+        {
+            // Arrange
+            var teacherId = Guid.NewGuid();
+            var clientId = Guid.NewGuid();
+            var identityUserId = Guid.NewGuid();
+            var requestId = Guid.NewGuid().ToString();
+
+            var logger = new Mock<ILogger<LinkTrnToIdentityUserService>>();
+            var apiClient = new Mock<IGetAnIdentityApiClient>();
+            var dataverseAdapter = new Mock<IDataverseAdapter>();
+            await WithDbContext(async dbContext =>
+            {
+                dbContext.Add(new TrnRequest()
+                {
+                    ClientId = ClientId,
+                    RequestId = requestId,
+                    TeacherId = teacherId,
+                    LinkedToIdentity = false,
+                    IdentityUserId = identityUserId
+                });
+                await dbContext.SaveChangesAsync();
+            });
+            LinkTrnToIdentityUserService service = new LinkTrnToIdentityUserService(dataverseAdapter.Object, logger.Object, ApiFixture.Services.GetRequiredService<IServiceProvider>(), apiClient.Object);
+
+            // Act
+            await service.AssociateTrnsNotLinkedToIdentities();
+
+            // Assert
+            logger.Verify(x => x.Log(
+                              LogLevel.Error,
+                              It.IsAny<EventId>(),
+                              It.Is<It.IsAnyType>((o, t) => string.Equals($"{teacherId} teacher not found!", o.ToString(), StringComparison.InvariantCultureIgnoreCase)),
+                              It.IsAny<Exception>(),
+                              (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                          Times.Once);
+        }
+
+        [Fact]
+        public async Task Given_apiclient_returns_error_error_an_error_is_logged()
+        {
+            // Arrange
+            var teacherId = Guid.NewGuid();
+            var clientId = Guid.NewGuid();
+            var identityUserId = Guid.NewGuid();
+            var requestId = Guid.NewGuid().ToString();
+            var trn = "1234567";
+            var contact = new Contact() { dfeta_TRN = trn, Id = teacherId };
+
+            var logger = new Mock<ILogger<LinkTrnToIdentityUserService>>();
+            var apiClient = new Mock<IGetAnIdentityApiClient>();
+            apiClient.Setup(x => x.SetTeacherTrn(It.IsAny<Guid>(), It.IsAny<string>())).Throws(new Exception());
+            var dataverseAdapter = new Mock<IDataverseAdapter>();
+            dataverseAdapter.Setup(x => x.GetTeacher(It.IsAny<Guid>(), It.IsAny<string[]>(), It.IsAny<bool>())).ReturnsAsync(contact);
+            await WithDbContext(async dbContext =>
+            {
+                dbContext.Add(new TrnRequest()
+                {
+                    ClientId = ClientId,
+                    RequestId = requestId,
+                    TeacherId = teacherId,
+                    LinkedToIdentity = false,
+                    IdentityUserId = identityUserId
+                });
+                await dbContext.SaveChangesAsync();
+            });
+            LinkTrnToIdentityUserService service = new LinkTrnToIdentityUserService(dataverseAdapter.Object, logger.Object, ApiFixture.Services.GetRequiredService<IServiceProvider>(), apiClient.Object);
+
+            // Act
+            await service.AssociateTrnsNotLinkedToIdentities();
+
+            // Assert
+            logger.Verify(x => x.Log(
+                              LogLevel.Error,
+                              It.IsAny<EventId>(),
+                              It.Is<It.IsAnyType>((o, t) => string.Equals($"Error occurred while linking an identity {identityUserId} to {contact.dfeta_TRN}", o.ToString(), StringComparison.InvariantCultureIgnoreCase)),
+                              It.IsAny<Exception>(),
+                              (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                          Times.Once);
+        }
+
+        [Fact]
+        public async Task Given_multiple_records_require_linking_SetTeacherTrn_invocation_matches()
+        {
+            // Arrange
+            var clientId = Guid.NewGuid();
+
+            var teacherId1 = Guid.NewGuid();
+            var identityUserId1 = Guid.NewGuid();
+            var requestId1 = Guid.NewGuid().ToString();
+            var trn1 = "1234567";
+            var contact1 = new Contact() { dfeta_TRN = trn1, Id = teacherId1 };
+
+
+            var teacherId2 = Guid.NewGuid();
+            var identityUserId2 = Guid.NewGuid();
+            var requestId2 = Guid.NewGuid().ToString();
+            var trn2 = "1234567";
+            var contact2 = new Contact() { dfeta_TRN = trn2, Id = teacherId2 };
+
+            var logger = new Mock<ILogger<LinkTrnToIdentityUserService>>();
+            var apiClient = new Mock<IGetAnIdentityApiClient>();
+            var dataverseAdapter = new Mock<IDataverseAdapter>();
+            dataverseAdapter.Setup(x => x.GetTeacher(teacherId1, It.IsAny<string[]>(), It.IsAny<bool>())).ReturnsAsync(contact1);
+            dataverseAdapter.Setup(x => x.GetTeacher(teacherId2, It.IsAny<string[]>(), It.IsAny<bool>())).ReturnsAsync(contact2);
+            await WithDbContext(async dbContext =>
+            {
+                dbContext.AddRange(new TrnRequest()
+                {
+                    ClientId = ClientId,
+                    RequestId = requestId1,
+                    TeacherId = teacherId1,
+                    LinkedToIdentity = false,
+                    IdentityUserId = identityUserId1
+                },
+                new TrnRequest()
+                {
+                    ClientId = ClientId,
+                    RequestId = requestId2,
+                    TeacherId = teacherId2,
+                    LinkedToIdentity = false,
+                    IdentityUserId = identityUserId2
+                });
+                await dbContext.SaveChangesAsync();
+            });
+            LinkTrnToIdentityUserService service = new LinkTrnToIdentityUserService(dataverseAdapter.Object, logger.Object, ApiFixture.Services.GetRequiredService<IServiceProvider>(), apiClient.Object);
+
+            // Act
+            await service.AssociateTrnsNotLinkedToIdentities();
+
+            // Assert
+            apiClient.Verify(x => x.SetTeacherTrn(identityUserId1, trn1));
+            apiClient.Verify(x => x.SetTeacherTrn(identityUserId2, trn2));
+        }
+    }
+}

--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -766,6 +766,11 @@
           "inductionRequired": {
             "type": "boolean",
             "nullable": true
+          },
+          "identityUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
Added backgroundservice to sync teachers that have a trn & haven't been linked to an identity to call get-an-identity api.

### Context

https://trello.com/c/tY5RjJMH/610-add-support-to-dqt-api-for-passing-in-a-teacher-id-when-creating-a-contact-record

### Changes proposed in this pull request

BackgroundService added.
Updated GetOrRequestTrn endpoint

### Guidance to review

Inlude any useful information needed to review this change.
Inlude any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
