### PR TITLE
Update TRN endpoint for new overseas regs

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/CreateTeacherCommand.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/CreateTeacherCommand.cs
@@ -69,6 +69,5 @@ public enum CreateTeacherRecognitionRoute
 {
     Scotland = 1,
     NorthernIreland = 2,
-    EuropeanEconomicArea = 3,
     OverseasTrainedTeachers = 4
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/CreateTeacherCommand.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/CreateTeacherCommand.cs
@@ -19,6 +19,7 @@ public class CreateTeacherCommand
     public CreateTeacherRecognitionRoute? RecognitionRoute { get; set; }
     public DateOnly? QtsDate { get; set; }
     public bool? InductionRequired { get; set; }
+    public bool? UnderNewOverseasRegulations { get; set; }
 }
 
 public class CreateTeacherCommandAddress
@@ -69,5 +70,6 @@ public enum CreateTeacherRecognitionRoute
 {
     Scotland = 1,
     NorthernIreland = 2,
+    EuropeanEconomicArea = 3,
     OverseasTrainedTeachers = 4
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -268,6 +268,7 @@ public partial class DataverseAdapter
                     CreateTeacherRecognitionRoute.Scotland => dfeta_InductionExemptionReason.HasoriseligibleforfullregistrationinScotland,
                     CreateTeacherRecognitionRoute.NorthernIreland => dfeta_InductionExemptionReason.SuccessfullycompletedinductioninNorthernIreland,
                     CreateTeacherRecognitionRoute.OverseasTrainedTeachers => dfeta_InductionExemptionReason.OverseasTrainedTeacher,
+                    CreateTeacherRecognitionRoute.EuropeanEconomicArea => dfeta_InductionExemptionReason.QualifiedthroughEEAmutualrecognitionroute,
                     _ => throw new NotImplementedException($"Unknown {nameof(CreateTeacherRecognitionRoute)}: '{_command.RecognitionRoute}'.")
                 };
 
@@ -471,11 +472,13 @@ public partial class DataverseAdapter
                 Debug.Assert(_command.RecognitionRoute.HasValue);
 
                 qtsDateRequired = true;
-                return _command.RecognitionRoute.Value switch
+                return (_command.RecognitionRoute.Value, _command.UnderNewOverseasRegulations.GetValueOrDefault(false)) switch
                 {
-                    CreateTeacherRecognitionRoute.Scotland => "68",
-                    CreateTeacherRecognitionRoute.NorthernIreland => "69",
-                    CreateTeacherRecognitionRoute.OverseasTrainedTeachers => "104",
+                    (CreateTeacherRecognitionRoute.Scotland, _) => "68",
+                    (CreateTeacherRecognitionRoute.NorthernIreland, _) => "69",
+                    (CreateTeacherRecognitionRoute.EuropeanEconomicArea, _) => "223",
+                    (CreateTeacherRecognitionRoute.OverseasTrainedTeachers, false) => "103",
+                    (CreateTeacherRecognitionRoute.OverseasTrainedTeachers, true) => "104",
                     _ => throw new NotImplementedException($"Unknown {nameof(CreateTeacherRecognitionRoute)}: '{_command.RecognitionRoute.Value}'.")
                 };
             }
@@ -495,7 +498,7 @@ public partial class DataverseAdapter
             return _command.RecognitionRoute.Value switch
             {
                 CreateTeacherRecognitionRoute.Scotland or CreateTeacherRecognitionRoute.NorthernIreland => "UK establishment (Scotland/Northern Ireland)",
-                CreateTeacherRecognitionRoute.OverseasTrainedTeachers => "Non-UK establishment",
+                CreateTeacherRecognitionRoute.EuropeanEconomicArea or CreateTeacherRecognitionRoute.OverseasTrainedTeachers => "Non-UK establishment",
                 _ => throw new NotImplementedException($"Unknown {nameof(CreateTeacherRecognitionRoute)}: '{_command.RecognitionRoute.Value}'.")
             };
         }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -83,11 +83,8 @@ public partial class DataverseAdapter
             var inductionEntity = helper.CreateInductionEntity();
             inductionId = inductionEntity.Id;
             txnRequest.Requests.Add(new CreateRequest() { Target = inductionEntity });
