### PR TITLE
Remove Husid Duplicate check

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -235,11 +235,6 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
             ErrorRegistry.OrganisationNotFound().Title);
 
         ConsumeReason(
-            CreateTeacherFailedReasons.DuplicateHusId,
-            $"{nameof(GetOrCreateTrnRequest.HusId)}",
-            ErrorRegistry.ExistingTeacherAlreadyHasHusId().Title);
-
-        ConsumeReason(
             CreateTeacherFailedReasons.TrainingCountryNotFound,
             $"{nameof(GetOrCreateTrnRequest.InitialTeacherTraining)}.{nameof(GetOrCreateTrnRequest.InitialTeacherTraining.TrainingCountryCode)}",
             ErrorRegistry.CountryNotFound().Title);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -633,26 +633,6 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
     }
 
     [Fact]
-    public async Task Given_request_with_existing_husid_returns_error()
-    {
-        // Arrange
-        var requestId = Guid.NewGuid().ToString();
-        var request = CreateRequest();
-        ApiFixture.DataverseAdapter
-            .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
-            .ReturnsAsync(CreateTeacherResult.Failed(CreateTeacherFailedReasons.DuplicateHusId));
-
-        // Act
-        var response = await HttpClientWithApiKey.PutAsync($"v2/trn-requests/{requestId}", request);
-
-        // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
-            response,
-            $"{nameof(GetOrCreateTrnRequest.HusId)}",
-            StringResources.Errors_10018_Title);
-    }
-
-    [Fact]
     public async Task Given_OverseasQualifiedTeacher_and_EarlyYears_ProgrammeType_returns_error()
     {
         // Arrange


### PR DESCRIPTION
### Context

https://trello.com/c/Tp9TIkiT/5369-no-error-on-the-dqt-api-if-theres-an-existing-husid

- Remove duplicate check on husid & follow existing dupliate check logic by creating a new crm task to review in the future.
- Removed old test
- added two new tests

### Changes proposed in this pull request

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
