### PR TITLE
Allow Register to unwithdraw a teacher to deferred/intraining

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/UpdateTeacherResult.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/UpdateTeacherResult.cs
@@ -43,5 +43,11 @@ public enum UpdateTeacherFailedReasons
     QualificationSubject2NotFound = 32768,
     QualificationSubject3NotFound = 65536,
     DuplicateHusId = 131072,
-    TrainingCountryNotFound = 262144
+    TrainingCountryNotFound = 262144,
+    InTrainingResultNotPermittedForProgrammeType = 524288,
+    UnderAssessmentOnlyPermittedForProgrammeType = 1048576,
+    NoMatchingQtsRecord = 2097152,
+    MultipleQtsRecords = 4194304,
+    UnableToUnwithdrawToDeferredStatus = 8388608,
+    UnableToChangeFailedResult = 16777216
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Properties/StringResources.Designer.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Properties/StringResources.Designer.cs
@@ -365,5 +365,41 @@ namespace QualifiedTeachersApi.Properties {
                 return ResourceManager.GetString("Errors.10023.Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to InTraining not permitted for AssessmentOnlyRoute programme types..
+        /// </summary>
+        public static string Errors_10024_Title {
+            get {
+                return ResourceManager.GetString("Errors.10024.Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UnderAssessment only permitted for AssessmentOnlyRoute programme types..
+        /// </summary>
+        public static string Errors_10025_Title {
+            get {
+                return ResourceManager.GetString("Errors.10025.Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Result cannot be unwithdrawn to deferred.
+        /// </summary>
+        public static string Errors_10026_Title {
+            get {
+                return ResourceManager.GetString("Errors.10026.Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to change Failed Result..
+        /// </summary>
+        public static string Errors_10027_Title {
+            get {
+                return ResourceManager.GetString("Errors.10027.Title", resourceCulture);
+            }
+        }
     }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Properties/StringResources.resx
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Properties/StringResources.resx
@@ -219,4 +219,16 @@
   <data name="Errors.10023.Title" xml:space="preserve">
     <value>User with specified UserId not found</value>
   </data>
+  <data name="Errors.10024.Title" xml:space="preserve">
+    <value>InTraining not permitted for AssessmentOnlyRoute programme types.</value>
+  </data>
+  <data name="Errors.10025.Title" xml:space="preserve">
+    <value>UnderAssessment only permitted for AssessmentOnlyRoute programme types.</value>
+  </data>
+  <data name="Errors.10026.Title" xml:space="preserve">
+    <value>Result cannot be unwithdrawn to deferred</value>
+  </data>
+  <data name="Errors.10027.Title" xml:space="preserve">
+    <value>Unable to change Failed Result.</value>
+  </data>
 </root>

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/UpdateTeacherHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/UpdateTeacherHandler.cs
@@ -170,6 +170,41 @@ public class UpdateTeacherHandler : IRequestHandler<UpdateTeacherRequest>
             $"{nameof(UpdateTeacherRequest.HusId)}.{nameof(UpdateTeacherRequest.HusId)}",
             ErrorRegistry.ExistingTeacherAlreadyHasHusId().Title);
 
+        ConsumeReason(
+            UpdateTeacherFailedReasons.InTrainingResultNotPermittedForProgrammeType,
+            $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Outcome)}",
+            ErrorRegistry.InTrainingResultNotPermittedForProgrammeType().Title);
+
+        ConsumeReason(
+            UpdateTeacherFailedReasons.UnderAssessmentOnlyPermittedForProgrammeType,
+            $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Outcome)}",
+            ErrorRegistry.UnderAssessmentOnlyPermittedForProgrammeType().Title);
+
+        ConsumeReason(
+            UpdateTeacherFailedReasons.NoMatchingQtsRecord,
+            $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Outcome)}",
+            ErrorRegistry.TeacherHasNoQtsRecord().Title);
+
+        ConsumeReason(
+            UpdateTeacherFailedReasons.MultipleQtsRecords,
+            $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Outcome)}",
+            ErrorRegistry.TeacherHasMultipleQtsRecords().Title);
+
+        ConsumeReason(
+            UpdateTeacherFailedReasons.UnableToUnwithdrawToDeferredStatus,
+            $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Outcome)}",
+            ErrorRegistry.UnableToUnwithdrawToDeferredStatus().Title);
+
+        ConsumeReason(
+            UpdateTeacherFailedReasons.UnableToChangeFailedResult,
+            $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Outcome)}",
+            ErrorRegistry.UnableToChangeFailedResult().Title);
+
+        ConsumeReason(
+            UpdateTeacherFailedReasons.MultipleInTrainingIttRecords,
+            $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}",
+            ErrorRegistry.TeacherAlreadyMultipleIncompleteIttRecords().Title);
+
         if (failedReasons != UpdateTeacherFailedReasons.None)
         {
             throw new NotImplementedException($"Unknown {nameof(UpdateTeacherFailedReasons)}: '{failedReasons}.");

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Validation/ErrorRegistry.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Validation/ErrorRegistry.cs
@@ -29,6 +29,10 @@ public static class ErrorRegistry
         ErrorDescriptor.Create(10020),  // Multiple npq qualiications for Qualification Type
         ErrorDescriptor.Create(10021),  // Npq Qualification not created by api
         ErrorDescriptor.Create(10022),  // Identity user not found
+        ErrorDescriptor.Create(10024),  // InTraining not permitted for AsessmentOnlyRoute
+        ErrorDescriptor.Create(10025),  // UnderAsessment only permitted for AsessmentOnlyRoute
+        ErrorDescriptor.Create(10026),  // Result cannot be unwithdrawn to deferred
+        ErrorDescriptor.Create(10027),  // Unable to change Failed Result.
     }.ToDictionary(d => d.ErrorCode, d => d);
 
     public static Error TeacherWithSpecifiedTrnNotFound() => CreateError(10001);
@@ -74,6 +78,14 @@ public static class ErrorRegistry
     public static Error NpqQualificationNotCreatedByApi() => CreateError(10021);
 
     public static Error IdentityUserNotFound() => CreateError(10022);
+
+    public static Error InTrainingResultNotPermittedForProgrammeType() => CreateError(10024);
+
+    public static Error UnderAssessmentOnlyPermittedForProgrammeType() => CreateError(10025);
+
+    public static Error UnableToUnwithdrawToDeferredStatus() => CreateError(10026);
+
+    public static Error UnableToChangeFailedResult() => CreateError(10027);
 
     private static Error CreateError(int errorCode)
     {


### PR DESCRIPTION
### Context

Register sometimes withdraw a teacher accidentally, and are unable to unwithdraw. This PR allows a teacher can be unwithdrawn to InTraining/Deferred.

https://trello.com/c/kygTQwKa/5304-allow-the-unwithdrawal-of-a-withdrawn-record-in-dqt-needs-working-out-of-technical-implementation

Added tests to the update teacher endpoint to verify it matches the following test matrix.
https://docs.google.com/document/d/1E10xuLPd3mw5rwi0JFoANMeIP3n1IyUqSYd8J3FiUrY/edit#heading=h.9gc6soagpn66
https://docs.google.com/spreadsheets/d/1WsINbQV7yvnYtl-3KkqZ63ji8B4RMgRQ9UXRfW359Fs/edit#gid=0

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
