### PR TITLE
Add code and tests to support induction certificate v3 API endpoint

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
@@ -685,7 +685,8 @@ public partial class DataverseAdapter : IDataverseAdapter
         Guid teacherId,
         string[] columnNames,
         string[] inductionPeriodColumnNames = null,
-        string[] appropriateBodyColumnNames = null)
+        string[] appropriateBodyColumnNames = null,
+        string[] contactColumnNames = null)
     {
         var filter = new FilterExpression();
         filter.AddCondition(dfeta_induction.Fields.dfeta_PersonId, ConditionOperator.Equal, teacherId);
@@ -719,6 +720,18 @@ public partial class DataverseAdapter : IDataverseAdapter
                 appropriateBodyLink.Columns = new ColumnSet(appropriateBodyColumnNames);
                 appropriateBodyLink.EntityAlias = $"{dfeta_inductionperiod.EntityLogicalName}.appropriatebody";
             }
+        }
+
+        if (contactColumnNames?.Length > 0)
+        {
+            var contactLink = query.AddLink(
+                Contact.EntityLogicalName,
+                dfeta_induction.Fields.dfeta_PersonId,
+                Contact.PrimaryIdAttribute,
+                JoinOperator.Inner);
+
+            contactLink.Columns = new ColumnSet(contactColumnNames);
+            contactLink.EntityAlias = Contact.EntityLogicalName;
         }
 
         var result = await _service.RetrieveMultipleAsync(query);

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
@@ -37,7 +37,8 @@ public interface IDataverseAdapter
         Guid teacherId,
         string[] columnNames,
         string[] inductionPeriodColumnNames = null,
