### PR TITLE
Add teacher status cache

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/CacheKeys.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/CacheKeys.cs
@@ -21,4 +21,8 @@ public static class CacheKeys
     public static object GetOrganizationByUkprnKey(string ukprn) => $"organization:{ukprn}";
 
     public static object GetTeacherStatusKey(string code) => $"teacher_status:{code}";
+
+    public static object GetAllTeacherStatuses() => "all_teacher_statuses";
+
+    public static object GetAllEytsStatuses() => "all_eyts_statuses";
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -643,7 +643,7 @@ public partial class DataverseAdapter
                     DeriveTeacherStatus(out var qtsDateRequired),
                     teacherStatusId => _dataverseAdapter._cache.GetOrCreateUnlessNullAsync(
                         CacheKeys.GetTeacherStatusKey(teacherStatusId),
-                        () => _dataverseAdapter.GetTeacherStatus(teacherStatusId, qtsDateRequired, requestBuilder))) :
+                        () => _dataverseAdapter.GetTeacherStatus(teacherStatusId, requestBuilder))) :
                 Task.FromResult<dfeta_teacherstatus>(null);
 
             var existingTeachersWithHusIdTask = !string.IsNullOrEmpty(_command.HusId) ?

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
@@ -644,7 +644,7 @@ public partial class DataverseAdapter
                         "211",   // 211 == 'Trainee Teacher'
                     teacherStatusId => _dataverseAdapter._cache.GetOrCreateUnlessNullAsync(
                         CacheKeys.GetTeacherStatusKey(teacherStatusId),
-                        () => _dataverseAdapter.GetTeacherStatus(teacherStatusId, qtsDateRequired: false, requestBuilder))) :
+                        () => _dataverseAdapter.GetTeacherStatus(teacherStatusId, requestBuilder))) :
                 Task.FromResult<dfeta_teacherstatus>(null);
 
             var existingTeachersWithHusIdTask = !string.IsNullOrEmpty(_command.HusId) ? _dataverseAdapter.GetTeachersByHusId(_command.HusId, columnNames: new[]

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetEarlyYearsStatusTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetEarlyYearsStatusTests.cs
@@ -25,7 +25,7 @@ public class GetEarlyYearsStatusTests : IAsyncLifetime
         var value = "220";
 
         // Act
-        var result = await _dataverseAdapter.GetEarlyYearsStatus(value);
+        var result = await _dataverseAdapter.GetEarlyYearsStatus(value, null);
 
         // Assert
         Assert.NotNull(result);
@@ -39,7 +39,7 @@ public class GetEarlyYearsStatusTests : IAsyncLifetime
         var countryCode = "XXXX";
 
         // Act
-        var result = await _dataverseAdapter.GetEarlyYearsStatus(countryCode);
+        var result = await _dataverseAdapter.GetEarlyYearsStatus(countryCode, null);
 
         // Assert
         Assert.Null(result);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetInductionByTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetInductionByTeacherTests.cs
@@ -68,7 +68,6 @@ public class GetInductionByTeacherTests : IAsyncLifetime
             }
         });
 
-        // Teacher needs TRN + DOB + ITT pass in order to get QTS registration records into CRM due to plugin validation
         await _organizationService.CreateAsync(new dfeta_initialteachertraining()
         {
             dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
@@ -76,7 +75,7 @@ public class GetInductionByTeacherTests : IAsyncLifetime
         });
 
         // Need QTS to be able to get induction records into CRM due to plugin validation
-        var teacherStatus = await _dataverseAdapter.GetTeacherStatus(teacherStatusValue, true);
+        var teacherStatus = await _dataverseAdapter.GetTeacherStatus(teacherStatusValue, null);
         await _organizationService.CreateAsync(new dfeta_qtsregistration()
         {
             dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetQualificationsForTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetQualificationsForTeacherTests.cs
@@ -79,7 +79,6 @@ public class GetQualificationsForTeacherTests : IAsyncLifetime
             }
         });
 
