### PR TITLE
Remove husid duplicate check on create endpoint

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -234,11 +234,6 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
             ErrorRegistry.OrganisationNotFound().Title);
 
         ConsumeReason(
-            CreateTeacherFailedReasons.DuplicateHusId,
-            $"{nameof(GetOrCreateTrnRequest.HusId)}",
-            ErrorRegistry.ExistingTeacherAlreadyHasHusId().Title);
-
-        ConsumeReason(
             CreateTeacherFailedReasons.TrainingCountryNotFound,
             $"{nameof(GetOrCreateTrnRequest.InitialTeacherTraining)}.{nameof(GetOrCreateTrnRequest.InitialTeacherTraining.TrainingCountryCode)}",
             ErrorRegistry.CountryNotFound().Title);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -109,6 +109,67 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
     }
 
     [Fact]
+    public async Task Given_husid_does_not_exist_request_succeeds_and_does_not_creates_review_task()
+    {
+        // Arrange
+        var husid = "87654321";
+        var command = new CreateTeacherCommand()
+        {
+            FirstName = "Minsnie",
+            LastName = "Rydser",
+            BirthDate = new(1990, 5, 23),
+            GenderCode = Contact_GenderCode.Female,
+            InitialTeacherTraining = new()
+            {
+                ProviderUkprn = "10044534",  // ARK Teacher Training
+                ProgrammeStartDate = new(2020, 4, 1),
+                ProgrammeEndDate = new(2020, 10, 10),
+                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
+                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
+            },
+            HusId = husid
+        };
+
+        // Act
+        var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        transactionRequest.AssertDoesNotContainCreateRequest<CrmTask>();
+    }
+
+    [Fact]
+    public async Task Given_husid_exists_request_succeeds_and_creates_review_task()
+    {
+        // Arrange
+        var husid = "123456";  //teacher with husid already exists because of CreateTeacherFixture initialize
+        var command = new CreateTeacherCommand()
+        {
+            FirstName = "Minnie",
+            LastName = "Ryder",
+            BirthDate = new(1990, 5, 23),
+            GenderCode = Contact_GenderCode.Female,
+            InitialTeacherTraining = new()
+            {
+                ProviderUkprn = "10044534",  // ARK Teacher Training
+                ProgrammeStartDate = new(2020, 4, 1),
+                ProgrammeEndDate = new(2020, 10, 10),
+                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
+                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
+            },
+            HusId = husid
+        };
+
+        // Act
+        var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        transactionRequest.AssertContainsCreateRequest<CrmTask>(x => x.Description.Contains($"HusId - {husid}"));
+    }
+
+
+    [Fact]
     public async Task Given_specified_qualification_type_creates_qualification_with_type()
     {
         // Arrange
@@ -764,6 +825,7 @@ public class CreateTeacherFixture : IAsyncLifetime
     public string ExistingTeacherFirstName => "Joe";
     public string ExistingTeacherFirstNameMiddleName => "X";
     public string ExistingTeacherFirstNameLastName => "Bloggs";
+    public string ExistingTeacherHusId => "123456";
     public DateTime ExistingTeacherFirstNameBirthDate => new DateTime(1990, 5, 23);
 
     public async Task DisposeAsync() => await _dataScope.DisposeAsync();
@@ -775,7 +837,8 @@ public class CreateTeacherFixture : IAsyncLifetime
             FirstName = ExistingTeacherFirstName,
             MiddleName = ExistingTeacherFirstNameMiddleName,
             LastName = ExistingTeacherFirstNameLastName,
-            BirthDate = ExistingTeacherFirstNameBirthDate
+            BirthDate = ExistingTeacherFirstNameBirthDate,
+            dfeta_HUSID = ExistingTeacherHusId
         });
     }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -632,26 +632,6 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
     }
 
     [Fact]
-    public async Task Given_request_with_existing_husid_returns_error()
-    {
-        // Arrange
-        var requestId = Guid.NewGuid().ToString();
-        var request = CreateRequest();
-        ApiFixture.DataverseAdapter
-            .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
-            .ReturnsAsync(CreateTeacherResult.Failed(CreateTeacherFailedReasons.DuplicateHusId));
-
-        // Act
-        var response = await HttpClientWithApiKey.PutAsync($"v2/trn-requests/{requestId}", request);
-
-        // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
-            response,
-            $"{nameof(GetOrCreateTrnRequest.HusId)}",
-            StringResources.Errors_10018_Title);
-    }
-
-    [Fact]
     public async Task Given_OverseasQualifiedTeacher_and_EarlyYears_ProgrammeType_returns_error()
     {
         // Arrange


### PR DESCRIPTION
### Context

- Remove validation rule that stops the create endpoint from creating a new teacher when the husid is already being used by an existing teacher.
- Added Tests 

https://trello.com/c/Tp9TIkiT/5369-no-error-on-the-dqt-api-if-theres-an-existing-husid

### Changes proposed in this pull request
- Removed validation rule
- Removed consume validation rule from hander
- Added tests 

### Guidance to review

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
