### PR TITLE
Skip lint on pushes to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
         dotnet-version: '7.0.x'
 
     - name: Lint
+      if: github.event_name != 'push'
       run: |
         #https://github.com/dotnet/format/issues/1433
         dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json


### PR DESCRIPTION
Similar to https://github.com/DFE-Digital/qualified-teachers-api/pull/453 there's no value running linting on pushes to main.