-        }
 
-        // Update the QTS record with the induction ID; we can't set it in the Create above as Induction can't be created before QTS
-        if (inductionId.HasValue)
-        {
+            // Update the QTS record with the induction ID; we can't set it in the Create above as Induction can't be created before QTS
             txnRequest.Requests.Add(new UpdateRequest()
             {
                 Target = new dfeta_qtsregistration()
@@ -120,7 +117,7 @@ public partial class DataverseAdapter
 
         public Guid TeacherId { get; }
 
-        public Models.Task CreateDuplicateReviewTaskEntity(CreateTeacherDuplicateTeacherResult duplicate)
+        public CrmTask CreateDuplicateReviewTaskEntity(CreateTeacherDuplicateTeacherResult duplicate)
         {
             var description = GetDescription();
 
@@ -128,7 +125,7 @@ public partial class DataverseAdapter
                 !string.IsNullOrEmpty(_command.HusId) ? "HESAImportTrn" :
                 "DMSImportTrn";
 
-            return new Models.Task()
+            return new CrmTask()
             {
                 RegardingObjectId = TeacherId.ToEntityReference(Contact.EntityLogicalName),
                 dfeta_potentialduplicateid = duplicate.TeacherId.ToEntityReference(Contact.EntityLogicalName),
@@ -271,7 +268,6 @@ public partial class DataverseAdapter
                     CreateTeacherRecognitionRoute.Scotland => dfeta_InductionExemptionReason.HasoriseligibleforfullregistrationinScotland,
                     CreateTeacherRecognitionRoute.NorthernIreland => dfeta_InductionExemptionReason.SuccessfullycompletedinductioninNorthernIreland,
                     CreateTeacherRecognitionRoute.OverseasTrainedTeachers => dfeta_InductionExemptionReason.OverseasTrainedTeacher,
-                    CreateTeacherRecognitionRoute.EuropeanEconomicArea => dfeta_InductionExemptionReason.QualifiedthroughEEAmutualrecognitionroute,
                     _ => throw new NotImplementedException($"Unknown {nameof(CreateTeacherRecognitionRoute)}: '{_command.RecognitionRoute}'.")
                 };
 
@@ -479,8 +475,7 @@ public partial class DataverseAdapter
                 {
                     CreateTeacherRecognitionRoute.Scotland => "68",
                     CreateTeacherRecognitionRoute.NorthernIreland => "69",
-                    CreateTeacherRecognitionRoute.EuropeanEconomicArea => "223",
-                    CreateTeacherRecognitionRoute.OverseasTrainedTeachers => "103",
+                    CreateTeacherRecognitionRoute.OverseasTrainedTeachers => "104",
                     _ => throw new NotImplementedException($"Unknown {nameof(CreateTeacherRecognitionRoute)}: '{_command.RecognitionRoute.Value}'.")
                 };
             }
@@ -500,7 +495,7 @@ public partial class DataverseAdapter
             return _command.RecognitionRoute.Value switch
             {
                 CreateTeacherRecognitionRoute.Scotland or CreateTeacherRecognitionRoute.NorthernIreland => "UK establishment (Scotland/Northern Ireland)",
-                CreateTeacherRecognitionRoute.EuropeanEconomicArea or CreateTeacherRecognitionRoute.OverseasTrainedTeachers => "Non-UK establishment",
+                CreateTeacherRecognitionRoute.OverseasTrainedTeachers => "Non-UK establishment",
                 _ => throw new NotImplementedException($"Unknown {nameof(CreateTeacherRecognitionRoute)}: '{_command.RecognitionRoute.Value}'.")
             };
         }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -140,7 +140,8 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
                     EnumHelper.ConvertToEnum<Requests.CreateTeacherRecognitionRoute, DataStore.Crm.CreateTeacherRecognitionRoute>(request.RecognitionRoute.Value) :
                     null,
                 QtsDate = request.QtsDate,
-                InductionRequired = request.InductionRequired
+                InductionRequired = request.InductionRequired,
+                UnderNewOverseasRegulations = request.UnderNewOverseasRegulations
             });
 
             if (!createTeacherResult.Succeeded)

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Requests/GetOrCreateTrnRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Requests/GetOrCreateTrnRequest.cs
@@ -93,6 +93,5 @@ public enum CreateTeacherRecognitionRoute
 {
     Scotland = 1,
     NorthernIreland = 2,
-    EuropeanEconomicArea = 3,
     OverseasTrainedTeachers = 4
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Requests/GetOrCreateTrnRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Requests/GetOrCreateTrnRequest.cs
@@ -39,6 +39,7 @@ public class GetOrCreateTrnRequest : IRequest<TrnRequestInfo>
     public DateOnly? QtsDate { get; set; }
     public bool? InductionRequired { get; set; }
     public Guid? IdentityUserId { get; set; }
+    public bool? UnderNewOverseasRegulations { get; set; }
 }
 
 public class GetOrCreateTrnRequestAddress
