### PR TITLE
Use case-insensitive comparison for webhook signature checking

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/GetAnIdentityEndpoints.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/GetAnIdentityEndpoints.cs
@@ -31,7 +31,7 @@ public static class GetAnIdentityEndpoints
                 var bodyBytes = Encoding.UTF8.GetBytes(body);
                 var calculatedSignature = Convert.ToHexString(HMACSHA256.HashData(secretBytes, bodyBytes));
 
-                if (!calculatedSignature.Equals(signature))
+                if (!calculatedSignature.Equals(signature, StringComparison.OrdinalIgnoreCase))
                 {
                     return Results.Unauthorized();
                 }


### PR DESCRIPTION
Signatures are a hex string; a difference in casing shouldn't fail the equality check.