### PR TITLE
Add Pending{Name|DateOfBirth} properties to v3 teacher response

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/CacheKeys.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/CacheKeys.cs
@@ -25,4 +25,6 @@ public static class CacheKeys
     public static object GetAllTeacherStatuses() => "all_teacher_statuses";
 
     public static object GetAllEytsStatuses() => "all_eyts_statuses";
+
+    public static object GetSubjectTitleKey(string title) => $"subjects_{title}";
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.RequestBuilder.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.RequestBuilder.cs
@@ -64,7 +64,7 @@ public partial class DataverseAdapter
 
             if (_requestType == RequestType.Single)
             {
-                Execute();
+                _ = Execute();
             }
 
             return new InnerRequestHandle<TResponse>(this, request);
@@ -78,17 +78,20 @@ public partial class DataverseAdapter
             }
         }
 
-        public Task Execute()
+        public async Task Execute()
         {
             ThrowIfCompleted();
 
-            return _requestType switch
+            var executeTask = _requestType switch
             {
                 RequestType.Single => ExecuteSingleRequest(),
                 RequestType.Multiple => ExecuteMultipleRequest(),
                 RequestType.Transaction => ExecuteTransactionRequest(),
                 _ => throw new NotSupportedException($"Unknown {nameof(RequestType)}: '{_requestType}'.")
             };
+
+            await executeTask;
+            await _completedTcs.Task;
 
             async Task ExecuteSingleRequest()
             {

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
@@ -65,7 +65,7 @@ public interface IDataverseAdapter
 
     Task<Account[]> GetOrganizationsByUkprn(string ukprn, string[] columnNames);
 
-    Task<Models.Task[]> GetCrmTasksForTeacher(Guid teacherId, string[] columnNames);
+    Task<CrmTask[]> GetCrmTasksForTeacher(Guid teacherId, string[] columnNames);
 
     Task<SetIttResultForTeacherResult> SetIttResultForTeacher(
         Guid teacherId,
@@ -82,4 +82,8 @@ public interface IDataverseAdapter
     Task<Contact[]> GetTeachersByHusId(string husId, string[] columnNames);
 
     Task<Guid> CreateNameChangeIncident(CreateNameChangeIncidentCommand command);
+
+    Task<Subject> GetSubjectByTitle(string title, string[] columnNames);
+
+    Task<Incident[]> GetIncidentsByContactId(Guid contactId, IncidentState? state, string[] columnNames);
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetTeacherHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetTeacherHandler.cs
@@ -114,6 +114,17 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 dfeta_specialism.Fields.dfeta_name
             });
 
+        var nameChangeSubject = await _dataverseAdapter.GetSubjectByTitle("Change of Name", columnNames: Array.Empty<string>());
+        var dateOfBirthChangeSubject = await _dataverseAdapter.GetSubjectByTitle("Change of Date of Birth", columnNames: Array.Empty<string>());
+
+        var incidents = await _dataverseAdapter.GetIncidentsByContactId(
+            teacher.Id,
+            IncidentState.Active,
+            columnNames: new[] { Incident.Fields.SubjectId, Incident.Fields.StateCode });
+
+        var pendingNameChange = incidents.Any(i => i.SubjectId.Id == nameChangeSubject.Id);
+        var pendingDateOfBirthChange = incidents.Any(i => i.SubjectId.Id == dateOfBirthChangeSubject.Id);
+
         return new GetTeacherResponse()
         {
             Trn = request.Trn,
@@ -122,6 +133,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             LastName = teacher.LastName,
             DateOfBirth = teacher.BirthDate.Value.ToDateOnly(),
             NationalInsuranceNumber = teacher.dfeta_NINumber,
+            PendingNameChange = pendingNameChange,
+            PendingDateOfBirthChange = pendingDateOfBirthChange,
             Qts = MapQts(teacher.dfeta_QTSDate?.ToDateOnly()),
             Eyts = MapEyts(teacher.dfeta_EYTSDate?.ToDateOnly()),
             Induction = MapInduction(induction, inductionPeriods),

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
@@ -12,10 +12,12 @@ public record GetTeacherResponse
     [SwaggerSchema(Nullable = false)]
     public required string FirstName { get; init; }
     [SwaggerSchema(Nullable = false)]
-    public required string LastName { get; init; }
     public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
     public required DateOnly DateOfBirth { get; init; }
     public required string NationalInsuranceNumber { get; init; }
+    public required bool PendingNameChange { get; init; }
+    public required bool PendingDateOfBirthChange { get; init; }
     public required GetTeacherResponseQts Qts { get; init; }
     public required GetTeacherResponseEyts Eyts { get; init; }
     public required GetTeacherResponseInduction Induction { get; init; }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherByTrnTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherByTrnTests.cs
@@ -1,16 +1,10 @@
-using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Xrm.Sdk;
-using Moq;
-using QualifiedTeachersApi.DataStore.Crm.Models;
-using QualifiedTeachersApi.TestCommon;
-using QualifiedTeachersApi.V3.ApiModels;
 using Xunit;
 
 namespace QualifiedTeachersApi.Tests.V3;
 
-public class GetTeacherByTrnTests : ApiTestBase
+public class GetTeacherByTrnTests : GetTeacherTestBase
 {
     public GetTeacherByTrnTests(ApiFixture apiFixture)
         : base(apiFixture)
@@ -18,7 +12,7 @@ public class GetTeacherByTrnTests : ApiTestBase
     }
 
     [Fact]
-    public async Task Get_UnauthenticatedRequest_Returns401()
+    public async Task Get_UnauthenticatedRequest_ReturnsUnauthorized()
     {
         // Arrange
         var trn = "1234567";
@@ -33,7 +27,7 @@ public class GetTeacherByTrnTests : ApiTestBase
     }
 
     [Fact]
-    public async Task Get_InvalidTrn_Returns400()
+    public async Task Get_InvalidTrn_ReturnsBadRequest()
     {
         // Arrange
         var trn = "invalid";
@@ -48,7 +42,7 @@ public class GetTeacherByTrnTests : ApiTestBase
     }
 
     [Fact]
-    public async Task Get_TrnNotFound_Returns404()
+    public async Task Get_TrnNotFound_ReturnsNotFound()
     {
         // Arrange
         var trn = "1234567";
@@ -62,325 +56,30 @@ public class GetTeacherByTrnTests : ApiTestBase
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
     }
 
-
     [Fact]
-    public async Task Get_ValidRequest_ReturnsExpectedResponse()
+    public Task Get_ValidRequest_ReturnsExpectedResponse()
     {
-        // Arrange
         var trn = "1234567";
-
-        var teacher = GenerateTeacher(trn);
-        var itt = GenerateItt(teacher);
-
-        var induction = GenerateInduction();
-        var inductionPeriods = GenerateInductionPeriods();
-
-        ApiFixture.DataverseAdapter
-            .Setup(mock => mock.GetInductionByTeacher(
-                teacher.Id,
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>()))
-            .ReturnsAsync((induction, inductionPeriods));
-
-        var npqQualificationNoAwardDate = GenerateQualification(dfeta_qualification_dfeta_Type.NPQLL, null, dfeta_qualificationState.Active, null);
-        var npqQualificationInactive = GenerateQualification(dfeta_qualification_dfeta_Type.NPQSL, new DateTime(2022, 5, 6), dfeta_qualificationState.Inactive, null);
-        var npqQualificationValid = GenerateQualification(dfeta_qualification_dfeta_Type.NPQEYL, new DateTime(2022, 3, 4), dfeta_qualificationState.Active, null);
-        var mandatoryQualificationNoAwardDate = GenerateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, null, dfeta_qualificationState.Active, "Visual Impairment");
-        var mandatoryQualificationNoSpecialism = GenerateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 2, 3), dfeta_qualificationState.Active, null);
-        var mandatoryQualificationValid = GenerateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 4, 6), dfeta_qualificationState.Active, "Hearing");
-        var mandatoryQualificationInactive = GenerateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 4, 8), dfeta_qualificationState.Inactive, "Mutli Sensory Impairment");
-
-        var qualifications = new dfeta_qualification[]
-        {
-            npqQualificationNoAwardDate,
-            npqQualificationInactive,
-            npqQualificationValid,
-            mandatoryQualificationNoAwardDate,
-            mandatoryQualificationNoSpecialism,
-            mandatoryQualificationValid,
-            mandatoryQualificationInactive
-        };
-
-        ApiFixture.DataverseAdapter
-             .Setup(mock => mock.GetQualificationsForTeacher(
-                 teacher.Id,
-                 It.IsAny<string[]>(),
-                 It.IsAny<string[]>(),
-                 It.IsAny<string[]>(),
-                 It.IsAny<string[]>()))
-             .ReturnsAsync(qualifications);
-
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{trn}");
 
