### PR TITLE
Don't cancel in-flight builds for same branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   checks: write


### PR DESCRIPTION
The Cloud Foundry Terraform provider corrupts its own state when terraform apply is cancelled mid-way, as happens when GitHub cancels the workflow because there's a newer commit.