-        string[] appropriateBodyColumnNames = null);
+        string[] appropriateBodyColumnNames = null,
+        string[] contactColumnNames = null);
 
     Task<Contact> GetTeacher(Guid teacherId, string[] columnNames, bool resolveMerges = true);
 

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/Certificates/CertificateGenerator.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/Certificates/CertificateGenerator.cs
@@ -33,6 +33,13 @@ public class CertificateGenerator : ICertificateGenerator
 
     private void ApplyContentToTemplate(PdfDocument pdfDocument, IReadOnlyDictionary<string, string> fieldValues)
     {
+        // Remove any template specific metadata (some of which is misleading in current templates)
+        pdfDocument.Info.Author = string.Empty;
+        pdfDocument.Info.Title = string.Empty;
+        pdfDocument.Info.Subject = string.Empty;
+        pdfDocument.Info.Creator = string.Empty;
+        pdfDocument.Info.CreationDate = pdfDocument.Info.ModificationDate;
+
         foreach (var kvp in fieldValues)
         {
             pdfDocument.AcroForm.Fields[kvp.Key].Value = new PdfString(kvp.Value);

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/CertificatesController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/CertificatesController.cs
@@ -87,6 +87,38 @@ public class CertificatesController : Controller
     }
 
     [HttpGet]
+    [Route("induction")]
+    [SwaggerOperation(
+    summary: "Induction Certificate",
+    description: "Returns a PDF of the Induction Certificate for the provided TRN holder")]
+    [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(FileResult), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetInduction()
+    {
+        var trn = User.FindFirstValue("trn");
+        if (trn is null)
+        {
+            return NotFound();
+        }
+
+        var request = new GetInductionCertificateRequest()
+        {
+            Trn = trn
+        };
+
+        var response = await _mediator.Send(request);
+        if (response is null)
+        {
+            return NotFound();
+        }
+
+        return new FileContentResult(response.FileContents, "application/pdf")
+        {
+            FileDownloadName = response.FileDownloadName
+        };
+    }
+
+    [HttpGet]
     [Route("npq/{qualificationId}")]
     [SwaggerOperation(
         summary: "NPQ Certificate",

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetInductionCertificateHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetInductionCertificateHandler.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using QualifiedTeachersApi.Services.Certificates;
+using QualifiedTeachersApi.V3.Requests;
+using QualifiedTeachersApi.V3.Responses;
+
+namespace QualifiedTeachersApi.V3.Handlers;
+
+public class GetInductionCertificateHandler : IRequestHandler<GetInductionCertificateRequest, GetCertificateResponse>
+{
+    private const string FullNameFormField = "Full Name";
+    private const string TrnFormField = "TRN";
+    private const string InductionDateFormField = "Induction Date";
+
+    private readonly IDataverseAdapter _dataverseAdapter;
+    private readonly ICertificateGenerator _certificateGenerator;
+
+    public GetInductionCertificateHandler(
+        IDataverseAdapter dataverseAdapter,
+        ICertificateGenerator certificateGenerator)
+    {
+        _dataverseAdapter = dataverseAdapter;
+        _certificateGenerator = certificateGenerator;
+    }
+
+    public async Task<GetCertificateResponse> Handle(GetInductionCertificateRequest request, CancellationToken cancellationToken)
+    {
+        var teacher = await _dataverseAdapter.GetTeacherByTrn(
+            request.Trn,
+            columnNames: new[]
+            {
+                Contact.Fields.dfeta_TRN
+            });
+
+        if (teacher == null)
+        {
+            return null;
+        }
+
+        var (induction, _) = await _dataverseAdapter.GetInductionByTeacher(
+            teacher.Id,
+            columnNames: new[]
+            {
+                dfeta_induction.PrimaryIdAttribute,
+                dfeta_induction.Fields.dfeta_StartDate,
+                dfeta_induction.Fields.dfeta_CompletionDate,
+                dfeta_induction.Fields.dfeta_InductionStatus
+            },
+            contactColumnNames: new[]
+            {
+                Contact.PrimaryIdAttribute,
+                Contact.Fields.FirstName,
+                Contact.Fields.MiddleName,
+                Contact.Fields.LastName
+            });
+
+        if (induction?.dfeta_InductionStatus != dfeta_InductionStatus.Pass
+            && induction?.dfeta_InductionStatus != dfeta_InductionStatus.PassedinWales)
+        {
+            return null;
+        }
+
+        var contact = induction.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute);
+
+        var fullName = new StringBuilder();
+        fullName.Append($"{contact.FirstName} ");
+        if (!string.IsNullOrWhiteSpace(contact.MiddleName))
+        {
+            fullName.Append($"{contact.MiddleName} ");
+        }
+
+        fullName.Append(contact.LastName);
+
+        var fieldValues = new Dictionary<string, string>()
+        {
+            { FullNameFormField, fullName.ToString() },
+            { TrnFormField, request.Trn },
+            { InductionDateFormField, induction.dfeta_CompletionDate.HasValue ? induction.dfeta_CompletionDate.Value.ToString("d MMMM yyyy") : string.Empty }
+        };
+
+        var pdfStream = await _certificateGenerator.GenerateCertificate("Induction certificate.pdf", fieldValues);
+        using var output = new MemoryStream();
+        pdfStream.CopyTo(output);
+
+        return new GetCertificateResponse()
+        {
+            FileDownloadName = $"InductionCertificate.pdf",
+            FileContents = output.ToArray()
+        };
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetInductionCertificateHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetInductionCertificateHandler.cs
@@ -60,8 +60,9 @@ public class GetInductionCertificateHandler : IRequestHandler<GetInductionCertif
                 Contact.Fields.LastName
             });
 
-        if (induction?.dfeta_InductionStatus != dfeta_InductionStatus.Pass
+        if ((induction?.dfeta_InductionStatus != dfeta_InductionStatus.Pass
             && induction?.dfeta_InductionStatus != dfeta_InductionStatus.PassedinWales)
+            || induction?.dfeta_CompletionDate == null)
         {
             return null;
         }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetTeacherHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetTeacherHandler.cs
@@ -160,6 +160,9 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 StartDate = induction.dfeta_StartDate.ToDateOnly(),
                 EndDate = induction.dfeta_CompletionDate.ToDateOnly(),
                 Status = MapInductionStatus(induction.dfeta_InductionStatus),
+                CertificateUrl = induction.dfeta_InductionStatus == dfeta_InductionStatus.Pass || induction.dfeta_InductionStatus == dfeta_InductionStatus.PassedinWales
+                ? "/v3/certificates/induction"
+                : null,
                 Periods = inductionperiods.Select(p => MapInductionPeriod(p)).ToArray()
             }
             : null;

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetInductionCertificateRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetInductionCertificateRequest.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using QualifiedTeachersApi.V3.Responses;
+
+namespace QualifiedTeachersApi.V3.Requests;
+
+public record GetInductionCertificateRequest : IRequest<GetCertificateResponse>
+{
+    public required string Trn { get; init; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
@@ -37,6 +37,7 @@ public record GetTeacherResponseInduction
     public DateOnly? StartDate { get; init; }
     public DateOnly? EndDate { get; init; }
     public InductionStatus? Status { get; init; }
+    public string CertificateUrl { get; init; }
     public IEnumerable<GetTeacherResponseInductionPeriod> Periods { get; init; }
 
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetInductionByTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetInductionByTeacherTests.cs
@@ -33,6 +33,7 @@ public class GetInductionByTeacherTests : IAsyncLifetime
 
         // Arrange
         var firstName = Faker.Name.First();
+        var middleName = Faker.Name.Middle();
         var lastName = Faker.Name.Last();
         var teacherStatusValue = "100"; // Qualified Teacher: Assessment Only Route 
         var qtsDate = new DateOnly(1997, 4, 23);
@@ -52,6 +53,7 @@ public class GetInductionByTeacherTests : IAsyncLifetime
         var teacherId = await _organizationService.CreateAsync(new Contact()
         {
             FirstName = firstName,
+            MiddleName = middleName,
             LastName = lastName,
             BirthDate = dateOfBirth.ToDateTime(),
             dfeta_QTSDate = qtsDate.ToDateTime()
@@ -146,6 +148,13 @@ public class GetInductionByTeacherTests : IAsyncLifetime
             {
                 Account.PrimaryIdAttribute,
                 Account.Fields.Name
+            },
+            contactColumnNames: new[]
+            {
+                Contact.PrimaryIdAttribute,
+                Contact.Fields.FirstName,
+                Contact.Fields.MiddleName,
+                Contact.Fields.LastName
             });
 
         // Assert
@@ -154,6 +163,13 @@ public class GetInductionByTeacherTests : IAsyncLifetime
         Assert.Equal(inductionStartDate.ToDateTime(), induction.dfeta_StartDate);
         Assert.Equal(inductionEndDate.ToDateTime(), induction.dfeta_CompletionDate);
         Assert.Equal(inductionStatus, induction.dfeta_InductionStatus);
+
+        var teacher = induction.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute);
+        Assert.NotNull(teacher);
+        Assert.Equal(firstName, teacher.FirstName);
+        Assert.Equal(middleName, teacher.MiddleName);
+        Assert.Equal(lastName, teacher.LastName);
+
         Assert.NotNull(inductionPeriods);
 
         if (numberOfInductionPeriods > 0)

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetInductionCertificateTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetInductionCertificateTests.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Xrm.Sdk;
+using Moq;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.V3;
+
+public class GetInductionCertificateTests : ApiTestBase
+{
+    public GetInductionCertificateTests(ApiFixture apiFixture)
+        : base(apiFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InductionCertificateWhenNoTeacherAssociatedWithTrn_ReturnsNotFound()
+    {
+        // Arrange
+        var trn = "1234567";
+
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/certificates/induction");
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_InductionCertificateWhenInductionDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var trn = "1234567";
+
+        ApiFixture.DataverseAdapter
+            .Setup(d => d.GetTeacherByTrn(trn, It.IsAny<string[]>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Contact()
+            {
+                Id = Guid.NewGuid(),
+                dfeta_TRN = trn
+            });
+
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/certificates/induction");
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_InductionCertificateWhenInductionNotPassed_ReturnsNotFound()
+    {
+        // Arrange
+        var trn = "1234567";
+        var teacherId = Guid.NewGuid();
+        var inductionStartDate = new DateOnly(2000, 5, 6);
+        var inductionStatus = dfeta_InductionStatus.NotYetCompleted;
+
+        ApiFixture.DataverseAdapter
+            .Setup(d => d.GetTeacherByTrn(trn, It.IsAny<string[]>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Contact()
+            {
+                Id = teacherId,
+                dfeta_TRN = trn
+            });
+
+        ApiFixture.DataverseAdapter
+            .Setup(d => d.GetInductionByTeacher(
+                teacherId,
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>()))
+            .ReturnsAsync(
+            (new dfeta_induction()
+            {
+                Id = Guid.NewGuid(),
+                dfeta_StartDate = inductionStartDate.ToDateTime(),
+                dfeta_InductionStatus = inductionStatus
+            },
+            new dfeta_inductionperiod[] { }
+            ));
+
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+
+        // Act        
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/certificates/induction");
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var trn = "1234567";
+        var teacherId = Guid.NewGuid();
+        var inductionStartDate = new DateOnly(2000, 5, 6);
+        var inductionEndDate = new DateOnly(2000, 7, 9);
+        var inductionStatus = dfeta_InductionStatus.Pass;
+
+        var teacher = new Contact()
+        {
+            Id = teacherId,
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            dfeta_TRN = trn
+        };
+
+        ApiFixture.DataverseAdapter
+            .Setup(d => d.GetTeacherByTrn(trn, It.IsAny<string[]>(), It.IsAny<bool>()))
+            .ReturnsAsync(teacher);
+
+        var induction = new dfeta_induction()
+        {
+            Id = Guid.NewGuid(),
+            dfeta_StartDate = inductionStartDate.ToDateTime(),
+            dfeta_CompletionDate = inductionEndDate.ToDateTime(),
+            dfeta_InductionStatus = inductionStatus,
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId)
+        };
+
+        induction.Attributes.Add($"contact.{Contact.PrimaryIdAttribute}", new AliasedValue(Contact.EntityLogicalName, Contact.PrimaryIdAttribute, teacherId));
+        induction.Attributes.Add($"contact.{Contact.Fields.FirstName}", new AliasedValue(Contact.EntityLogicalName, Contact.Fields.FirstName, teacher.FirstName));
+        induction.Attributes.Add($"contact.{Contact.Fields.MiddleName}", new AliasedValue(Contact.EntityLogicalName, Contact.Fields.MiddleName, teacher.MiddleName));
+        induction.Attributes.Add($"contact.{Contact.Fields.LastName}", new AliasedValue(Contact.EntityLogicalName, Contact.Fields.FirstName, teacher.LastName));
+
+        ApiFixture.DataverseAdapter
+            .Setup(d => d.GetInductionByTeacher(
+                teacherId,
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>()))
+            .ReturnsAsync((induction, new dfeta_inductionperiod[] { }));
+
+        string projectDirectory = Directory.GetParent(Environment.CurrentDirectory)?.Parent?.Parent?.FullName;
+        var pdfPath = Path.Combine(projectDirectory!, "Resources", "TestCertificate.pdf");
+        var pdfStream = File.OpenRead(pdfPath);
+
+        ApiFixture.CertificateGenerator
+            .Setup(g => g.GenerateCertificate(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>()))
+            .ReturnsAsync(pdfStream);
+
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/certificates/induction");
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var downloadFilename = response!.Content?.Headers?.ContentDisposition?.FileNameStar;
+        Assert.Equal($"InductionCertificate.pdf", downloadFilename);
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
@@ -175,6 +175,7 @@ public class GetTeacherTests : ApiTestBase
                 teacherId,
                 It.IsAny<string[]>(),
                 It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
                 It.IsAny<string[]>()))
             .ReturnsAsync((induction, inductionPeriods));
 
@@ -224,6 +225,7 @@ public class GetTeacherTests : ApiTestBase
                     startDate = inductionStartDate.ToString("yyyy-MM-dd"),
                     endDate = inductionEndDate.ToString("yyyy-MM-dd"),
                     status = inductionStatus.ToString(),
+                    certificateUrl = "/v3/certificates/induction",
                     periods = new[]
                     {
                         new

--- a/docs/api-specs/v3.json
+++ b/docs/api-specs/v3.json
@@ -103,6 +103,55 @@
         }
       }
     },
+    "/v3/certificates/induction": {
+      "get": {
+        "tags": [
+          "Certificates"
+        ],
+        "summary": "Induction Certificate",
+        "description": "Returns a PDF of the Induction Certificate for the provided TRN holder",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/problem+json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v3/certificates/npq/{qualificationId}": {
       "get": {
         "tags": [
@@ -265,6 +314,10 @@
           },
           "status": {
             "$ref": "#/components/schemas/InductionStatus"
+          },
+          "certificateUrl": {
+            "type": "string",
+            "nullable": true
           },
           "periods": {
             "type": "array",


### PR DESCRIPTION
### Context

Need to be able to generate induction certificate in qualifications v3 API to be consumed by new UI.

### Changes proposed in this pull request

Code changes + tests + change to certificate generation to remove unncessary metadata

### Guidance to review

API / Dataverse adapter / tests

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
