### PR TITLE
Remove certificate URL properties when they're not accessible

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/AccessMode.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/AccessMode.cs
@@ -1,0 +1,7 @@
+﻿namespace QualifiedTeachersApi.V3;
+
+public enum AccessMode
+{
+    ApiKey,
+    IdentityAccessToken
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeacherController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeacherController.cs
@@ -43,7 +43,8 @@ public class TeacherController : Controller
         var request = new GetTeacherRequest()
         {
             Trn = trn,
-            Include = include ?? GetTeacherRequestIncludes.None
+            Include = include ?? GetTeacherRequestIncludes.None,
+            AccessMode = AccessMode.IdentityAccessToken
         };
 
         var response = await _mediator.Send(request);

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeachersController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeachersController.cs
@@ -40,7 +40,8 @@ public class TeachersController : ControllerBase
         var request = new GetTeacherRequest()
         {
             Trn = trn,
-            Include = include ?? GetTeacherRequestIncludes.None
+            Include = include ?? GetTeacherRequestIncludes.None,
+            AccessMode = AccessMode.ApiKey
         };
 
         var response = await _mediator.Send(request);

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
@@ -10,6 +10,7 @@ public record GetTeacherRequest : IRequest<GetTeacherResponse>
 {
     public required string Trn { get; init; }
     public required GetTeacherRequestIncludes Include { get; init; } = GetTeacherRequestIncludes.All;
+    public required AccessMode AccessMode { get; init; }
 }
 
 [Flags]

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
@@ -57,6 +57,7 @@ public record GetTeacherResponseQts
 {
     public required DateOnly Awarded { get; init; }
     [SwaggerSchema(Nullable = false)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string CertificateUrl { get; init; }
 }
 
@@ -64,6 +65,7 @@ public record GetTeacherResponseEyts
 {
     public required DateOnly Awarded { get; init; }
     [SwaggerSchema(Nullable = false)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string CertificateUrl { get; init; }
 }
 
@@ -72,6 +74,8 @@ public record GetTeacherResponseInduction
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required InductionStatus? Status { get; init; }
+    [SwaggerSchema(Nullable = false)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string CertificateUrl { get; init; }
     [SwaggerSchema(Nullable = false)]
     public required IEnumerable<GetTeacherResponseInductionPeriod> Periods { get; init; }
@@ -137,6 +141,7 @@ public record GetTeacherResponseNpqQualificationsQualification
     public required DateOnly Awarded { get; init; }
     public required GetTeacherResponseNpqQualificationsQualificationType Type { get; init; }
     [SwaggerSchema(Nullable = false)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string CertificateUrl { get; init; }
 }
 

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.TestCommon/AssertEx.Http.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.TestCommon/AssertEx.Http.cs
@@ -32,7 +32,7 @@ public static partial class AssertEx
     public static async Task JsonResponseEquals(HttpResponseMessage response, object expected, int expectedStatusCode = StatusCodes.Status200OK)
     {
         var jsonResponse = await JsonResponse<JObject>(response, expectedStatusCode);
-        JsonObjectEquals(jsonResponse, JToken.FromObject(expected));
+        JsonObjectEquals(jsonResponse, expected is JToken expectedJToken ? expectedJToken : JToken.FromObject(expected));
     }
 
     public static async Task ResponseIsError(HttpResponseMessage response, int errorCode, int expectedStatusCode)

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherByTrnTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherByTrnTests.cs
@@ -47,7 +47,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
         var trn = "1234567";
         var baseUrl = $"/v3/teachers/{trn}";
 
-        return ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, trn);
+        return ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, trn, expectCertificateUrls: false);
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
         var trn = "1234567";
         var baseUrl = $"/v3/teachers/{trn}";
 
-        return ValidRequestWithInduction_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, trn);
+        return ValidRequestWithInduction_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, trn, expectCertificateUrls: false);
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
         var trn = "1234567";
         var baseUrl = $"/v3/teachers/{trn}";
 
-        return ValidRequestWithNpqQualifications_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, trn);
+        return ValidRequestWithNpqQualifications_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, trn, expectCertificateUrls: false);
     }
 
     [Fact]

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
@@ -34,7 +34,7 @@ public class GetTeacherTests : GetTeacherTestBase
         var httpClient = GetHttpClientWithIdentityAccessToken(trn);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, trn);
+        return ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, trn, expectCertificateUrls: true);
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class GetTeacherTests : GetTeacherTestBase
         var httpClient = GetHttpClientWithIdentityAccessToken(trn);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, trn);
+        return ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, trn, expectCertificateUrls: true);
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class GetTeacherTests : GetTeacherTestBase
         var httpClient = GetHttpClientWithIdentityAccessToken(trn);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithNpqQualifications_ReturnsExpectedInductionContent(httpClient, baseUrl, trn);
+        return ValidRequestWithNpqQualifications_ReturnsExpectedInductionContent(httpClient, baseUrl, trn, expectCertificateUrls: true);
     }
 
     [Fact]

--- a/docs/api-specs/v3.json
+++ b/docs/api-specs/v3.json
@@ -534,8 +534,7 @@
             "$ref": "#/components/schemas/InductionStatus"
           },
           "certificateUrl": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "periods": {
             "type": "array",


### PR DESCRIPTION
Certificates are only available when the caller is authorised using an ID access token. Remove the various `certificateUrl` properties from the `/v3/teachers/{trn}` response since that's not authorised the same way.