### PR TITLE
Add new v3 GET teachers endpoint with TRN parameter

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeacherController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeacherController.cs
@@ -12,7 +12,6 @@ using Swashbuckle.AspNetCore.Annotations;
 namespace QualifiedTeachersApi.V3.Controllers;
 
 [ApiController]
-[Route("teacher")]
 public class TeacherController : Controller
 {
     private readonly IMediator _mediator;
@@ -24,7 +23,7 @@ public class TeacherController : Controller
 
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
-    [Route("")]
+    [Route("teacher")]
     [SwaggerOperation(
         summary: "Get teacher details",
         description: "Gets the details of the currently authenticated teacher")]
@@ -57,7 +56,7 @@ public class TeacherController : Controller
     }
 
     [Authorize(AuthorizationPolicies.ApiKey)]
-    [HttpGet("{Trn}")]
+    [HttpGet("teachers/{Trn}")]
     [SwaggerOperation(
         summary: "Get teacher details by TRN",
         description: "Gets the details of the teacher corresponding to the given TRN")]

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeacherController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeacherController.cs
@@ -13,7 +13,6 @@ namespace QualifiedTeachersApi.V3.Controllers;
 
 [ApiController]
 [Route("teacher")]
-[Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
 public class TeacherController : Controller
 {
     private readonly IMediator _mediator;
@@ -23,12 +22,14 @@ public class TeacherController : Controller
         _mediator = mediator;
     }
 
+    [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
     [Route("")]
     [SwaggerOperation(
-        summary: "Teacher",
+        summary: "Get teacher details",
         description: "Gets the details of the currently authenticated teacher")]
     [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Get()
     {
         var trn = User.FindFirstValue("trn");
@@ -53,5 +54,26 @@ public class TeacherController : Controller
         return Ok(response);
 
         IActionResult MissingOrInvalidTrn() => BadRequest();
+    }
+
+    [Authorize(AuthorizationPolicies.ApiKey)]
+    [HttpGet("{Trn}")]
+    [SwaggerOperation(
+        summary: "Get teacher details by TRN",
+        description: "Gets the details of the teacher corresponding to the given TRN")]
+    [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get([FromRoute] GetTeacherRequest request)
+    {
+        var response = await _mediator.Send(request);
+
+        if (response is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(response);
     }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
@@ -6,6 +6,5 @@ namespace QualifiedTeachersApi.V3.Requests;
 
 public record GetTeacherRequest : IRequest<GetTeacherResponse>
 {
-    [RegularExpression(@"^\d{7}$", ErrorMessage = "TRN must be 7 digits")]
     public required string Trn { get; init; }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
@@ -1,9 +1,11 @@
-﻿using MediatR;
+﻿using System.ComponentModel.DataAnnotations;
+using MediatR;
 using QualifiedTeachersApi.V3.Responses;
 
 namespace QualifiedTeachersApi.V3.Requests;
 
 public record GetTeacherRequest : IRequest<GetTeacherResponse>
 {
+    [RegularExpression(@"^\d{7}$", ErrorMessage = "TRN must be 7 digits")]
     public required string Trn { get; init; }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-using MediatR;
+﻿using MediatR;
 using QualifiedTeachersApi.V3.Responses;
 
 namespace QualifiedTeachersApi.V3.Requests;

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Validators/GetTeacherRequestValidator.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Validators/GetTeacherRequestValidator.cs
@@ -1,5 +1,5 @@
 ﻿using FluentValidation;
-using QualifiedTeachersApi.V2.Requests;
+using QualifiedTeachersApi.V3.Requests;
 
 namespace QualifiedTeachersApi.V3.Validators;
 

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Validators/GetTeacherRequestValidator.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Validators/GetTeacherRequestValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+using QualifiedTeachersApi.V2.Requests;
+
+namespace QualifiedTeachersApi.V3.Validators;
+
+public class GetTeacherRequestValidator : AbstractValidator<GetTeacherRequest>
+{
+    public GetTeacherRequestValidator()
+    {
+        RuleFor(x => x.Trn)
+            .Matches(@"^\d{7}$")
+            .WithMessage(Properties.StringResources.ErrorMessages_TRNMustBe7Digits);
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherByTrnTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherByTrnTests.cs
@@ -23,7 +23,7 @@ public class GetTeacherByTrnTests : ApiTestBase
         // Arrange
         var trn = "1234567";
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teacher/{trn}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{trn}");
 
         // Act
         var response = await ApiFixture.CreateClient().SendAsync(request);
@@ -38,7 +38,7 @@ public class GetTeacherByTrnTests : ApiTestBase
         // Arrange
         var trn = "invalid";
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teacher/{trn}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{trn}");
 
         // Act
         var response = await HttpClientWithApiKey.SendAsync(request);
@@ -53,7 +53,7 @@ public class GetTeacherByTrnTests : ApiTestBase
         // Arrange
         var trn = "1234567";
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teacher/{trn}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{trn}");
 
         // Act
         var response = await HttpClientWithApiKey.SendAsync(request);
@@ -112,7 +112,7 @@ public class GetTeacherByTrnTests : ApiTestBase
                  It.IsAny<string[]>()))
              .ReturnsAsync(qualifications);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teacher/{trn}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{trn}");
 
         // Act
         var response = await HttpClientWithApiKey.SendAsync(request);

--- a/docs/api-specs/v3.json
+++ b/docs/api-specs/v3.json
@@ -254,7 +254,7 @@
         }
       }
     },
-    "/v3/teacher/{Trn}": {
+    "/v3/teachers/{Trn}": {
       "get": {
         "tags": [
           "Teacher"
@@ -267,7 +267,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d{7}$",
               "type": "string"
             }
           }

--- a/docs/api-specs/v3.json
+++ b/docs/api-specs/v3.json
@@ -218,7 +218,7 @@
         "tags": [
           "Teacher"
         ],
-        "summary": "Teacher",
+        "summary": "Get teacher details",
         "description": "Gets the details of the currently authenticated teacher",
         "responses": {
           "200": {
@@ -227,6 +227,98 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetTeacherResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/teacher/{Trn}": {
+      "get": {
+        "tags": [
+          "Teacher"
+        ],
+        "summary": "Get teacher details by TRN",
+        "description": "Gets the details of the teacher corresponding to the given TRN",
+        "parameters": [
+          {
+            "name": "Trn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^\\d{7}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetTeacherResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }


### PR DESCRIPTION
### Context

The Right to teach service needs to able to retrieve data for a teacher by a TRN. The existing v3 endpoints are authorised by an ID access token, which has a TRN baked in. We need an alternative endpoint where the TRN can be specified.

### Changes proposed in this pull request

Add a `GET /v3/teachers/<trn>` endpoint. It should be authorised using the ApiKey authorization policy. It should return data in the same format as the existing /v3/teacher endpoint, for the TRN specified in the URL. If the TRN is not 7 digits, return a 400 response. If no teacher exists with the specified TRN, return a 404.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