-        // Act
-        var response = await HttpClientWithApiKey.SendAsync(request);
-
-        // Assert
-        await AssertEx.JsonResponseEquals(
-            response,
-            new
-            {
-                firstName = teacher.FirstName,
-                lastName = teacher.LastName,
-                middleName = teacher.MiddleName,
-                trn = trn,
-                dateOfBirth = teacher.BirthDate?.ToString("yyyy-MM-dd"),
-                nationalInsuranceNumber = teacher.dfeta_NINumber,
-                qts = new
-                {
-                    awarded = teacher.dfeta_QTSDate?.ToString("yyyy-MM-dd"),
-                    certificateUrl = "/v3/certificates/qts"
-                },
-                eyts = new
-                {
-                    awarded = teacher.dfeta_EYTSDate?.ToString("yyyy-MM-dd"),
-                    certificateUrl = "/v3/certificates/eyts"
-                },
-                induction = new
-                {
-                    startDate = induction.dfeta_StartDate?.ToString("yyyy-MM-dd"),
-                    endDate = induction.dfeta_CompletionDate?.ToString("yyyy-MM-dd"),
-                    status = induction.dfeta_InductionStatus.ToString(),
-                    certificateUrl = "/v3/certificates/induction",
-                    periods = new[]
-                    {
-                        new
-                        {
-                            startDate = inductionPeriods[0].dfeta_StartDate?.ToString("yyyy-MM-dd"),
-                            endDate = inductionPeriods[0].dfeta_EndDate?.ToString("yyyy-MM-dd"),
-                            terms = inductionPeriods[0].dfeta_Numberofterms,
-                            appropriateBody = new
-                            {
-                                name = inductionPeriods[0].GetAttributeValue<AliasedValue>($"appropriatebody.{Account.Fields.Name}").Value
-                            }
-                        }
-                    }
-                },
-                initialTeacherTraining = new[]
-                {
-                    new
-                    {
-                        qualification = new
-                        {
-                            name = itt.GetAttributeValue<AliasedValue>($"qualification.{dfeta_ittqualification.Fields.dfeta_name}").Value
-                        },
-                        programmeType = itt.dfeta_ProgrammeType.ToString(),
-                        startDate = itt.dfeta_ProgrammeStartDate?.ToString("yyyy-MM-dd"),
-                        endDate = itt.dfeta_ProgrammeEndDate?.ToString("yyyy-MM-dd"),
-                        result = itt.dfeta_Result?.ToString(),
-                        ageRange = new
-                        {
-                            description = "11 to 16 years"
-                        },
-                        provider = new
-                        {
-                            name = itt.GetAttributeValue<AliasedValue>($"establishment.{Account.Fields.Name}").Value,
-                            ukprn = itt.GetAttributeValue<AliasedValue>($"establishment.{Account.Fields.dfeta_UKPRN}").Value
-                        },
-                        subjects = new[]
-                        {
-                            new
-                            {
-                                code = itt.GetAttributeValue<AliasedValue>($"subject1.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
-                                name = itt.GetAttributeValue<AliasedValue>($"subject1.{dfeta_ittsubject.Fields.dfeta_name}").Value
-                            },
-                            new
-                            {
-                                code = itt.GetAttributeValue<AliasedValue>($"subject2.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
-                                name = itt.GetAttributeValue<AliasedValue>($"subject2.{dfeta_ittsubject.Fields.dfeta_name}").Value
-                            },
-                            new
-                            {
-                                code = itt.GetAttributeValue<AliasedValue>($"subject3.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
-                                name = itt.GetAttributeValue<AliasedValue>($"subject3.{dfeta_ittsubject.Fields.dfeta_name}").Value
-                            }
-                        }
-                    }
-                },
-                npqQualifications = new[]
-                {
-                    new
-                    {
-                        awarded = npqQualificationValid.dfeta_CompletionorAwardDate?.ToString("yyyy-MM-dd"),
-                        type = new
-                        {
-                            code = npqQualificationValid.dfeta_Type.ToString(),
-                            name = npqQualificationValid.dfeta_Type?.GetName()
-                        },
-                        certificateUrl = $"/v3/certificates/npq/{npqQualificationValid.Id}"
-                    }
-                },
-                mandatoryQualifications = new[]
-                {
-                    new
-                    {
-                        awarded = mandatoryQualificationValid.dfeta_MQ_Date?.ToString("yyyy-MM-dd"),
-                        specialism = mandatoryQualificationValid.GetAttributeValue<AliasedValue>($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.Fields.dfeta_name}").Value
-                    }
-                }
-            },
-            StatusCodes.Status200OK);
+        return ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, request, trn);
     }
 
-    private Contact GenerateTeacher(string trn)
+    [Fact]
+    public Task Get_ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue()
     {
-        var teacherId = Guid.NewGuid();
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-        var middleName = Faker.Name.Middle();
-        var dateOfBirth = Faker.Identification.DateOfBirth().ToDateOnly();
-        var nino = Faker.Identification.UkNationalInsuranceNumber();
+        var trn = "1234567";
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{trn}");
 
-        var qtsDate = new DateOnly(1997, 4, 23);
-        var eytsDate = new DateOnly(1995, 5, 14);
-
-        var teacher = new Contact()
-        {
-            Id = teacherId,
-            dfeta_TRN = trn,
-            FirstName = firstName,
-            MiddleName = middleName,
-            LastName = lastName,
-            BirthDate = dateOfBirth.ToDateTime(),
-            dfeta_NINumber = nino,
-            dfeta_QTSDate = qtsDate.ToDateTime(),
-            dfeta_EYTSDate = eytsDate.ToDateTime(),
-        };
-
-        ApiFixture.DataverseAdapter
-            .Setup(mock => mock.GetTeacherByTrn(trn, /* columnNames: */ It.IsAny<string[]>(), /* activeOnly: */ true))
-            .ReturnsAsync(teacher);
-
-        return teacher;
+        return ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(HttpClientWithApiKey, request, trn);
     }
 
-    private dfeta_initialteachertraining GenerateItt(Contact teacher)
+    [Fact]
+    public Task Get_ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue()
     {
-        var ittStartDate = new DateOnly(2021, 9, 7);
-        var ittEndDate = new DateOnly(2022, 7, 29);
-        var ittProgrammeType = IttProgrammeType.EYITTGraduateEntry;
-        var ittResult = IttOutcome.Pass;
-        var ittAgeRangeFrom = dfeta_AgeRange._11;
-        var ittAgeRangeTo = dfeta_AgeRange._16;
-        var ittProviderName = Faker.Company.Name();
-        var ittProviderUkprn = "12345";
-        var ittTraineeId = "54321";
-        var ittSubject1Value = "12345";
-        var ittSubject1Name = "Subject 1";
-        var ittSubject2Value = "23456";
-        var ittSubject2Name = "Subject 2";
-        var ittSubject3Value = "34567";
-        var ittSubject3Name = "Subject 3";
-        var ittQualificationName = "My test qualification 123";
+        var trn = "1234567";
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{trn}");
 
-        var itt = new dfeta_initialteachertraining()
-        {
-            dfeta_PersonId = new Microsoft.Xrm.Sdk.EntityReference(Contact.EntityLogicalName, teacher.Id),
-            dfeta_ProgrammeStartDate = ittStartDate.ToDateTime(),
-            dfeta_ProgrammeEndDate = ittEndDate.ToDateTime(),
-            dfeta_ProgrammeType = ittProgrammeType.ConvertToIttProgrammeType(),
-            dfeta_Result = ittResult.ConvertToITTResult(),
-            dfeta_AgeRangeFrom = ittAgeRangeFrom,
-            dfeta_AgeRangeTo = ittAgeRangeTo,
-            dfeta_TraineeID = ittTraineeId,
-            StateCode = dfeta_initialteachertrainingState.Active
-        };
-
-        itt.Attributes.Add($"qualification.{dfeta_ittqualification.PrimaryIdAttribute}", new AliasedValue(dfeta_ittqualification.EntityLogicalName, dfeta_ittqualification.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"qualification.{dfeta_ittqualification.Fields.dfeta_name}", new AliasedValue(dfeta_ittqualification.EntityLogicalName, dfeta_ittqualification.Fields.dfeta_name, ittQualificationName));
-        itt.Attributes.Add($"establishment.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"establishment.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, ittProviderName));
-        itt.Attributes.Add($"establishment.{Account.Fields.dfeta_UKPRN}", new AliasedValue(Account.EntityLogicalName, Account.Fields.dfeta_UKPRN, ittProviderUkprn));
-        itt.Attributes.Add($"subject1.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"subject1.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject1Value));
-        itt.Attributes.Add($"subject1.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject1Name));
-        itt.Attributes.Add($"subject2.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"subject2.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject2Value));
-        itt.Attributes.Add($"subject2.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject2Name));
-        itt.Attributes.Add($"subject3.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject3Value));
-        itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject3Name));
-
-        ApiFixture.DataverseAdapter
-            .Setup(mock => mock.GetInitialTeacherTrainingByTeacher(
-                teacher.Id,
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                false))
-            .ReturnsAsync(new[] { itt });
-
-        return itt;
-    }
-
-    private dfeta_induction GenerateInduction()
-    {
-        var inductionStartDate = new DateOnly(1996, 2, 3);
-        var inductionEndDate = new DateOnly(1996, 6, 7);
-        var inductionStatus = dfeta_InductionStatus.Pass;
-
-        return new dfeta_induction()
-        {
-            dfeta_StartDate = inductionStartDate.ToDateTime(),
-            dfeta_CompletionDate = inductionEndDate.ToDateTime(),
-            dfeta_InductionStatus = inductionStatus
-        };
-    }
-
-    private dfeta_inductionperiod[] GenerateInductionPeriods()
-    {
-        var inductionPeriodStartDate = new DateOnly(1996, 2, 3);
-        var inductionPeriodEndDate = new DateOnly(1996, 6, 7);
-        var inductionPeriodTerms = 3;
-        var inductionPeriodAppropriateBodyName = "My appropriate body";
-
-        var inductionPeriod = new dfeta_inductionperiod()
-        {
-            dfeta_StartDate = inductionPeriodStartDate.ToDateTime(),
-            dfeta_EndDate = inductionPeriodEndDate.ToDateTime(),
-            dfeta_Numberofterms = inductionPeriodTerms
-        };
-
-        inductionPeriod.Attributes.Add($"appropriatebody.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
-        inductionPeriod.Attributes.Add($"appropriatebody.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, inductionPeriodAppropriateBodyName));
-
-        return new[]
-        {
-            inductionPeriod
-        };
-    }
-
-    private dfeta_qualification GenerateQualification(
-        dfeta_qualification_dfeta_Type type,
-        DateTime? date,
-        dfeta_qualificationState state,
-        string specialismName)
-    {
-        var qualification = new dfeta_qualification
-        {
-            Id = Guid.NewGuid(),
-            dfeta_Type = type,
-            StateCode = state
-        };
-
-        if (type == dfeta_qualification_dfeta_Type.MandatoryQualification)
-        {
-            qualification.dfeta_MQ_Date = date;
-        }
-        else
-        {
-            qualification.dfeta_CompletionorAwardDate = date;
-        }
-
-        if (specialismName is not null)
-        {
-            qualification.Attributes.Add($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.PrimaryIdAttribute}", new AliasedValue(dfeta_specialism.EntityLogicalName, dfeta_specialism.PrimaryIdAttribute, Guid.NewGuid()));
-            qualification.Attributes.Add($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.Fields.dfeta_name}", new AliasedValue(dfeta_specialism.EntityLogicalName, dfeta_specialism.Fields.dfeta_name, specialismName));
-        }
-
-        return qualification;
+        return ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(HttpClientWithApiKey, request, trn);
     }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTestBase.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTestBase.cs
@@ -1,0 +1,447 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Xrm.Sdk;
+using Moq;
+using Newtonsoft.Json.Linq;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using QualifiedTeachersApi.TestCommon;
+using QualifiedTeachersApi.V3.ApiModels;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.V3;
+
+public abstract class GetTeacherTestBase : ApiTestBase
+{
+    private readonly Guid _changeOfNameSubjectId = Guid.NewGuid();
+    private readonly Guid _changeOfDateOfBirthSubjectId = Guid.NewGuid();
+
+    protected GetTeacherTestBase(ApiFixture apiFixture) : base(apiFixture)
+    {
+    }
+
+    protected async Task ValidRequestForTeacher_ReturnsExpectedContent(
+        HttpClient httpClient,
+        HttpRequestMessage request,
+        string trn)
+    {
+        // Arrange
+        var contact = CreateContact(trn);
+        var itt = CreateItt(contact);
+        var induction = CreateInduction();
+        var inductionPeriods = CreateInductionPeriods();
+
+        var npqQualificationNoAwardDate = CreateQualification(dfeta_qualification_dfeta_Type.NPQLL, null, dfeta_qualificationState.Active, null);
+        var npqQualificationInactive = CreateQualification(dfeta_qualification_dfeta_Type.NPQSL, new DateTime(2022, 5, 6), dfeta_qualificationState.Inactive, null);
+        var npqQualificationValid = CreateQualification(dfeta_qualification_dfeta_Type.NPQEYL, new DateTime(2022, 3, 4), dfeta_qualificationState.Active, null);
+        var mandatoryQualificationNoAwardDate = CreateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, null, dfeta_qualificationState.Active, "Visual Impairment");
+        var mandatoryQualificationNoSpecialism = CreateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 2, 3), dfeta_qualificationState.Active, null);
+        var mandatoryQualificationValid = CreateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 4, 6), dfeta_qualificationState.Active, "Hearing");
+        var mandatoryQualificationInactive = CreateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 4, 8), dfeta_qualificationState.Inactive, "Mutli Sensory Impairment");
+
+        var qualifications = new dfeta_qualification[]
+        {
+            npqQualificationNoAwardDate,
+            npqQualificationInactive,
+            npqQualificationValid,
+            mandatoryQualificationNoAwardDate,
+            mandatoryQualificationNoSpecialism,
+            mandatoryQualificationValid,
+            mandatoryQualificationInactive
+        };
+
+        var incidents = Array.Empty<Incident>();
+
+        ConfigureDataverseApiMock(trn, contact, itt, induction, inductionPeriods, qualifications, incidents);
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseEquals(
+            response,
+            new
+            {
+                firstName = contact.FirstName,
+                lastName = contact.LastName,
+                middleName = contact.MiddleName,
+                trn = trn,
+                pendingNameChange = false,
+                pendingDateOfBirthChange = false,
+                dateOfBirth = contact.BirthDate?.ToString("yyyy-MM-dd"),
+                nationalInsuranceNumber = contact.dfeta_NINumber,
+                qts = new
+                {
+                    awarded = contact.dfeta_QTSDate?.ToString("yyyy-MM-dd"),
+                    certificateUrl = "/v3/certificates/qts"
+                },
+                eyts = new
+                {
+                    awarded = contact.dfeta_EYTSDate?.ToString("yyyy-MM-dd"),
+                    certificateUrl = "/v3/certificates/eyts"
+                },
+                induction = new
+                {
+                    startDate = induction.dfeta_StartDate?.ToString("yyyy-MM-dd"),
+                    endDate = induction.dfeta_CompletionDate?.ToString("yyyy-MM-dd"),
+                    status = induction.dfeta_InductionStatus.ToString(),
+                    certificateUrl = "/v3/certificates/induction",
+                    periods = new[]
+                    {
+                        new
+                        {
+                            startDate = inductionPeriods[0].dfeta_StartDate?.ToString("yyyy-MM-dd"),
+                            endDate = inductionPeriods[0].dfeta_EndDate?.ToString("yyyy-MM-dd"),
+                            terms = inductionPeriods[0].dfeta_Numberofterms,
+                            appropriateBody = new
+                            {
+                                name = inductionPeriods[0].GetAttributeValue<AliasedValue>($"appropriatebody.{Account.Fields.Name}").Value
+                            }
+                        }
+                    }
+                },
+                initialTeacherTraining = new[]
+                {
+                    new
+                    {
+                        qualification = new
+                        {
+                            name = itt.GetAttributeValue<AliasedValue>($"qualification.{dfeta_ittqualification.Fields.dfeta_name}").Value
+                        },
+                        programmeType = itt.dfeta_ProgrammeType.ToString(),
+                        startDate = itt.dfeta_ProgrammeStartDate?.ToString("yyyy-MM-dd"),
+                        endDate = itt.dfeta_ProgrammeEndDate?.ToString("yyyy-MM-dd"),
+                        result = itt.dfeta_Result?.ToString(),
+                        ageRange = new
+                        {
+                            description = "11 to 16 years"
+                        },
+                        provider = new
+                        {
+                            name = itt.GetAttributeValue<AliasedValue>($"establishment.{Account.Fields.Name}").Value,
+                            ukprn = itt.GetAttributeValue<AliasedValue>($"establishment.{Account.Fields.dfeta_UKPRN}").Value
+                        },
+                        subjects = new[]
+                        {
+                            new
+                            {
+                                code = itt.GetAttributeValue<AliasedValue>($"subject1.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
+                                name = itt.GetAttributeValue<AliasedValue>($"subject1.{dfeta_ittsubject.Fields.dfeta_name}").Value
+                            },
+                            new
+                            {
+                                code = itt.GetAttributeValue<AliasedValue>($"subject2.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
+                                name = itt.GetAttributeValue<AliasedValue>($"subject2.{dfeta_ittsubject.Fields.dfeta_name}").Value
+                            },
+                            new
+                            {
+                                code = itt.GetAttributeValue<AliasedValue>($"subject3.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
+                                name = itt.GetAttributeValue<AliasedValue>($"subject3.{dfeta_ittsubject.Fields.dfeta_name}").Value
+                            }
+                        }
+                    }
+                },
+                npqQualifications = new[]
+                {
+                    new
+                    {
+                        awarded = npqQualificationValid.dfeta_CompletionorAwardDate?.ToString("yyyy-MM-dd"),
+                        type = new
+                        {
+                            code = npqQualificationValid.dfeta_Type.ToString(),
+                            name = npqQualificationValid.dfeta_Type?.GetName()
+                        },
+                        certificateUrl = $"/v3/certificates/npq/{npqQualificationValid.Id}"
+                    }
+                },
+                mandatoryQualifications = new[]
+                {
+                    new
+                    {
+                        awarded = mandatoryQualificationValid.dfeta_MQ_Date?.ToString("yyyy-MM-dd"),
+                        specialism = mandatoryQualificationValid.GetAttributeValue<AliasedValue>($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.Fields.dfeta_name}").Value
+                    }
+                }
+            },
+            StatusCodes.Status200OK);
+    }
+
+    protected async Task ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(
+        HttpClient httpClient,
+        HttpRequestMessage request,
+        string trn)
+    {
+        // Arrange
+        var contact = CreateContact(trn);
+
+        var incidents = new[]
+        {
+            new Incident()
+            {
+                CustomerId = contact.Id.ToEntityReference(Contact.EntityLogicalName),
+                Title = "Name change request",
+                SubjectId = _changeOfNameSubjectId.ToEntityReference(DataStore.Crm.Models.Subject.EntityLogicalName)
+            }
+        };
+
+        ConfigureDataverseApiMock(
+            trn,
+            contact,
+            itt: null,
+            induction: null,
+            inductionPeriods: null,
+            qualifications: Array.Empty<dfeta_qualification>(),
+            incidents);
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse<JObject>(response);
+        Assert.True(jsonResponse["pendingNameChange"].ToObject<bool>());
+    }
+
+    protected async Task ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(
+        HttpClient httpClient,
+        HttpRequestMessage request,
+        string trn)
+    {
+        // Arrange
+        var contact = CreateContact(trn);
+
+        var incidents = new[]
+        {
+            new Incident()
+            {
+                CustomerId = contact.Id.ToEntityReference(Contact.EntityLogicalName),
+                Title = "DOB change request",
+                SubjectId = _changeOfDateOfBirthSubjectId.ToEntityReference(DataStore.Crm.Models.Subject.EntityLogicalName)
+            }
+        };
+
+        ConfigureDataverseApiMock(
+            trn,
+            contact,
+            itt: null,
+            induction: null,
+            inductionPeriods: null,
+            qualifications: Array.Empty<dfeta_qualification>(),
+            incidents);
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse<JObject>(response);
+        Assert.True(jsonResponse["pendingDateOfBirthChange"].ToObject<bool>());
+    }
+
+    private void ConfigureDataverseApiMock(
+        string trn,
+        Contact contact,
+        dfeta_initialteachertraining itt,
+        dfeta_induction induction,
+        dfeta_inductionperiod[] inductionPeriods,
+        dfeta_qualification[] qualifications,
+        Incident[] incidents)
+    {
+        ApiFixture.DataverseAdapter
+            .Setup(mock => mock.GetSubjectByTitle("Change of Name", It.IsAny<string[]>()))
+            .ReturnsAsync(new DataStore.Crm.Models.Subject()
+            {
+                Id = _changeOfNameSubjectId,
+                Title = "Change of Name"
+            });
+
+        ApiFixture.DataverseAdapter
+            .Setup(mock => mock.GetSubjectByTitle("Change of Date of Birth", It.IsAny<string[]>()))
+            .ReturnsAsync(new DataStore.Crm.Models.Subject()
+            {
+                Id = _changeOfDateOfBirthSubjectId,
+                Title = "Change of Date of Birth"
+            });
+
+        ApiFixture.DataverseAdapter
+            .Setup(mock => mock.GetTeacherByTrn(trn, /* columnNames: */ It.IsAny<string[]>(), /* activeOnly: */ true))
+            .ReturnsAsync(contact);
+
+        ApiFixture.DataverseAdapter
+            .Setup(mock => mock.GetInitialTeacherTrainingByTeacher(
+                contact.Id,
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                false))
+            .ReturnsAsync(itt != null ? new[] { itt } : Array.Empty<dfeta_initialteachertraining>());
+
+        ApiFixture.DataverseAdapter
+            .Setup(mock => mock.GetInductionByTeacher(
+                contact.Id,
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>()))
+            .ReturnsAsync((induction, inductionPeriods));
+
+        ApiFixture.DataverseAdapter
+             .Setup(mock => mock.GetQualificationsForTeacher(
+                 contact.Id,
+                 It.IsAny<string[]>(),
+                 It.IsAny<string[]>(),
+                 It.IsAny<string[]>(),
+                 It.IsAny<string[]>()))
+             .ReturnsAsync(qualifications);
+
+        ApiFixture.DataverseAdapter
+            .Setup(mock => mock.GetIncidentsByContactId(contact.Id, IncidentState.Active, It.IsAny<string[]>()))
+            .ReturnsAsync(incidents);
+    }
+
+    private static Contact CreateContact(string trn)
+    {
+        var contactId = Guid.NewGuid();
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+        var middleName = Faker.Name.Middle();
+        var dateOfBirth = Faker.Identification.DateOfBirth().ToDateOnly();
+        var nino = Faker.Identification.UkNationalInsuranceNumber();
+
+        var qtsDate = new DateOnly(1997, 4, 23);
+        var eytsDate = new DateOnly(1995, 5, 14);
+
+        var teacher = new Contact()
+        {
+            Id = contactId,
+            dfeta_TRN = trn,
+            FirstName = firstName,
+            MiddleName = middleName,
+            LastName = lastName,
+            BirthDate = dateOfBirth.ToDateTime(),
+            dfeta_NINumber = nino,
+            dfeta_QTSDate = qtsDate.ToDateTime(),
+            dfeta_EYTSDate = eytsDate.ToDateTime(),
+        };
+
+        return teacher;
+    }
+
+    private static dfeta_initialteachertraining CreateItt(Contact teacher)
+    {
+        var ittStartDate = new DateOnly(2021, 9, 7);
+        var ittEndDate = new DateOnly(2022, 7, 29);
+        var ittProgrammeType = IttProgrammeType.EYITTGraduateEntry;
+        var ittResult = IttOutcome.Pass;
+        var ittAgeRangeFrom = dfeta_AgeRange._11;
+        var ittAgeRangeTo = dfeta_AgeRange._16;
+        var ittProviderName = Faker.Company.Name();
+        var ittProviderUkprn = "12345";
+        var ittTraineeId = "54321";
+        var ittSubject1Value = "12345";
+        var ittSubject1Name = "Subject 1";
+        var ittSubject2Value = "23456";
+        var ittSubject2Name = "Subject 2";
+        var ittSubject3Value = "34567";
+        var ittSubject3Name = "Subject 3";
+        var ittQualificationName = "My test qualification 123";
+
+        var itt = new dfeta_initialteachertraining()
+        {
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacher.Id),
+            dfeta_ProgrammeStartDate = ittStartDate.ToDateTime(),
+            dfeta_ProgrammeEndDate = ittEndDate.ToDateTime(),
+            dfeta_ProgrammeType = ittProgrammeType.ConvertToIttProgrammeType(),
+            dfeta_Result = ittResult.ConvertToITTResult(),
+            dfeta_AgeRangeFrom = ittAgeRangeFrom,
+            dfeta_AgeRangeTo = ittAgeRangeTo,
+            dfeta_TraineeID = ittTraineeId,
+            StateCode = dfeta_initialteachertrainingState.Active
+        };
+
+        itt.Attributes.Add($"qualification.{dfeta_ittqualification.PrimaryIdAttribute}", new AliasedValue(dfeta_ittqualification.EntityLogicalName, dfeta_ittqualification.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"qualification.{dfeta_ittqualification.Fields.dfeta_name}", new AliasedValue(dfeta_ittqualification.EntityLogicalName, dfeta_ittqualification.Fields.dfeta_name, ittQualificationName));
+        itt.Attributes.Add($"establishment.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"establishment.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, ittProviderName));
+        itt.Attributes.Add($"establishment.{Account.Fields.dfeta_UKPRN}", new AliasedValue(Account.EntityLogicalName, Account.Fields.dfeta_UKPRN, ittProviderUkprn));
+        itt.Attributes.Add($"subject1.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"subject1.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject1Value));
+        itt.Attributes.Add($"subject1.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject1Name));
+        itt.Attributes.Add($"subject2.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"subject2.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject2Value));
+        itt.Attributes.Add($"subject2.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject2Name));
+        itt.Attributes.Add($"subject3.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject3Value));
+        itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject3Name));
+
+        return itt;
+    }
+
+    private static dfeta_induction CreateInduction()
+    {
+        var inductionStartDate = new DateOnly(1996, 2, 3);
+        var inductionEndDate = new DateOnly(1996, 6, 7);
+        var inductionStatus = dfeta_InductionStatus.Pass;
+
+        return new dfeta_induction()
+        {
+            dfeta_StartDate = inductionStartDate.ToDateTime(),
+            dfeta_CompletionDate = inductionEndDate.ToDateTime(),
+            dfeta_InductionStatus = inductionStatus
+        };
+    }
+
+    private static dfeta_inductionperiod[] CreateInductionPeriods()
+    {
+        var inductionPeriodStartDate = new DateOnly(1996, 2, 3);
+        var inductionPeriodEndDate = new DateOnly(1996, 6, 7);
+        var inductionPeriodTerms = 3;
+        var inductionPeriodAppropriateBodyName = "My appropriate body";
+
+        var inductionPeriod = new dfeta_inductionperiod()
+        {
+            dfeta_StartDate = inductionPeriodStartDate.ToDateTime(),
+            dfeta_EndDate = inductionPeriodEndDate.ToDateTime(),
+            dfeta_Numberofterms = inductionPeriodTerms
+        };
+
+        inductionPeriod.Attributes.Add($"appropriatebody.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
+        inductionPeriod.Attributes.Add($"appropriatebody.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, inductionPeriodAppropriateBodyName));
+
+        return new[]
+        {
+            inductionPeriod
+        };
+    }
+
+    private static dfeta_qualification CreateQualification(
+        dfeta_qualification_dfeta_Type type,
+        DateTime? date,
+        dfeta_qualificationState state,
+        string specialismName)
+    {
+        var qualification = new dfeta_qualification
+        {
+            Id = Guid.NewGuid(),
+            dfeta_Type = type,
+            StateCode = state
+        };
+
+        if (type == dfeta_qualification_dfeta_Type.MandatoryQualification)
+        {
+            qualification.dfeta_MQ_Date = date;
+        }
+        else
+        {
+            qualification.dfeta_CompletionorAwardDate = date;
+        }
+
+        if (specialismName is not null)
+        {
+            qualification.Attributes.Add($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.PrimaryIdAttribute}", new AliasedValue(dfeta_specialism.EntityLogicalName, dfeta_specialism.PrimaryIdAttribute, Guid.NewGuid()));
+            qualification.Attributes.Add($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.Fields.dfeta_name}", new AliasedValue(dfeta_specialism.EntityLogicalName, dfeta_specialism.Fields.dfeta_name, specialismName));
+        }
+
+        return qualification;
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
@@ -1,16 +1,10 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Xrm.Sdk;
-using Moq;
-using QualifiedTeachersApi.DataStore.Crm.Models;
-using QualifiedTeachersApi.TestCommon;
-using QualifiedTeachersApi.V3.ApiModels;
 using Xunit;
 
 namespace QualifiedTeachersApi.Tests.V3;
 
-public class GetTeacherTests : ApiTestBase
+public class GetTeacherTests : GetTeacherTestBase
 {
     public GetTeacherTests(ApiFixture apiFixture)
         : base(apiFixture)
@@ -34,324 +28,32 @@ public class GetTeacherTests : ApiTestBase
     }
 
     [Fact]
-    public async Task Get_ValidRequest_ReturnsExpectedResponse()
+    public Task Get_ValidRequest_ReturnsExpectedResponse()
     {
-        // Arrange
         var trn = "1234567";
         var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var request = new HttpRequestMessage(HttpMethod.Get, "v3/teacher");
 
-        var teacher = GenerateTeacher(trn);
-        var itt = GenerateItt(teacher);
-
-        var induction = GenerateInduction();
-        var inductionPeriods = GenerateInductionPeriods();
-
-        ApiFixture.DataverseAdapter
-            .Setup(mock => mock.GetInductionByTeacher(
-                teacher.Id,
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>()))
-            .ReturnsAsync((induction, inductionPeriods));
-
-        var npqQualificationNoAwardDate = GenerateQualification(dfeta_qualification_dfeta_Type.NPQLL, null, dfeta_qualificationState.Active, null);
-        var npqQualificationInactive = GenerateQualification(dfeta_qualification_dfeta_Type.NPQSL, new DateTime(2022, 5, 6), dfeta_qualificationState.Inactive, null);
-        var npqQualificationValid = GenerateQualification(dfeta_qualification_dfeta_Type.NPQEYL, new DateTime(2022, 3, 4), dfeta_qualificationState.Active, null);
-        var mandatoryQualificationNoAwardDate = GenerateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, null, dfeta_qualificationState.Active, "Visual Impairment");
-        var mandatoryQualificationNoSpecialism = GenerateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 2, 3), dfeta_qualificationState.Active, null);
-        var mandatoryQualificationValid = GenerateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 4, 6), dfeta_qualificationState.Active, "Hearing");
-        var mandatoryQualificationInactive = GenerateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 4, 8), dfeta_qualificationState.Inactive, "Mutli Sensory Impairment");
-
-        var qualifications = new dfeta_qualification[]
-        {
-            npqQualificationNoAwardDate,
-            npqQualificationInactive,
-            npqQualificationValid,
-            mandatoryQualificationNoAwardDate,
-            mandatoryQualificationNoSpecialism,
-            mandatoryQualificationValid,
-            mandatoryQualificationInactive
-        };
-
-        ApiFixture.DataverseAdapter
-             .Setup(mock => mock.GetQualificationsForTeacher(
-                 teacher.Id,
-                 It.IsAny<string[]>(),
-                 It.IsAny<string[]>(),
-                 It.IsAny<string[]>(),
-                 It.IsAny<string[]>()))
-             .ReturnsAsync(qualifications);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teacher");
-
-        // Act
-        var response = await httpClient.SendAsync(request);
-
-        // Assert
-        await AssertEx.JsonResponseEquals(
-            response,
-            new
-            {
-                firstName = teacher.FirstName,
-                lastName = teacher.LastName,
-                middleName = teacher.MiddleName,
-                trn = trn,
-                dateOfBirth = teacher.BirthDate?.ToString("yyyy-MM-dd"),
-                nationalInsuranceNumber = teacher.dfeta_NINumber,
-                qts = new
-                {
-                    awarded = teacher.dfeta_QTSDate?.ToString("yyyy-MM-dd"),
-                    certificateUrl = "/v3/certificates/qts"
-                },
-                eyts = new
-                {
-                    awarded = teacher.dfeta_EYTSDate?.ToString("yyyy-MM-dd"),
-                    certificateUrl = "/v3/certificates/eyts"
-                },
-                induction = new
-                {
-                    startDate = induction.dfeta_StartDate?.ToString("yyyy-MM-dd"),
-                    endDate = induction.dfeta_CompletionDate?.ToString("yyyy-MM-dd"),
-                    status = induction.dfeta_InductionStatus.ToString(),
-                    certificateUrl = "/v3/certificates/induction",
-                    periods = new[]
-                    {
-                        new
-                        {
-                            startDate = inductionPeriods[0].dfeta_StartDate?.ToString("yyyy-MM-dd"),
-                            endDate = inductionPeriods[0].dfeta_EndDate?.ToString("yyyy-MM-dd"),
-                            terms = inductionPeriods[0].dfeta_Numberofterms,
-                            appropriateBody = new
-                            {
-                                name = inductionPeriods[0].GetAttributeValue<AliasedValue>($"appropriatebody.{Account.Fields.Name}").Value
-                            }
-                        }
-                    }
-                },
-                initialTeacherTraining = new[]
-                {
-                    new
-                    {
-                        qualification = new
-                        {
-                            name = itt.GetAttributeValue<AliasedValue>($"qualification.{dfeta_ittqualification.Fields.dfeta_name}").Value
-                        },
-                        programmeType = itt.dfeta_ProgrammeType.ToString(),
-                        startDate = itt.dfeta_ProgrammeStartDate?.ToString("yyyy-MM-dd"),
-                        endDate = itt.dfeta_ProgrammeEndDate?.ToString("yyyy-MM-dd"),
-                        result = itt.dfeta_Result?.ToString(),
-                        ageRange = new
-                        {
-                            description = "11 to 16 years"
-                        },
-                        provider = new
-                        {
-                            name = itt.GetAttributeValue<AliasedValue>($"establishment.{Account.Fields.Name}").Value,
-                            ukprn = itt.GetAttributeValue<AliasedValue>($"establishment.{Account.Fields.dfeta_UKPRN}").Value
-                        },
-                        subjects = new[]
-                        {
-                            new
-                            {
-                                code = itt.GetAttributeValue<AliasedValue>($"subject1.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
-                                name = itt.GetAttributeValue<AliasedValue>($"subject1.{dfeta_ittsubject.Fields.dfeta_name}").Value
-                            },
-                            new
-                            {
-                                code = itt.GetAttributeValue<AliasedValue>($"subject2.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
-                                name = itt.GetAttributeValue<AliasedValue>($"subject2.{dfeta_ittsubject.Fields.dfeta_name}").Value
-                            },
-                            new
-                            {
-                                code = itt.GetAttributeValue<AliasedValue>($"subject3.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
-                                name = itt.GetAttributeValue<AliasedValue>($"subject3.{dfeta_ittsubject.Fields.dfeta_name}").Value
-                            }
-                        }
-                    }
-                },
-                npqQualifications = new[]
-                {
-                    new
-                    {
-                        awarded = npqQualificationValid.dfeta_CompletionorAwardDate?.ToString("yyyy-MM-dd"),
-                        type = new
-                        {
-                            code = npqQualificationValid.dfeta_Type.ToString(),
-                            name = npqQualificationValid.dfeta_Type?.GetName()
-                        },
-                        certificateUrl = $"/v3/certificates/npq/{npqQualificationValid.Id}"
-                    }
-                },
-                mandatoryQualifications = new[]
-                {
-                    new
-                    {
-                        awarded = mandatoryQualificationValid.dfeta_MQ_Date?.ToString("yyyy-MM-dd"),
-                        specialism = mandatoryQualificationValid.GetAttributeValue<AliasedValue>($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.Fields.dfeta_name}").Value
-                    }
-                }
-            },
-            StatusCodes.Status200OK);
+        return ValidRequestForTeacher_ReturnsExpectedContent(httpClient, request, trn);
     }
 
-    private Contact GenerateTeacher(string trn)
+    [Fact]
+    public Task Get_ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue()
     {
-        var teacherId = Guid.NewGuid();
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-        var middleName = Faker.Name.Middle();
-        var dateOfBirth = Faker.Identification.DateOfBirth().ToDateOnly();
-        var nino = Faker.Identification.UkNationalInsuranceNumber();
+        var trn = "1234567";
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var request = new HttpRequestMessage(HttpMethod.Get, "v3/teacher");
 
-        var qtsDate = new DateOnly(1997, 4, 23);
-        var eytsDate = new DateOnly(1995, 5, 14);
-
-        var teacher = new Contact()
-        {
-            Id = teacherId,
-            dfeta_TRN = trn,
-            FirstName = firstName,
-            MiddleName = middleName,
-            LastName = lastName,
-            BirthDate = dateOfBirth.ToDateTime(),
-            dfeta_NINumber = nino,
-            dfeta_QTSDate = qtsDate.ToDateTime(),
-            dfeta_EYTSDate = eytsDate.ToDateTime(),
-        };
-
-        ApiFixture.DataverseAdapter
-            .Setup(mock => mock.GetTeacherByTrn(trn, /* columnNames: */ It.IsAny<string[]>(), /* activeOnly: */ true))
-            .ReturnsAsync(teacher);
-
-        return teacher;
+        return ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(httpClient, request, trn);
     }
 
-    private dfeta_initialteachertraining GenerateItt(Contact teacher)
+    [Fact]
+    public Task Get_ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue()
     {
-        var ittStartDate = new DateOnly(2021, 9, 7);
-        var ittEndDate = new DateOnly(2022, 7, 29);
-        var ittProgrammeType = IttProgrammeType.EYITTGraduateEntry;
-        var ittResult = IttOutcome.Pass;
-        var ittAgeRangeFrom = dfeta_AgeRange._11;
-        var ittAgeRangeTo = dfeta_AgeRange._16;
-        var ittProviderName = Faker.Company.Name();
-        var ittProviderUkprn = "12345";
-        var ittTraineeId = "54321";
-        var ittSubject1Value = "12345";
-        var ittSubject1Name = "Subject 1";
-        var ittSubject2Value = "23456";
-        var ittSubject2Name = "Subject 2";
-        var ittSubject3Value = "34567";
-        var ittSubject3Name = "Subject 3";
-        var ittQualificationName = "My test qualification 123";
+        var trn = "1234567";
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var request = new HttpRequestMessage(HttpMethod.Get, "v3/teacher");
 
-        var itt = new dfeta_initialteachertraining()
-        {
-            dfeta_PersonId = new Microsoft.Xrm.Sdk.EntityReference(Contact.EntityLogicalName, teacher.Id),
-            dfeta_ProgrammeStartDate = ittStartDate.ToDateTime(),
-            dfeta_ProgrammeEndDate = ittEndDate.ToDateTime(),
-            dfeta_ProgrammeType = ittProgrammeType.ConvertToIttProgrammeType(),
-            dfeta_Result = ittResult.ConvertToITTResult(),
-            dfeta_AgeRangeFrom = ittAgeRangeFrom,
-            dfeta_AgeRangeTo = ittAgeRangeTo,
-            dfeta_TraineeID = ittTraineeId,
-            StateCode = dfeta_initialteachertrainingState.Active
-        };
-
-        itt.Attributes.Add($"qualification.{dfeta_ittqualification.PrimaryIdAttribute}", new AliasedValue(dfeta_ittqualification.EntityLogicalName, dfeta_ittqualification.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"qualification.{dfeta_ittqualification.Fields.dfeta_name}", new AliasedValue(dfeta_ittqualification.EntityLogicalName, dfeta_ittqualification.Fields.dfeta_name, ittQualificationName));
-        itt.Attributes.Add($"establishment.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"establishment.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, ittProviderName));
-        itt.Attributes.Add($"establishment.{Account.Fields.dfeta_UKPRN}", new AliasedValue(Account.EntityLogicalName, Account.Fields.dfeta_UKPRN, ittProviderUkprn));
-        itt.Attributes.Add($"subject1.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"subject1.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject1Value));
-        itt.Attributes.Add($"subject1.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject1Name));
-        itt.Attributes.Add($"subject2.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"subject2.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject2Value));
-        itt.Attributes.Add($"subject2.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject2Name));
-        itt.Attributes.Add($"subject3.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
-        itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject3Value));
-        itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject3Name));
-
-        ApiFixture.DataverseAdapter
-            .Setup(mock => mock.GetInitialTeacherTrainingByTeacher(
-                teacher.Id,
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                It.IsAny<string[]>(),
-                false))
-            .ReturnsAsync(new[] { itt });
-
-        return itt;
-    }
-
-    private dfeta_induction GenerateInduction()
-    {
-        var inductionStartDate = new DateOnly(1996, 2, 3);
-        var inductionEndDate = new DateOnly(1996, 6, 7);
-        var inductionStatus = dfeta_InductionStatus.Pass;
-
-        return new dfeta_induction()
-        {
-            dfeta_StartDate = inductionStartDate.ToDateTime(),
-            dfeta_CompletionDate = inductionEndDate.ToDateTime(),
-            dfeta_InductionStatus = inductionStatus
-        };
-    }
-
-    private dfeta_inductionperiod[] GenerateInductionPeriods()
-    {
-        var inductionPeriodStartDate = new DateOnly(1996, 2, 3);
-        var inductionPeriodEndDate = new DateOnly(1996, 6, 7);
-        var inductionPeriodTerms = 3;
-        var inductionPeriodAppropriateBodyName = "My appropriate body";
-
-        var inductionPeriod = new dfeta_inductionperiod()
-        {
-            dfeta_StartDate = inductionPeriodStartDate.ToDateTime(),
-            dfeta_EndDate = inductionPeriodEndDate.ToDateTime(),
-            dfeta_Numberofterms = inductionPeriodTerms
-        };
-
-        inductionPeriod.Attributes.Add($"appropriatebody.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
-        inductionPeriod.Attributes.Add($"appropriatebody.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, inductionPeriodAppropriateBodyName));
-
-        return new[]
-        {
-            inductionPeriod
-        };
-    }
-
-    private dfeta_qualification GenerateQualification(
-        dfeta_qualification_dfeta_Type type,
-        DateTime? date,
-        dfeta_qualificationState state,
-        string specialismName)
-    {
-        var qualification = new dfeta_qualification
-        {
-            Id = Guid.NewGuid(),
-            dfeta_Type = type,
-            StateCode = state
-        };
-
-        if (type == dfeta_qualification_dfeta_Type.MandatoryQualification)
-        {
-            qualification.dfeta_MQ_Date = date;
-        }
-        else
-        {
-            qualification.dfeta_CompletionorAwardDate = date;
-        }
-
-        if (specialismName is not null)
-        {
-            qualification.Attributes.Add($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.PrimaryIdAttribute}", new AliasedValue(dfeta_specialism.EntityLogicalName, dfeta_specialism.PrimaryIdAttribute, Guid.NewGuid()));
-            qualification.Attributes.Add($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.Fields.dfeta_name}", new AliasedValue(dfeta_specialism.EntityLogicalName, dfeta_specialism.Fields.dfeta_name, specialismName));
-        }
-
-        return qualification;
+        return ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(httpClient, request, trn);
     }
 }

--- a/docs/api-specs/v3.json
+++ b/docs/api-specs/v3.json
@@ -424,10 +424,10 @@
           "firstName": {
             "type": "string"
           },
-          "lastName": {
+          "middleName": {
             "type": "string"
           },
-          "middleName": {
+          "lastName": {
             "type": "string",
             "nullable": true
           },
@@ -438,6 +438,12 @@
           "nationalInsuranceNumber": {
             "type": "string",
             "nullable": true
+          },
+          "pendingNameChange": {
+            "type": "boolean"
+          },
+          "pendingDateOfBirthChange": {
+            "type": "boolean"
           },
           "qts": {
             "$ref": "#/components/schemas/GetTeacherResponseQts"


### PR DESCRIPTION
Properties are computed by looking for active `incident`s for the `contact`. I've had to omit tests for `GetIncidentsByContactId` since the `build` environment seems to be broken when transitioning incidents to completed.

This also moves some common test logic for the v3 teacher response into a base class.