### PR TITLE
Added husid to get teacher endpoint

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetTeacherHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetTeacherHandler.cs
@@ -32,7 +32,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 Contact.Fields.dfeta_QTSDate,
                 Contact.Fields.dfeta_ActiveSanctions,
                 Contact.Fields.dfeta_NINumber,
-                Contact.Fields.dfeta_TRN
+                Contact.Fields.dfeta_TRN,
+                Contact.Fields.dfeta_HUSID
             },
             activeOnly: true);
 
@@ -65,7 +66,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 dfeta_initialteachertraining.Fields.dfeta_ProgrammeStartDate,
                 dfeta_initialteachertraining.Fields.dfeta_ProgrammeType,
                 dfeta_initialteachertraining.Fields.dfeta_Result,
-                dfeta_initialteachertraining.Fields.dfeta_EstablishmentId
+                dfeta_initialteachertraining.Fields.dfeta_EstablishmentId,
+                dfeta_initialteachertraining.Fields.dfeta_TraineeID
             },
             establishmentColumnNames: new[]
             {
@@ -83,6 +85,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             Trn = teacher.dfeta_TRN,
             QtsDate = teacher.dfeta_QTSDate.ToDateOnly(),
             EytsDate = teacher.dfeta_EYTSDate.ToDateOnly(),
+            HusId = teacher.dfeta_HUSID,
             EarlyYearsStatus = earlyYearsStatus is not null ?
                 new GetTeacherResponseEarlyYearsStatus()
                 {
@@ -99,7 +102,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 Provider = new()
                 {
                     Ukprn = i.Extract<Account>("establishment", Account.PrimaryIdAttribute).dfeta_UKPRN
-                }
+                },
+                HusId = i.dfeta_TraineeID
             })
         };
     }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/GetTeacherResponse.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/GetTeacherResponse.cs
@@ -14,6 +14,7 @@ public class GetTeacherResponse
     public bool HasActiveSanctions { get; set; }
     public DateOnly? QtsDate { get; set; }
     public DateOnly? EytsDate { get; set; }
+    public string HusId { get; set; }
     public GetTeacherResponseEarlyYearsStatus EarlyYearsStatus { get; set; }
     public IEnumerable<GetTeacherResponseInitialTeacherTraining> InitialTeacherTraining { get; set; }
 }
@@ -31,6 +32,7 @@ public class GetTeacherResponseInitialTeacherTraining
     public IttProgrammeType? ProgrammeType { get; set; }
     public IttOutcome? Result { get; set; }
     public GetTeacherResponseInitialTeacherTrainingProvider Provider { get; set; }
+    public string HusId { get; set; }
 }
 
 public class GetTeacherResponseInitialTeacherTrainingProvider

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTeacherTests.cs
@@ -74,6 +74,8 @@ public class GetTeacherTests : ApiTestBase
         var ittProgrammeType = IttProgrammeType.EYITTGraduateEntry;
         var ittResult = IttOutcome.Pass;
         var ittProviderUkprn = "12345";
+        var ittTraineeId = "54321";
+        var husId = "987654";
 
         var contact = new Contact()
         {
@@ -84,7 +86,8 @@ public class GetTeacherTests : ApiTestBase
             dfeta_TRN = trn,
             dfeta_NINumber = nino,
             StateCode = ContactState.Active,
-            dfeta_EYTSDate = eytsDate.ToDateTime()
+            dfeta_EYTSDate = eytsDate.ToDateTime(),
+            dfeta_HUSID = husId
         };
 
         var qtsRegistration = new dfeta_qtsregistration()
@@ -107,7 +110,8 @@ public class GetTeacherTests : ApiTestBase
             dfeta_ProgrammeStartDate = ittStartDate.ToDateTime(),
             dfeta_ProgrammeEndDate = ittEndDate.ToDateTime(),
             dfeta_ProgrammeType = ittProgrammeType.ConvertToIttProgrammeType(),
-            dfeta_Result = ittResult.ConvertToITTResult()
+            dfeta_Result = ittResult.ConvertToITTResult(),
+            dfeta_TraineeID = ittTraineeId
         };
         itt.Attributes.Add($"establishment.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
         itt.Attributes.Add($"establishment.{Account.Fields.dfeta_UKPRN}", new AliasedValue(Account.EntityLogicalName, Account.Fields.dfeta_UKPRN, ittProviderUkprn));
@@ -149,6 +153,7 @@ public class GetTeacherTests : ApiTestBase
                 hasActiveSanctions = false,
                 qtsDate = qtsDate?.ToString("yyyy-MM-dd"),
                 eytsDate = eytsDate?.ToString("yyyy-MM-dd"),
+                husId = husId,
                 earlyYearsStatus = new
                 {
                     name = earlyYearsStatusName,
@@ -165,7 +170,8 @@ public class GetTeacherTests : ApiTestBase
                         provider = new
                         {
                             ukprn = ittProviderUkprn
-                        }
+                        },
+                        husId = ittTraineeId
                     }
                 }
             });

--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -938,6 +938,10 @@
             "format": "date",
             "nullable": true
           },
+          "husId": {
+            "type": "string",
+            "nullable": true
+          },
           "earlyYearsStatus": {
             "$ref": "#/components/schemas/GetTeacherResponseEarlyYearsStatus"
           },
@@ -986,6 +990,10 @@
           },
           "provider": {
             "$ref": "#/components/schemas/GetTeacherResponseInitialTeacherTrainingProvider"
+          },
+          "husId": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
### Context

Husid required on the get teacher endpoint.

### Guidance to review

Register require husid to be returned from the get teacher endpoint. Husid has been added to both the ITT (dfeta_traineeid) response and Contact response (dfeta_HusID).

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
