### PR TITLE
Add middle name to the V2 and V3 GET teachers endpoint

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetTeacherHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetTeacherHandler.cs
@@ -27,6 +27,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             {
                 Contact.Fields.FirstName,
                 Contact.Fields.LastName,
+                Contact.Fields.MiddleName,
                 Contact.Fields.BirthDate,
                 Contact.Fields.dfeta_EYTSDate,
                 Contact.Fields.dfeta_QTSDate,
@@ -85,6 +86,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             FirstName = teacher.FirstName,
             HasActiveSanctions = teacher.dfeta_ActiveSanctions == true,
             LastName = teacher.LastName,
+            MiddleName = teacher.MiddleName,
             NationalInsuranceNumber = teacher.dfeta_NINumber,
             Trn = teacher.dfeta_TRN,
             QtsDate = teacher.dfeta_QTSDate.ToDateOnly(),

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/GetTeacherResponse.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/GetTeacherResponse.cs
@@ -9,6 +9,7 @@ public class GetTeacherResponse
     public string Trn { get; set; }
     public string FirstName { get; set; }
     public string LastName { get; set; }
+    public string MiddleName { get; set; }
     public DateOnly? DateOfBirth { get; set; }
     public string NationalInsuranceNumber { get; set; }
     public bool HasActiveSanctions { get; set; }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetTeacherHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetTeacherHandler.cs
@@ -29,6 +29,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             columnNames: new[]
             {
                 Contact.Fields.FirstName,
+                Contact.Fields.MiddleName,
                 Contact.Fields.LastName,
                 Contact.Fields.dfeta_QTSDate,
                 Contact.Fields.dfeta_EYTSDate
@@ -116,6 +117,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             Trn = request.Trn,
             FirstName = teacher.FirstName,
             LastName = teacher.LastName,
+            MiddleName = teacher.MiddleName,
             Qts = MapQts(teacher.dfeta_QTSDate?.ToDateOnly()),
             Eyts = MapEyts(teacher.dfeta_EYTSDate?.ToDateOnly()),
             Induction = MapInduction(induction, inductionPeriods),

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
@@ -13,6 +13,7 @@ public record GetTeacherResponse
     public required string FirstName { get; init; }
     [SwaggerSchema(Nullable = false)]
     public required string LastName { get; init; }
+    public required string MiddleName { get; init; }
     public required GetTeacherResponseQts Qts { get; init; }
     public required GetTeacherResponseEyts Eyts { get; init; }
     public required GetTeacherResponseInduction Induction { get; init; }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTeacherTests.cs
@@ -218,6 +218,7 @@ public class GetTeacherTests : ApiTestBase
         var birthDate = "1990-04-01";
         var firstName = Faker.Name.First();
         var lastName = Faker.Name.Last();
+        var middleName = Faker.Name.Middle();
         var nino = Faker.Identification.UkNationalInsuranceNumber();
         var qtsDate = (DateOnly?)null;
         var eytsDate = (DateOnly?)new DateOnly(2022, 7, 7);
@@ -239,6 +240,7 @@ public class GetTeacherTests : ApiTestBase
             BirthDate = DateTime.Parse(birthDate),
             FirstName = firstName,
             LastName = lastName,
+            MiddleName = middleName,
             dfeta_TRN = trn,
             dfeta_NINumber = nino,
             StateCode = ContactState.Active,
@@ -308,6 +310,7 @@ public class GetTeacherTests : ApiTestBase
                 trn = trn,
                 firstName = firstName,
                 lastName = lastName,
+                middleName = middleName,
                 dateOfBirth = birthDate,
                 nationalInsuranceNumber = nino,
                 hasActiveSanctions = false,

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTeacherTests.cs
@@ -62,6 +62,7 @@ public class GetTeacherTests : ApiTestBase
         var birthDate = "1990-04-01";
         var firstName = Faker.Name.First();
         var lastName = Faker.Name.Last();
+        var middleName = Faker.Name.Middle();
         var nino = Faker.Identification.UkNationalInsuranceNumber();
         var qtsDate = (DateOnly?)null;
         var eytsDate = (DateOnly?)new DateOnly(2022, 7, 7);
@@ -84,6 +85,7 @@ public class GetTeacherTests : ApiTestBase
             BirthDate = DateTime.Parse(birthDate),
             FirstName = firstName,
             LastName = lastName,
+            MiddleName = middleName,
             dfeta_TRN = trn,
             dfeta_NINumber = nino,
             StateCode = ContactState.Active,
@@ -166,6 +168,7 @@ public class GetTeacherTests : ApiTestBase
                 trn = trn,
                 firstName = firstName,
                 lastName = lastName,
+                middleName = middleName,
                 dateOfBirth = birthDate,
                 nationalInsuranceNumber = nino,
                 hasActiveSanctions = false,

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
@@ -43,6 +43,8 @@ public class GetTeacherTests : ApiTestBase
         var teacherId = Guid.NewGuid();
         var firstName = Faker.Name.First();
         var lastName = Faker.Name.Last();
+        var middleName = Faker.Name.Middle();
+
         var qtsDate = new DateOnly(1997, 4, 23);
         var eytsDate = new DateOnly(1995, 5, 14);
         var inductionStartDate = new DateOnly(1996, 2, 3);
@@ -78,6 +80,7 @@ public class GetTeacherTests : ApiTestBase
             dfeta_TRN = trn,
             FirstName = firstName,
             LastName = lastName,
+            MiddleName = middleName,
             dfeta_QTSDate = qtsDate.ToDateTime(),
             dfeta_EYTSDate = eytsDate.ToDateTime(),
         };
@@ -252,6 +255,7 @@ public class GetTeacherTests : ApiTestBase
             {
                 firstName = firstName,
                 lastName = lastName,
+                middleName = middleName,
                 trn = trn,
                 qts = new
                 {

--- a/docs/api-specs/v2.json
+++ b/docs/api-specs/v2.json
@@ -927,6 +927,10 @@
             "type": "string",
             "nullable": true
           },
+          "middleName": {
+            "type": "string",
+            "nullable": true
+          },
           "dateOfBirth": {
             "type": "string",
             "format": "date",

--- a/docs/api-specs/v3.json
+++ b/docs/api-specs/v3.json
@@ -259,6 +259,10 @@
           "lastName": {
             "type": "string"
           },
+          "middleName": {
+            "type": "string",
+            "nullable": true
+          },
           "qts": {
             "$ref": "#/components/schemas/GetTeacherResponseQts"
           },


### PR DESCRIPTION
### Context

We’re building an Account page for a user to change their DQT name and this includes middle name. The current DQT API endpoints don’t include middle name but we need it to be able to play back the user’s current name completely.

### Changes proposed in this pull request

Add a MiddleName property to the v2 and v3 ‘get teacher’ endpoints, mapped from the contact’s middlename attribute.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
