### PR TITLE
Install MS Core fonts to docker container for PdfSharpCore

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Dockerfile
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Dockerfile
@@ -4,5 +4,10 @@ ARG GIT_SHA
 ENV GitSha ${GIT_SHA}
 COPY bin/Release/net7.0/publish/ App/
 WORKDIR /App
+
+# install required fonts for PdfSharpCore
+RUN sed -i'.bak' 's/$/ contrib/' /etc/apt/sources.list
+RUN apt-get update; apt-get install -y ttf-mscorefonts-installer fontconfig
+
 ENTRYPOINT ["dotnet", "QualifiedTeachersApi.dll"]
 EXPOSE 80


### PR DESCRIPTION
### Context

We've added a new endpoint for the QTS certificate. The following error was thrown when trying to get the certificate from the deployed app:

FileNotFoundException: No Fonts installed on this device!
 
### Changes proposed in this pull request

Install MS Core fonts in the docker build step

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
