### PR TITLE
Nest qts and eyts data in own properties

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetTeacherHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetTeacherHandler.cs
@@ -86,10 +86,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             Trn = request.Trn,
             FirstName = teacher.FirstName,
             LastName = teacher.LastName,
-            QtsDate = teacher.dfeta_QTSDate?.ToDateOnly(),
-            QtsCertificateUrl = teacher.dfeta_QTSDate.HasValue ? "/v3/certificates/qts" : null,
-            EytsDate = teacher.dfeta_EYTSDate?.ToDateOnly(),
-            EytsCertificateUrl = teacher.dfeta_EYTSDate.HasValue ? "/v3/certificates/eyts" : null,
+            Qts = MapQts(teacher.dfeta_QTSDate?.ToDateOnly()),
+            Eyts = MapEyts(teacher.dfeta_EYTSDate?.ToDateOnly()),
             InitialTeacherTraining = itt.Select(i => new GetTeacherResponseInitialTeacherTraining()
             {
                 Qualification = MapIttQualification(i),
@@ -103,6 +101,30 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             }),
             NpqQualifications = MapNpqQualifications(qualifications)
         };
+    }
+
+    private static GetTeacherResponseQts MapQts(DateOnly? qtsDate)
+    {
+        return
+            qtsDate != null
+            ? new GetTeacherResponseQts()
+            {
+                Awarded = qtsDate.Value,
+                CertificateUrl = "/v3/certificates/qts"
+            }
+            : null;
+    }
+
+    private static GetTeacherResponseEyts MapEyts(DateOnly? eytsDate)
+    {
+        return
+            eytsDate != null
+            ? new GetTeacherResponseEyts()
+            {
+                Awarded = eytsDate.Value,
+                CertificateUrl = "/v3/certificates/eyts"
+            }
+            : null;
     }
 
     private static GetTeacherResponseInitialTeacherTrainingQualification MapIttQualification(dfeta_initialteachertraining initialTeacherTraining)

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
@@ -13,12 +13,22 @@ public record GetTeacherResponse
     public required string FirstName { get; init; }
     [SwaggerSchema(Nullable = false)]
     public required string LastName { get; init; }
-    public required DateOnly? QtsDate { get; init; }
-    public string QtsCertificateUrl { get; init; }
-    public required DateOnly? EytsDate { get; init; }
-    public string EytsCertificateUrl { get; init; }
+    public GetTeacherResponseQts Qts { get; init; }
+    public GetTeacherResponseEyts Eyts { get; init; }
     public IEnumerable<GetTeacherResponseInitialTeacherTraining> InitialTeacherTraining { get; init; }
     public IEnumerable<GetTeacherResponseNpqQualificationsQualification> NpqQualifications { get; init; }
+}
+
+public record GetTeacherResponseQts
+{
+    public DateOnly Awarded { get; init; }
+    public string CertificateUrl { get; init; }
+}
+
+public record GetTeacherResponseEyts
+{
+    public DateOnly Awarded { get; init; }
+    public string CertificateUrl { get; init; }
 }
 
 public record GetTeacherResponseInitialTeacherTraining

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
@@ -172,10 +172,16 @@ public class GetTeacherTests : ApiTestBase
                 firstName = firstName,
                 lastName = lastName,
                 trn = trn,
-                qtsDate = qtsDate.ToString("yyyy-MM-dd"),
-                qtsCertificateUrl = "/v3/certificates/qts",
-                eytsDate = eytsDate.ToString("yyyy-MM-dd"),
-                eytsCertificateUrl = "/v3/certificates/eyts",
+                qts = new
+                {
+                    awarded = qtsDate.ToString("yyyy-MM-dd"),
+                    certificateUrl = "/v3/certificates/qts"
+                },
+                eyts = new
+                {
+                    awarded = eytsDate.ToString("yyyy-MM-dd"),
+                    certificateUrl = "/v3/certificates/eyts"
+                },
                 initialTeacherTraining = new[]
                 {
                     new

--- a/docs/api-specs/v3.json
+++ b/docs/api-specs/v3.json
@@ -210,23 +210,11 @@
           "lastName": {
             "type": "string"
           },
-          "qtsDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
+          "qts": {
+            "$ref": "#/components/schemas/GetTeacherResponseQts"
           },
-          "qtsCertificateUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "eytsDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "eytsCertificateUrl": {
-            "type": "string",
-            "nullable": true
+          "eyts": {
+            "$ref": "#/components/schemas/GetTeacherResponseEyts"
           },
           "initialTeacherTraining": {
             "type": "array",
@@ -240,6 +228,20 @@
             "items": {
               "$ref": "#/components/schemas/GetTeacherResponseNpqQualificationsQualification"
             },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetTeacherResponseEyts": {
+        "type": "object",
+        "properties": {
+          "awarded": {
+            "type": "string",
+            "format": "date"
+          },
+          "certificateUrl": {
+            "type": "string",
             "nullable": true
           }
         },
@@ -355,6 +357,20 @@
             "$ref": "#/components/schemas/NpqQualificationType"
           },
           "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetTeacherResponseQts": {
+        "type": "object",
+        "properties": {
+          "awarded": {
+            "type": "string",
+            "format": "date"
+          },
+          "certificateUrl": {
             "type": "string",
             "nullable": true
           }


### PR DESCRIPTION
### Context

QTS and EYTS are inconsistent with the way we specify NPQ details so need to align them. 

### Changes proposed in this pull request

Tweak to get teacher response to make QTS and EYTS have their own section.

### Guidance to review

Simple change in API and test.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
