### PR TITLE
Revert "Remove husid duplicate check on create endpoint (#446)"

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -75,14 +75,6 @@ public partial class DataverseAdapter
             });
         }
 
-        if (referenceData.HaveExistingTeacherWithHusId == true)
-        {
-            txnRequest.Requests.Add(new CreateRequest()
-            {
-                Target = helper.CreateDuplicateHusIdReviewTaskEntity(command.HusId)
-            });
-        }
-
         var qtsEntity = helper.CreateQtsRegistrationEntity(referenceData);
         txnRequest.Requests.Add(new CreateRequest() { Target = qtsEntity });
 
@@ -125,32 +117,6 @@ public partial class DataverseAdapter
         }
 
         public Guid TeacherId { get; }
-
-        public CrmTask CreateDuplicateHusIdReviewTaskEntity(string duplicateHusId)
-        {
-            var description = GetDescription();
-            var category = _command.TeacherType == CreateTeacherType.OverseasQualifiedTeacher ? "ApplyForQts" :
-                !string.IsNullOrEmpty(_command.HusId) ? "HESAImportTrn" :
-                "DMSImportTrn";
-
-            return new CrmTask()
-            {
-                RegardingObjectId = TeacherId.ToEntityReference(Contact.EntityLogicalName),
-                Category = category,
-                Subject = "Notification for QTS Unit Team",
-                Description = description,
-                ScheduledEnd = _dataverseAdapter._clock.UtcNow
-            };
-
-            string GetDescription()
-            {
-                var sb = new StringBuilder();
-                sb.AppendLine("Potential duplicate");
-                sb.AppendLine("Matched on");
-                sb.AppendLine($"HusId - {duplicateHusId}");
-                return sb.ToString();
-            }
-        }
 
         public CrmTask CreateDuplicateReviewTaskEntity(CreateTeacherDuplicateTeacherResult duplicate)
         {
@@ -788,6 +754,11 @@ public partial class DataverseAdapter
             if (referenceData.QualificationId == null)
             {
                 failedReasons |= CreateTeacherFailedReasons.QualificationNotFound;
+            }
+
+            if (referenceData.HaveExistingTeacherWithHusId == true)
+            {
+                failedReasons |= CreateTeacherFailedReasons.DuplicateHusId;
             }
 
             if (referenceData.IttCountryId == null)

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -235,6 +235,11 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
             ErrorRegistry.OrganisationNotFound().Title);
 
         ConsumeReason(
+            CreateTeacherFailedReasons.DuplicateHusId,
+            $"{nameof(GetOrCreateTrnRequest.HusId)}",
+            ErrorRegistry.ExistingTeacherAlreadyHasHusId().Title);
+
+        ConsumeReason(
             CreateTeacherFailedReasons.TrainingCountryNotFound,
             $"{nameof(GetOrCreateTrnRequest.InitialTeacherTraining)}.{nameof(GetOrCreateTrnRequest.InitialTeacherTraining.TrainingCountryCode)}",
             ErrorRegistry.CountryNotFound().Title);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -110,66 +110,6 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
     }
 
     [Fact]
-    public async Task Given_husid_does_not_exist_request_succeeds_and_does_not_creates_review_task()
-    {
-        // Arrange
-        var husid = Guid.NewGuid().ToString();
-        var command = new CreateTeacherCommand()
-        {
-            FirstName = "Minsnie",
-            LastName = "Rydser",
-            BirthDate = new(1990, 5, 23),
-            GenderCode = Contact_GenderCode.Female,
-            InitialTeacherTraining = new()
-            {
-                ProviderUkprn = "10044534",  // ARK Teacher Training
-                ProgrammeStartDate = new(2020, 4, 1),
-                ProgrammeEndDate = new(2020, 10, 10),
-                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
-                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
-            },
-            HusId = husid
-        };
-
-        // Act
-        var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command);
-
-        // Assert
-        Assert.True(result.Succeeded);
-        transactionRequest.AssertDoesNotContainCreateRequest<CrmTask>(x => x.Description.Contains($"HusId - {husid}"));
-    }
-
-    [Fact]
-    public async Task Given_husid_exists_request_succeeds_and_creates_review_task()
-    {
-        // Arrange
-        var husid = "123456";  //teacher with husid already exists because of CreateTeacherFixture initialize
-        var command = new CreateTeacherCommand()
-        {
-            FirstName = "Minnie",
-            LastName = "Ryder",
-            BirthDate = new(1990, 5, 23),
-            GenderCode = Contact_GenderCode.Female,
-            InitialTeacherTraining = new()
-            {
-                ProviderUkprn = "10044534",  // ARK Teacher Training
-                ProgrammeStartDate = new(2020, 4, 1),
-                ProgrammeEndDate = new(2020, 10, 10),
-                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
-                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
-            },
-            HusId = husid
-        };
-
-        // Act
-        var (result, transactionRequest) = await _dataverseAdapter.CreateTeacherImpl(command);
-
-        // Assert
-        Assert.True(result.Succeeded);
-        transactionRequest.AssertContainsCreateRequest<CrmTask>(x => x.Description.Contains($"HusId - {husid}"));
-    }
-
-    [Fact]
     public async Task Given_specified_qualification_type_creates_qualification_with_type()
     {
         // Arrange
@@ -825,7 +765,6 @@ public class CreateTeacherFixture : IAsyncLifetime
     public string ExistingTeacherFirstName => "Joe";
     public string ExistingTeacherFirstNameMiddleName => "X";
     public string ExistingTeacherFirstNameLastName => "Bloggs";
-    public string ExistingTeacherHusId => "123456";
     public DateTime ExistingTeacherFirstNameBirthDate => new DateTime(1990, 5, 23);
 
     public async Task DisposeAsync() => await _dataScope.DisposeAsync();
@@ -837,8 +776,7 @@ public class CreateTeacherFixture : IAsyncLifetime
             FirstName = ExistingTeacherFirstName,
             MiddleName = ExistingTeacherFirstNameMiddleName,
             LastName = ExistingTeacherFirstNameLastName,
-            BirthDate = ExistingTeacherFirstNameBirthDate,
-            dfeta_HUSID = ExistingTeacherHusId
+            BirthDate = ExistingTeacherFirstNameBirthDate
         });
     }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -633,6 +633,26 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
     }
 
     [Fact]
+    public async Task Given_request_with_existing_husid_returns_error()
+    {
+        // Arrange
+        var requestId = Guid.NewGuid().ToString();
+        var request = CreateRequest();
+        ApiFixture.DataverseAdapter
+            .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
+            .ReturnsAsync(CreateTeacherResult.Failed(CreateTeacherFailedReasons.DuplicateHusId));
+
+        // Act
+        var response = await HttpClientWithApiKey.PutAsync($"v2/trn-requests/{requestId}", request);
+
+        // Assert
+        await AssertEx.ResponseIsValidationErrorForProperty(
+            response,
+            $"{nameof(GetOrCreateTrnRequest.HusId)}",
+            StringResources.Errors_10018_Title);
+    }
+
+    [Fact]
     public async Task Given_OverseasQualifiedTeacher_and_EarlyYears_ProgrammeType_returns_error()
     {
         // Arrange


### PR DESCRIPTION
This reverts commit b2a9c9eb494344ceb98319b97d0ba782fc305dd0.

This commit was merged previously, but does not behave how dqt want this to behave. Backing changes out until changes have been done that match the existing dqt dup matching.

https://trello.com/c/Tp9TIkiT/5369-no-error-on-the-dqt-api-if-theres-an-existing-husid

### Context

Include relevant motivation and context.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