-        // Teacher needs TRN + DOB + ITT pass in order to get QTS registration records into CRM due to plugin validation
         await _organizationService.CreateAsync(new dfeta_initialteachertraining()
         {
             dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
@@ -87,7 +86,7 @@ public class GetQualificationsForTeacherTests : IAsyncLifetime
         });
 
         // Need QTS to be able to get MQ quals into CRM due to plugin validation
-        var teacherStatus = await _dataverseAdapter.GetTeacherStatus(teacherStatusValue, true);
+        var teacherStatus = await _dataverseAdapter.GetTeacherStatus(teacherStatusValue, null);
         await _organizationService.CreateAsync(new dfeta_qtsregistration()
         {
             dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetTeacherStatusTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetTeacherStatusTests.cs
@@ -25,7 +25,7 @@ public class GetTeacherStatusTests : IAsyncLifetime
         var value = "211";
 
         // Act
-        var result = await _dataverseAdapter.GetTeacherStatus(value, qtsDateRequired: false);
+        var result = await _dataverseAdapter.GetTeacherStatus(value, null);
 
         // Assert
         Assert.NotNull(result);
@@ -39,7 +39,7 @@ public class GetTeacherStatusTests : IAsyncLifetime
         var value = "XXXX";
 
         // Act
-        var result = await _dataverseAdapter.GetTeacherStatus(value, qtsDateRequired: false);
+        var result = await _dataverseAdapter.GetTeacherStatus(value, null);
 
         // Assert
         Assert.Null(result);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/SetIttOutcomeForTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/SetIttOutcomeForTeacherTests.cs
@@ -37,7 +37,7 @@ public class SetIttOutcomeForTeacherTests : IAsyncLifetime
         var ittResult = dfeta_ITTResult.Pass;
         var assessmentDate = _clock.Today;
 
-        var earlyYearsTeacherStatusId = (await _dataverseAdapter.GetEarlyYearsStatus("221")).Id;
+        var earlyYearsTeacherStatusId = (await _dataverseAdapter.GetEarlyYearsStatus("221", null)).Id;
 
         // Act
         var (result, transactionRequest) = await _dataverseAdapter.SetIttResultForTeacherImpl(
@@ -80,7 +80,7 @@ public class SetIttOutcomeForTeacherTests : IAsyncLifetime
 
         var ittResult = dfeta_ITTResult.Pass;
         var assessmentDate = _clock.Today;
-        var teacherStatusId = (await _dataverseAdapter.GetTeacherStatus(expectedTeacherStatus, qtsDateRequired: true)).Id;
+        var teacherStatusId = (await _dataverseAdapter.GetTeacherStatus(expectedTeacherStatus, null)).Id;
 
         // Act
         var (result, transactionRequest) = await _dataverseAdapter.SetIttResultForTeacherImpl(

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/TestDataHelper.CreatePerson.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/TestDataHelper.CreatePerson.cs
@@ -59,7 +59,7 @@ public partial class TestDataHelper
         var getTeacherStatusTask = !earlyYears ?
             _globalCache.GetOrCreateAsync(
                 CacheKeys.GetTeacherStatusKey(teacherStatus),
-                _ => _dataverseAdapter.GetTeacherStatus(teacherStatus, qtsDateRequired: false, lookupRequestBuilder)) :
+                _ => _dataverseAdapter.GetTeacherStatus(teacherStatus, lookupRequestBuilder)) :
             Task.FromResult<dfeta_teacherstatus>(null);
 
         var country = "XK";


### PR DESCRIPTION
### Context

More and more Teacher statuses are being used in the dataverse adapter methods. This PR is to introduce a cache of teacher statuses so we do not have to fetch the teacher/eyts statuses every time we need them.

The Below tickets were the triggers for making the change. Register require more statuses in the setittoutcome/update endpoints, which would dramatically reduce performance. 

- https://trello.com/c/DWSeHva5/5303-when-a-trainee-is-awarded-in-register-and-its-already-awarded-in-dqt-error-if-the-qts-date-differs-between-the-services
- https://trello.com/c/kygTQwKa/5304-allow-the-unwithdrawal-of-a-withdrawn-record-in-dqt

### Changes proposed in this pull request


### Guidance to review


### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
