### PR TITLE
Workaround CF CLI download issue

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -105,12 +105,23 @@ runs:
         name: migrations
         path: migrations
 
-    - uses: DFE-Digital/github-actions/setup-cf-cli@master
-      with:
+    - name: Install CF CLI
+      shell: bash
+      run: |
+        curl -sL ${CF_CLI_DOWNLOAD_URL} --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15" | sudo tar -zx -C /usr/local/bin
+
+        cf install-plugin conduit -f
+
+        cf api ${CF_API_URL}
+        cf auth
+        cf target -o ${CF_ORG_NAME} -s ${CF_SPACE_NAME}
+      env:
         CF_USERNAME: ${{ steps.get_secrets.outputs.PAAS-USER }}
         CF_PASSWORD: ${{ steps.get_secrets.outputs.PAAS-PASSWORD }}
         CF_SPACE_NAME: ${{ env.paas_space }}
-        INSTALL_CONDUIT: true
+        CF_API_URL: https://api.london.cloud.service.gov.uk
+        CF_ORG_NAME: dfe
+        CF_CLI_DOWNLOAD_URL: https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github&version=v7
 
     - name: Set environment variables
       shell: bash


### PR DESCRIPTION
The action we use to download the CF CLI is currently broken as `curl`-like user agents are being blocked. This change copies the guts of the action and spoofs the user agent to make the download work.