### PR TITLE
Reject update when assessment date differs from the one dqt hold

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/SetIttResultForTeacherResult.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/SetIttResultForTeacherResult.cs
@@ -24,10 +24,10 @@ public sealed class SetIttResultForTeacherResult
 
 public enum SetIttResultForTeacherFailedReason
 {
-    AlreadyHaveQtsDate,
-    AlreadyHaveEytsDate,
+    QtsDateMismatch,
+    EytsDateMismatch,
     NoMatchingIttRecord,
-    MultipleInTrainingIttRecords,
+    MultipleIttRecords,
     NoMatchingQtsRecord,
     MultipleQtsRecords,
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/SetIttOutcomeHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/SetIttOutcomeHandler.cs
@@ -54,10 +54,10 @@ public class SetIttOutcomeHandler : IRequestHandler<SetIttOutcomeRequest, SetItt
         {
             switch (result.FailedReason)
             {
-                case SetIttResultForTeacherFailedReason.AlreadyHaveEytsDate:
-                case SetIttResultForTeacherFailedReason.AlreadyHaveQtsDate:
+                case SetIttResultForTeacherFailedReason.QtsDateMismatch:
+                case SetIttResultForTeacherFailedReason.EytsDateMismatch:
                     throw new ErrorException(ErrorRegistry.TeacherAlreadyHasQtsDate());
-                case SetIttResultForTeacherFailedReason.MultipleInTrainingIttRecords:
+                case SetIttResultForTeacherFailedReason.MultipleIttRecords:
                     throw new ErrorException(ErrorRegistry.TeacherAlreadyMultipleIncompleteIttRecords());
                 case SetIttResultForTeacherFailedReason.NoMatchingIttRecord:
                     throw new ErrorException(ErrorRegistry.TeacherHasNoIncompleteIttRecord());

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/SetIttOutcomeTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/SetIttOutcomeTests.cs
@@ -236,7 +236,7 @@ public class SetIttOutcomeTests : ApiTestBase
     }
 
     [Fact]
-    public async Task Given_teacher_already_has_QTS_date_returns_error()
+    public async Task Given_teacher_already_has_different_QTS_date_returns_error()
     {
         // Arrange
         var trn = "1234567";
@@ -253,7 +253,7 @@ public class SetIttOutcomeTests : ApiTestBase
 
         ApiFixture.DataverseAdapter
             .Setup(mock => mock.SetIttResultForTeacher(contact.Id, ittProviderUkprn, outcome.ConvertToITTResult(), assessmentDate))
-            .ReturnsAsync(SetIttResultForTeacherResult.Failed(SetIttResultForTeacherFailedReason.AlreadyHaveQtsDate));
+            .ReturnsAsync(SetIttResultForTeacherResult.Failed(SetIttResultForTeacherFailedReason.QtsDateMismatch));
 
         var requestBody = new SetIttOutcomeRequest()
         {
@@ -315,9 +315,9 @@ public class SetIttOutcomeTests : ApiTestBase
     }
 
     [Theory]
-    [InlineData(SetIttResultForTeacherFailedReason.AlreadyHaveEytsDate, 10003)]
-    [InlineData(SetIttResultForTeacherFailedReason.AlreadyHaveQtsDate, 10003)]
-    [InlineData(SetIttResultForTeacherFailedReason.MultipleInTrainingIttRecords, 10004)]
+    [InlineData(SetIttResultForTeacherFailedReason.EytsDateMismatch, 10003)]
+    [InlineData(SetIttResultForTeacherFailedReason.QtsDateMismatch, 10003)]
+    [InlineData(SetIttResultForTeacherFailedReason.MultipleIttRecords, 10004)]
     [InlineData(SetIttResultForTeacherFailedReason.NoMatchingIttRecord, 10005)]
     [InlineData(SetIttResultForTeacherFailedReason.NoMatchingQtsRecord, 10006)]
     [InlineData(SetIttResultForTeacherFailedReason.MultipleQtsRecords, 10007)]


### PR DESCRIPTION
### Context

Register require an update to the **v2/setittoutcome** endpoint to stop error'ing when the asessement date matches the one that dqt hold. In Addition, to reject an update if the assessment date differs.

https://trello.com/c/DWSeHva5/5303-award-api-endpoints-should-be-idempotent

### Changes proposed in this pull request

- Update to the dataverse update operation to handle update when a teacher has qts/eyts. 
- Update to the tests to handle returning errors when assessment date differs from the one dqt holds.
- added new tests to show that passing a pass to dqt that dqt already know about does not return an error.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