@@ -93,5 +94,6 @@ public enum CreateTeacherRecognitionRoute
 {
     Scotland = 1,
     NorthernIreland = 2,
+    EuropeanEconomicArea = 3,
     OverseasTrainedTeachers = 4
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
@@ -145,6 +145,7 @@ public class GetOrCreateTrnRequestValidator : AbstractValidator<GetOrCreateTrnRe
             .Custom((countryCode, ctx) =>
             {
                 if (ctx.InstanceToValidate.TeacherType == CreateTeacherType.OverseasQualifiedTeacher &&
+                    ctx.InstanceToValidate.UnderNewOverseasRegulations == true &&
                     !string.IsNullOrEmpty(ctx.InstanceToValidate.InitialTeacherTraining?.TrainingCountryCode))
                 {
                     var route = ctx.InstanceToValidate.RecognitionRoute;
@@ -202,6 +203,11 @@ public class GetOrCreateTrnRequestValidator : AbstractValidator<GetOrCreateTrnRe
             .When(r => r.TeacherType == CreateTeacherType.OverseasQualifiedTeacher, ApplyConditionTo.CurrentValidator)
             .Null()
             .When(r => r.TeacherType != CreateTeacherType.OverseasQualifiedTeacher, ApplyConditionTo.CurrentValidator);
+
+        RuleFor(r => r.RecognitionRoute)
+            .NotEqual(CreateTeacherRecognitionRoute.EuropeanEconomicArea)
+            .When(r => r.UnderNewOverseasRegulations == true)
+            .WithMessage($"EuropeanEconomicArea is not permitted under new regulations.");
 
         RuleFor(r => r.QtsDate)
             .NotNull()

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
@@ -141,6 +141,54 @@ public class GetOrCreateTrnRequestValidator : AbstractValidator<GetOrCreateTrnRe
             .When(trainingCountryRequired, ApplyConditionTo.CurrentValidator)
             .When(r => r.InitialTeacherTraining != null, ApplyConditionTo.AllValidators);
 
+        RuleFor(r => r.InitialTeacherTraining.TrainingCountryCode)
+            .Custom((countryCode, ctx) =>
+            {
+                if (ctx.InstanceToValidate.TeacherType == CreateTeacherType.OverseasQualifiedTeacher &&
+                    !string.IsNullOrEmpty(ctx.InstanceToValidate.InitialTeacherTraining?.TrainingCountryCode))
+                {
+                    var route = ctx.InstanceToValidate.RecognitionRoute;
+                    var countryCodePropertyName = $"{nameof(ctx.InstanceToValidate.InitialTeacherTraining)}.{nameof(ctx.InstanceToValidate.InitialTeacherTraining.TrainingCountryCode)}";
+
+                    if (countryCode == "XK")
+                    {
+                        ctx.AddFailure(
+                            countryCodePropertyName,
+                            $"CountryCode cannot be 'XK' when TeacherType is '{CreateTeacherType.OverseasQualifiedTeacher}'.");
+
+                        return;
+                    }
+
+                    if (route is CreateTeacherRecognitionRoute.Scotland)
+                    {
+                        if (countryCode != "XH")
+                        {
+                            ctx.AddFailure(
+                                countryCodePropertyName,
+                                $"CountryCode must be 'XH' when RecognitionRoute is '{CreateTeacherRecognitionRoute.Scotland}'.");
+                        }
+                    }
+                    else if (route is CreateTeacherRecognitionRoute.NorthernIreland)
+                    {
+                        if (countryCode != "XG")
+                        {
+                            ctx.AddFailure(
+                                countryCodePropertyName,
+                                $"CountryCode must be 'XG' when RecognitionRoute is '{CreateTeacherRecognitionRoute.NorthernIreland}'.");
+                        }
+                    }
+                    else
+                    {
+                        if (countryCode == "XH" || countryCode == "XG")
+                        {
+                            ctx.AddFailure(
+                                countryCodePropertyName,
+                                $"CountryCode cannot be 'XH' or 'XG' when RecognitionRoute is '{CreateTeacherRecognitionRoute.OverseasTrainedTeachers}'.");
+                        }
+                    }
+                }
+            });
+
         RuleFor(r => r.Qualification.Class)
             .IsInEnum()
             .When(r => r.Qualification != null);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -602,14 +602,17 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
     }
 
     [Theory]
-    [InlineData(CreateTeacherType.TraineeTeacher, null, dfeta_ITTProgrammeType.AssessmentOnlyRoute, "212")]
-    [InlineData(CreateTeacherType.TraineeTeacher, null, dfeta_ITTProgrammeType.GraduateTeacherProgramme, "211")]
-    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.Scotland, null, "68")]
-    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.NorthernIreland, null, "69")]
-    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.OverseasTrainedTeachers, null, "104")]
+    [InlineData(CreateTeacherType.TraineeTeacher, null, null, dfeta_ITTProgrammeType.AssessmentOnlyRoute, "212")]
+    [InlineData(CreateTeacherType.TraineeTeacher, null, null, dfeta_ITTProgrammeType.GraduateTeacherProgramme, "211")]
+    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.Scotland, null, null, "68")]
+    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.NorthernIreland, null, null, "69")]
+    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.EuropeanEconomicArea, null, null, "223")]
+    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.OverseasTrainedTeachers, false, null, "103")]
+    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.OverseasTrainedTeachers, true, null, "104")]
     public void DeriveTeacherStatus(
         CreateTeacherType teacherType,
         CreateTeacherRecognitionRoute? recognitionRoute,
+        bool? underNewOverseasRegulations,
         dfeta_ITTProgrammeType? programmeType,
         string expectedTeacherStatus)
     {
@@ -620,6 +623,7 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
             {
                 c.InitialTeacherTraining.ProgrammeType = programmeType;
                 c.RecognitionRoute = recognitionRoute;
+                c.UnderNewOverseasRegulations = underNewOverseasRegulations;
             });
 
         var helper = new DataverseAdapter.CreateTeacherHelper(_dataverseAdapter, command);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -606,8 +606,7 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
     [InlineData(CreateTeacherType.TraineeTeacher, null, dfeta_ITTProgrammeType.GraduateTeacherProgramme, "211")]
     [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.Scotland, null, "68")]
     [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.NorthernIreland, null, "69")]
