### PR TITLE
Remove UseTrnGenerationApi feature flag

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.ServiceModel;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.FeatureManagement;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.PowerPlatform.Dataverse.Client.Utils;
 using Microsoft.Xrm.Sdk;
@@ -22,20 +21,17 @@ public partial class DataverseAdapter : IDataverseAdapter
     private readonly IOrganizationServiceAsync _service;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
-    private readonly IFeatureManager _featureManager;
     private readonly ITrnGenerationApiClient _trnGenerationApiClient;
 
     public DataverseAdapter(
         IOrganizationServiceAsync organizationServiceAsync,
         IClock clock,
         IMemoryCache cache,
-        IFeatureManager featureManager,
         ITrnGenerationApiClient trnGenerationApiClient)
     {
         _service = organizationServiceAsync;
         _clock = clock;
         _cache = cache;
-        _featureManager = featureManager;
         _trnGenerationApiClient = trnGenerationApiClient;
     }
 

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/FeatureFlags.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/FeatureFlags.cs
@@ -2,5 +2,4 @@
 
 public static class FeatureFlags
 {
-    public const string UseTrnGenerationApi = "UseTrnGenerationApi";
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.json
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.json
@@ -23,6 +23,5 @@
   },
   "AllowedHosts": "*",
   "FeatureManagement": {
-    "UseTrnGenerationApi":  false
   }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -9,7 +9,6 @@ namespace QualifiedTeachersApi.Tests.DataverseIntegration;
 public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLifetime
 {
     private readonly CreateTeacherFixture _createTeacherFixture;
-    private readonly CrmClientFixture _crmClientFixture;
     private readonly TestableClock _clock;
     private readonly CrmClientFixture.TestDataScope _dataScope;
     private readonly DataverseAdapter _dataverseAdapter;
@@ -18,7 +17,6 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
     public CreateTeacherTests(CreateTeacherFixture createTeacherFixture, CrmClientFixture crmClientFixture)
     {
         _createTeacherFixture = createTeacherFixture;
-        _crmClientFixture = crmClientFixture;
         _clock = crmClientFixture.Clock;
         _dataScope = crmClientFixture.CreateTestDataScope();
         _dataverseAdapter = _dataScope.CreateDataverseAdapter();
@@ -105,36 +103,6 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
 
         // Act
         var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command);
-
-        // Assert
-        Assert.True(result.Succeeded);
-    }
-
-    [Fact]
-    public async Task Given_minimal_details_request_and_feature_to_generate_trn_via_api_is_enabled_succeeds()
-    {
-        // Arrange
-        var command = new CreateTeacherCommand()
-        {
-            FirstName = "Minnie",
-            LastName = "Ryder",
-            BirthDate = new(1990, 5, 23),
-            GenderCode = Contact_GenderCode.Female,
-            InitialTeacherTraining = new()
-            {
-                ProviderUkprn = "10044534",  // ARK Teacher Training
-                ProgrammeStartDate = new(2020, 4, 1),
-                ProgrammeEndDate = new(2020, 10, 10),
-                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
-                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
-            }
-        };
-
-        await using var localDataScope = _crmClientFixture.CreateTestDataScope(useTrnGenerationApi: true);
-        var localDataverseAdapter = localDataScope.CreateDataverseAdapter();
-
-        // Act
-        var (result, transactionRequest) = await localDataverseAdapter.CreateTeacherImpl(command);
 
         // Assert
         Assert.True(result.Succeeded);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetMatchingTeachersFixture.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetMatchingTeachersFixture.cs
@@ -16,8 +16,7 @@ public class GetMatchingTeachersFixture : IAsyncLifetime
         public Guid ID { get; set; }
     }
 
-    private readonly CrmClientFixture.TestDataScope _dataScope;
-
+    public CrmClientFixture.TestDataScope DataScope { get; }
     public IOrganizationServiceAsync Service { get; }
     private readonly string _nonmatchingNationalInsuranceNumber;
     private readonly string _nonmatchingTRN;
@@ -29,8 +28,8 @@ public class GetMatchingTeachersFixture : IAsyncLifetime
 
     public GetMatchingTeachersFixture(CrmClientFixture crmClientFixture)
     {
-        _dataScope = crmClientFixture.CreateTestDataScope();
-        Service = _dataScope.OrganizationService;
+        DataScope = crmClientFixture.CreateTestDataScope();
+        Service = DataScope.OrganizationService;
 
         var nationalInsuranceNumberGenerator = new NationalInsuranceNumberGenerator(Service);
 
@@ -107,5 +106,5 @@ public class GetMatchingTeachersFixture : IAsyncLifetime
 
     public Task InitializeAsync() => Task.CompletedTask;
 
-    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+    public async Task DisposeAsync() => await DataScope.DisposeAsync();
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetMatchingTeachersTests.cs
@@ -1,10 +1,5 @@
 ﻿using System.Linq;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
-using Microsoft.FeatureManagement;
-using Moq;
 using QualifiedTeachersApi.DataStore.Crm;
-using QualifiedTeachersApi.Services.TrnGenerationApi;
 using Xunit;
 using static QualifiedTeachersApi.Tests.DataverseIntegration.GetMatchingTeachersFixture.MatchFixture;
 
@@ -19,19 +14,7 @@ public class GetMatchingTeachersTests : IClassFixture<GetMatchingTeachersFixture
     public GetMatchingTeachersTests(GetMatchingTeachersFixture fixture)
     {
         _fixture = fixture;
-
-        var featureManager = Mock.Of<IFeatureManager>();
-        Mock.Get(featureManager)
-            .Setup(f => f.IsEnabledAsync(FeatureFlags.UseTrnGenerationApi))
-            .ReturnsAsync(false);
-        var trnGenerationApiClient = new NoopTrnGenerationApiClient();
-
-        _dataverseAdapter = new DataverseAdapter(
-            _fixture.Service,
-            new TestableClock(),
-            new MemoryCache(Options.Create<MemoryCacheOptions>(new())),
-            featureManager,
-            trnGenerationApiClient);
+        _dataverseAdapter = fixture.DataScope.CreateDataverseAdapter();
     }
 
     [Fact]


### PR DESCRIPTION
Now that TRN Generation API is rolled out everywhere we no longer need to keep its use behind a feature flag.