-    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.EuropeanEconomicArea, null, "223")]
-    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.OverseasTrainedTeachers, null, "103")]
+    [InlineData(CreateTeacherType.OverseasQualifiedTeacher, CreateTeacherRecognitionRoute.OverseasTrainedTeachers, null, "104")]
     public void DeriveTeacherStatus(
         CreateTeacherType teacherType,
         CreateTeacherRecognitionRoute? recognitionRoute,
@@ -636,7 +635,6 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
     [InlineData(CreateTeacherRecognitionRoute.Scotland, "UK establishment (Scotland/Northern Ireland)")]
     [InlineData(CreateTeacherRecognitionRoute.NorthernIreland, "UK establishment (Scotland/Northern Ireland)")]
     [InlineData(CreateTeacherRecognitionRoute.OverseasTrainedTeachers, "Non-UK establishment")]
-    [InlineData(CreateTeacherRecognitionRoute.EuropeanEconomicArea, "Non-UK establishment")]
     public void DeriveIttProviderNameForOverseasQualifiedTeacher(
         CreateTeacherRecognitionRoute recognitionRoute,
         string expectedIttProviderName)
@@ -659,11 +657,9 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
     [InlineData(true, CreateTeacherRecognitionRoute.Scotland, dfeta_InductionStatus.RequiredtoComplete, null)]
     [InlineData(true, CreateTeacherRecognitionRoute.NorthernIreland, dfeta_InductionStatus.RequiredtoComplete, null)]
     [InlineData(true, CreateTeacherRecognitionRoute.OverseasTrainedTeachers, dfeta_InductionStatus.RequiredtoComplete, null)]
-    [InlineData(true, CreateTeacherRecognitionRoute.EuropeanEconomicArea, dfeta_InductionStatus.RequiredtoComplete, null)]
     [InlineData(false, CreateTeacherRecognitionRoute.Scotland, dfeta_InductionStatus.Exempt, dfeta_InductionExemptionReason.HasoriseligibleforfullregistrationinScotland)]
     [InlineData(false, CreateTeacherRecognitionRoute.NorthernIreland, dfeta_InductionStatus.Exempt, dfeta_InductionExemptionReason.SuccessfullycompletedinductioninNorthernIreland)]
     [InlineData(false, CreateTeacherRecognitionRoute.OverseasTrainedTeachers, dfeta_InductionStatus.Exempt, dfeta_InductionExemptionReason.OverseasTrainedTeacher)]
-    [InlineData(false, CreateTeacherRecognitionRoute.EuropeanEconomicArea, dfeta_InductionStatus.Exempt, dfeta_InductionExemptionReason.QualifiedthroughEEAmutualrecognitionroute)]
     public void CreateInductionEntity(
         bool inductionRequired,
         CreateTeacherRecognitionRoute recognitionRoute,

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -699,7 +699,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
         {
             req.TeacherType = QualifiedTeachersApi.V2.Requests.CreateTeacherType.OverseasQualifiedTeacher;
             req.InitialTeacherTraining.ProviderUkprn = null;
-            req.InitialTeacherTraining.TrainingCountryCode = "SC";
+            req.InitialTeacherTraining.TrainingCountryCode = "XH";
             req.QtsDate = new DateOnly(2020, 10, 10);
             req.RecognitionRoute = QualifiedTeachersApi.V2.Requests.CreateTeacherRecognitionRoute.Scotland;
             req.InductionRequired = false;

--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -625,7 +625,6 @@
         "enum": [
           "Scotland",
           "NorthernIreland",
-          "EuropeanEconomicArea",
           "OverseasTrainedTeachers"
         ],
         "type": "string"

--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -625,6 +625,7 @@
         "enum": [
           "Scotland",
           "NorthernIreland",
+          "EuropeanEconomicArea",
           "OverseasTrainedTeachers"
         ],
         "type": "string"
@@ -776,6 +777,10 @@
           "identityUserId": {
             "type": "string",
             "format": "uuid",
+            "nullable": true
+          },
+          "underNewOverseasRegulations": {
+            "type": "boolean",
             "nullable": true
           }
         },


### PR DESCRIPTION
### Context

Regs have changed regarding overseas qualified teachers. This updates the TRN endpoint with new rules.

### Changes proposed in this pull request

- Removes the `EuropeanEconomicArea` route.
- Add validation for `InitialTeachingTraining.TrainingCountry`.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
