### PR TITLE
Remove Newtonsoft from tests

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/FindTeachersHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/FindTeachersHandler.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -73,7 +71,7 @@ public class FindTeachersHandler : IRequestHandler<FindTeachersRequest, FindTeac
             Results = result?.Select(a => new FindTeacherResult()
             {
                 Trn = a.dfeta_TRN,
-                EmailAddresses = !string.IsNullOrEmpty(a.EMailAddress1) ? new List<string> { a.EMailAddress1 } : null,
+                EmailAddresses = !string.IsNullOrEmpty(a.EMailAddress1) ? new[] { a.EMailAddress1 } : Array.Empty<string>(),
                 FirstName = a.FirstName,
                 LastName = a.LastName,
                 DateOfBirth = a.BirthDate.HasValue ? DateOnly.FromDateTime(a.BirthDate.Value) : null,

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/FindTeacherResult.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/FindTeacherResult.cs
@@ -1,17 +1,15 @@
-﻿#nullable disable
-using System;
-using System.Collections.Generic;
+﻿using System;
 
 namespace QualifiedTeachersApi.V2.Responses;
 
-public class FindTeacherResult
+public record FindTeacherResult
 {
-    public string Trn { get; set; }
-    public List<string> EmailAddresses { get; set; }
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
-    public DateOnly? DateOfBirth { get; set; }
-    public string NationalInsuranceNumber { get; set; }
-    public string Uid { get; set; }
-    public bool HasActiveSanctions { get; set; }
+    public required string Trn { get; set; }
+    public required string[] EmailAddresses { get; set; }
+    public required string FirstName { get; set; }
+    public required string LastName { get; set; }
+    public required DateOnly? DateOfBirth { get; set; }
+    public required string? NationalInsuranceNumber { get; set; }
+    public required string Uid { get; set; }
+    public required bool HasActiveSanctions { get; set; }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.TestCommon/AssertEx.Json.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.TestCommon/AssertEx.Json.cs
@@ -1,106 +1,134 @@
-﻿#nullable disable
-using System;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 namespace QualifiedTeachersApi.TestCommon;
 
 public static partial class AssertEx
 {
-    public static void JsonEquals(string expected, string actual)
-        => JsonEquals(JToken.Parse(expected), JToken.Parse(actual));
+    public static JsonSerializerOptions SerializerOptions { get; } = new JsonSerializerOptions(JsonSerializerDefaults.Web);
 
-    public static void JsonObjectEquals(object actual, object expected)
-        => JsonEquals(JToken.FromObject(expected), JToken.FromObject(actual));
+    public static void JsonEquals(string expected, string actual) =>
+        JsonEquals(JsonNode.Parse(expected), JsonNode.Parse(actual));
 
-    public static void JsonEquals(JToken expected, JToken actual)
+    public static void JsonObjectEquals(JsonDocument expected, object actual) =>
+        JsonEquals(JsonSerializer.SerializeToNode(expected.RootElement, SerializerOptions), JsonSerializer.SerializeToNode(actual, SerializerOptions));
+
+    public static void JsonObjectEquals(object expected, object actual) =>
+        JsonEquals(JsonSerializer.SerializeToNode(expected, SerializerOptions), JsonSerializer.SerializeToNode(actual, SerializerOptions));
+
+    public static void JsonEquals(JsonNode? expected, JsonNode? actual)
     {
-        if (expected is JValue expectedJValue)
+        Core(expected, actual, pathHint: null);
+
+        static void Core(JsonNode? expected, JsonNode? actual, string? pathHint)
         {
-            if (!(actual is JValue))
+            if (expected is null && actual is null)
             {
-                ThrowMismatchedTypeException("JValue", actual.GetType().Name, GetPrintablePath(expected.Path));
+                return;
+            }
+            else if (expected is null && actual is not null)
+            {
+                var path = GetPrintablePath(expected?.GetPath());
+                throw new JsonNotEqualException($"JSON not equal:\nExpected: null\nActual: <not null>\nPath: {path}");
+            }
+            else if (expected is not null && actual is null)
+            {
+                var path = GetPrintablePath(expected?.GetPath());
+                throw new JsonNotEqualException($"JSON not equal:\nExpected: <not null>\nActual: null\nPath: {path}");
             }
 
-            var actualJValue = (JValue)actual;
+            Debug.Assert(expected is not null);
+            Debug.Assert(actual is not null);
 
-            // We don't care if the types are different, only if the generated JSON is different
-            var expectedValue = expectedJValue.ToString(Formatting.None);
-            var actualValue = actualJValue.ToString(Formatting.None);
-
-            if (StringComparer.Ordinal.Compare(expectedValue, actualValue) != 0)
+            if (expected is JsonValue expectedJValue)
             {
-                ThrowNotEqualException(expectedValue, actualValue, GetPrintablePath(expected.Path));
-            }
-        }
-        else if (expected is JArray expectedJArray)
-        {
-            if (!(actual is JArray))
-            {
-                ThrowMismatchedTypeException("JArray", actual.GetType().Name, GetPrintablePath(expected.Path));
-            }
-
-            var actualJArray = (JArray)actual;
-
-            if (expectedJArray.Count != actualJArray.Count)
-            {
-                throw new JsonNotEqualException(
-                    $"JSON not equal\nExpected {expectedJArray.Count} elements\nGot: {actualJArray.Count}\nPath: {GetPrintablePath(expected.Path)}");
-            }
-
-            for (var i = 0; i < expectedJArray.Count; i++)
-            {
-                var expectedElement = expectedJArray[i];
-                var actualElement = actualJArray[i];
-
-                JsonEquals(expectedElement, actualElement);
-            }
-        }
-        else if (expected is JObject expectedJObject)
-        {
-            if (!(actual is JObject))
-            {
-                ThrowMismatchedTypeException("JObject", actual.GetType().Name, GetPrintablePath(expected.Path));
-            }
-
-            var actualJObject = (JObject)actual;
-
-            // Compare each property on `expected` with `actual`
-            foreach (var prop in expectedJObject.Properties())
-            {
-                var actualProp = actualJObject[prop.Name];
-                if (actualProp == null)
+                if (actual is not JsonValue actualJValue)
                 {
-                    throw new JsonNotEqualException(
-                        $"JSON not equal\nMissing property: '{prop.Name}'\nPath: {GetPrintablePath(expected.Path)}");
+                    ThrowMismatchedTypeException("JsonValue", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
                 }
 
-                JsonEquals(prop.Value, actualProp);
-            }
+                // We don't care if the types are different, only if the generated JSON is different
+                var expectedValue = expectedJValue.ToString();
+                var actualValue = actualJValue.ToString();
 
-            // Check `actual` doesn't have extra properties over `expected`
-            foreach (var prop in actualJObject.Properties())
-            {
-                var expectedProp = expectedJObject[prop.Name];
-                if (expectedProp == null)
+                if (StringComparer.Ordinal.Compare(expectedValue, actualValue) != 0)
                 {
-                    throw new JsonNotEqualException(
-                        $"JSON not equal\nExtra property {prop.Name}\nPath: {GetPrintablePath(expected.Path)}");
+                    ThrowNotEqualException(expectedValue, actualValue, GetPrintablePath(expected.GetPath()));
                 }
             }
+            else if (expected is JsonArray expectedJArray)
+            {
+                if (actual is not JsonArray actualJArray)
+                {
+                    ThrowMismatchedTypeException("JsonArray", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
+                }
+
+                if (expectedJArray.Count != actualJArray.Count)
+                {
+                    throw new JsonNotEqualException(
+                        $"JSON not equal\nExpected {expectedJArray.Count} elements\nGot: {actualJArray.Count}\nPath: {GetPrintablePath(expected.GetPath())}");
+                }
+
+                for (var i = 0; i < expectedJArray.Count; i++)
+                {
+                    var expectedElement = expectedJArray[i]!;
+                    var actualElement = actualJArray[i]!;
+
+                    Core(expectedElement, actualElement, expectedElement.GetPath());
+                }
+            }
+            else if (expected is JsonObject expectedJObject)
+            {
+                if (actual is not JsonObject actualJObject)
+                {
+                    ThrowMismatchedTypeException("JsonObject", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
+                }
+
+                // Compare each property on `expected` with `actual`
+                foreach (var (name, expectedProp) in (IDictionary<string, JsonNode?>)expectedJObject)
+                {
+                    if (!actualJObject.ContainsKey(name))
+                    {
+                        throw new JsonNotEqualException(
+                            $"JSON not equal\nActual is missing property: '{name}'\nPath: {GetPrintablePath(expected.GetPath())}");
+                    }
+
+                    var actualProp = actualJObject[name];
+                    Core(expectedProp, actualProp, $"{expected.GetPath()}.{name}");
+                }
+
+                // Check `actual` doesn't have extra properties over `expected`
+                foreach (var (name, actualProp) in (IDictionary<string, JsonNode?>)actualJObject)
+                {
+                    if (!expectedJObject.ContainsKey(name))
+                    {
+                        throw new JsonNotEqualException(
+                            $"JSON not equal\nActual has extra property '{name}'\nPath: {GetPrintablePath(expected.GetPath())}");
+                    }
+                }
+            }
+            else
+            {
+                throw new NotSupportedException($"Don't know how to compare JTokens of type '{expected.GetType().Name}'.");
+            }
+
+            string GetPrintablePath(string? path) => !string.IsNullOrEmpty(path) ?
+                path :
+                !string.IsNullOrEmpty(pathHint) ?
+                pathHint :
+                "(root)";
+
+            [DoesNotReturn]
+            void ThrowNotEqualException(string expectedValue, string actualValue, string path) =>
+                throw new JsonNotEqualException($"JSON not equal:\nExpected: {expectedValue}\nActual: {actualValue}\nPath: {path}");
+
+            [DoesNotReturn]
+            void ThrowMismatchedTypeException(string expectedType, string actualType, string path) =>
+                throw new JsonNotEqualException($"Token types not equal\nExpected: {expectedType}\nActual: {actualType}\nPath: {path}");
         }
-        else
-        {
-            throw new NotSupportedException($"Don't know how to compare JTokens of type '{expected.GetType().Name}'.");
-        }
-
-        string GetPrintablePath(string path) => string.IsNullOrEmpty(path) ? "(root)" : path;
-
-        void ThrowNotEqualException(string expectedValue, string actualValue, string path)
-            => throw new JsonNotEqualException($"JSON not equal:\nExpected: {expected}\nActual: {actual}\nPath: {path}");
-
-        void ThrowMismatchedTypeException(string expectedType, string actualType, string path)
-            => throw new JsonNotEqualException($"Token types not equal\nExpected: {expectedType}\nActual: {actualType}\nPath: {path}");
     }
 
     public class JsonNotEqualException : Exception

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.TestCommon/QualifiedTeachersApi.TestCommon.csproj
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.TestCommon/QualifiedTeachersApi.TestCommon.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V1/Operations/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V1/Operations/GetTeacherTests.cs
@@ -31,7 +31,7 @@ public class GetTeacherTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, "trn", expectedError: StringResources.ErrorMessages_TRNMustBe7Digits);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, "trn", expectedError: StringResources.ErrorMessages_TRNMustBe7Digits);
     }
 
     [Theory]
@@ -46,7 +46,7 @@ public class GetTeacherTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, "birthdate", expectedError: $"The value '{birthDate}' is not valid for BirthDate.");
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, "birthdate", expectedError: $"The value '{birthDate}' is not valid for BirthDate.");
     }
 
     [Fact]
@@ -143,6 +143,6 @@ public class GetTeacherTests : ApiTestBase
 
         // Assert
         var responseJson = await AssertEx.JsonResponse(response, expectedStatusCode: StatusCodes.Status200OK);
-        Assert.Equal(matchingTrn, (string)responseJson.trn);
+        Assert.Equal(matchingTrn, responseJson.RootElement.GetProperty("trn").GetString());
     }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -1,6 +1,5 @@
 ﻿#nullable disable
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
@@ -46,7 +45,15 @@ public class FindTeachersTests : ApiTestBase
     public async Task Given_search_returns_a_result_returns_expected_response()
     {
         // Arrange
-        var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 2, 1), dfeta_TRN = "someReference" };
+        var contact1 = new Contact()
+        {
+            FirstName = "test",
+            LastName = "testing",
+            Id = Guid.NewGuid(),
+            dfeta_NINumber = "1111",
+            BirthDate = new DateTime(1988, 2, 1),
+            dfeta_TRN = "someReference"
+        };
 
         ApiFixture.DataverseAdapter
             .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
@@ -67,7 +74,7 @@ public class FindTeachersTests : ApiTestBase
                     new
                     {
                          trn = contact1.dfeta_TRN,
-                         emailAddresses = default(List<string>),
+                         emailAddresses = Array.Empty<string>(),
                          firstName = contact1.FirstName,
                          lastName = contact1.LastName,
                          dateOfBirth = DateOnly.FromDateTime(contact1.BirthDate.Value).ToString("yyyy-MM-dd"),
@@ -111,7 +118,15 @@ public class FindTeachersTests : ApiTestBase
         // Arrange
         var account = new Account() { Name = "someProvider" };
 
-        var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 1, 1), dfeta_TRN = "someReference" };
+        var contact1 = new Contact()
+        {
+            FirstName = "test",
+            LastName = "testing",
+            Id = Guid.NewGuid(),
+            dfeta_NINumber = "1111",
+            BirthDate = new DateTime(1988, 1, 1),
+            dfeta_TRN = "someReference"
+        };
 
         ApiFixture.DataverseAdapter
             .Setup(mock => mock.GetIttProviderOrganizationsByName(It.IsAny<string>(), It.IsAny<string[]>(), /*activeOnly: */false))
@@ -125,7 +140,9 @@ public class FindTeachersTests : ApiTestBase
             .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
             .ReturnsAsync(new[] { contact1 });
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}&IttProviderUkPrn={providerUkprn}&IttProviderName={providerName}");
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}&IttProviderUkPrn={providerUkprn}&IttProviderName={providerName}");
 
         // Act
         var response = await HttpClientWithApiKey.SendAsync(request);
@@ -140,7 +157,7 @@ public class FindTeachersTests : ApiTestBase
                     new
                     {
                          trn = contact1.dfeta_TRN,
-                         emailAddresses = default(List<string>),
+                         emailAddresses = Array.Empty<string>(),
                          firstName = contact1.FirstName,
                          lastName = contact1.LastName,
                          dateOfBirth = DateOnly.FromDateTime(contact1.BirthDate.Value).ToString("yyyy-MM-dd"),
@@ -157,13 +174,23 @@ public class FindTeachersTests : ApiTestBase
     public async Task Given_both_ukprn_and_provider_name_are_specified_returns_error()
     {
         // Arrange
-        var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 1, 1), dfeta_TRN = "someReference" };
+        var contact1 = new Contact()
+        {
+            FirstName = "test",
+            LastName = "testing",
+            Id = Guid.NewGuid(),
+            dfeta_NINumber = "1111",
+            BirthDate = new DateTime(1988, 1, 1),
+            dfeta_TRN = "someReference"
+        };
 
         ApiFixture.DataverseAdapter
             .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
             .ReturnsAsync(new[] { contact1 });
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}&IttProviderUkPrn=12345678910&IttProviderName=provider");
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"v2/teachers/find?FirstName={contact1.FirstName}&LastName={contact1.LastName}&IttProviderUkPrn=12345678910&IttProviderName=provider");
 
         // Act
         var response = await HttpClientWithApiKey.SendAsync(request);
@@ -196,7 +223,7 @@ public class FindTeachersTests : ApiTestBase
                     new
                     {
                          trn = contact1.dfeta_TRN,
-                         emailAddresses = default(List<string>),
+                         emailAddresses = Array.Empty<string>(),
                          firstName = contact1.FirstName,
                          lastName = contact1.LastName,
                          dateOfBirth = DateOnly.FromDateTime(contact1.BirthDate.Value).ToString("yyyy-MM-dd"),
@@ -215,7 +242,17 @@ public class FindTeachersTests : ApiTestBase
     public async Task Given_search_returns_a_result_with_activesanctions_set_returns_expected_response(bool? activeSanctions)
     {
         // Arrange
-        var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 2, 1), dfeta_TRN = "someReference", dfeta_ActiveSanctions = activeSanctions };
+        var contact1 = new Contact()
+        {
+            FirstName = "test",
+            LastName = "testing",
+            Id = Guid.NewGuid(),
+            dfeta_NINumber = "1111",
+            BirthDate = new DateTime(1988, 2, 1),
+            dfeta_TRN = "someReference",
+            dfeta_ActiveSanctions = activeSanctions
+        };
+
         ApiFixture.DataverseAdapter
             .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
             .ReturnsAsync(new[] { contact1 });
@@ -235,7 +272,7 @@ public class FindTeachersTests : ApiTestBase
                     new
                     {
                          trn = contact1.dfeta_TRN,
-                         emailAddresses = default(List<string>),
+                         emailAddresses = Array.Empty<string>(),
                          firstName = contact1.FirstName,
                          lastName = contact1.LastName,
                          dateOfBirth = DateOnly.FromDateTime(contact1.BirthDate.Value).ToString("yyyy-MM-dd"),

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -111,7 +111,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
         var response = await HttpClientWithApiKey.PutAsync($"v2/trn-requests/{requestId}", CreateRequest());
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: nameof(GetOrCreateTrnRequest.RequestId),
             expectedError: Properties.StringResources.ErrorMessages_RequestIdCanOnlyContainCharactersDigitsUnderscoresAndDashes);
@@ -127,7 +127,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
         var response = await HttpClientWithApiKey.PutAsync($"v2/trn-requests/{requestId}", CreateRequest());
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: nameof(GetOrCreateTrnRequest.RequestId),
             expectedError: Properties.StringResources.ErrorMessages_RequestIdMustBe100CharactersOrFewer);
@@ -220,7 +220,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
 
         // Assert
         Assert.False(response.IsSuccessStatusCode);
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: nameof(GetOrCreateTrnRequest.IdentityUserId),
             expectedError: Properties.StringResources.Errors_10022_Title);
@@ -319,7 +319,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.Qualification.Subject2 = "some invalid subject"));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(GetOrCreateTrnRequest.Qualification)}.{nameof(GetOrCreateTrnRequest.Qualification.Subject2)}",
             expectedError: Properties.StringResources.Errors_10009_Title);
@@ -341,7 +341,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.Qualification.Subject3 = "some invalid subject"));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(GetOrCreateTrnRequest.Qualification)}.{nameof(GetOrCreateTrnRequest.Qualification.Subject3)}",
             expectedError: Properties.StringResources.Errors_10009_Title);
@@ -364,7 +364,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.ProviderUkprn = ukprn));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(GetOrCreateTrnRequest.InitialTeacherTraining)}.{nameof(GetOrCreateTrnRequest.InitialTeacherTraining.ProviderUkprn)}",
             expectedError: Properties.StringResources.Errors_10008_Title);
@@ -387,7 +387,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.Subject1 = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(GetOrCreateTrnRequest.InitialTeacherTraining)}.{nameof(GetOrCreateTrnRequest.InitialTeacherTraining.Subject1)}",
             expectedError: Properties.StringResources.Errors_10009_Title);
@@ -410,7 +410,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.Subject2 = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(GetOrCreateTrnRequest.InitialTeacherTraining)}.{nameof(GetOrCreateTrnRequest.InitialTeacherTraining.Subject2)}",
             expectedError: Properties.StringResources.Errors_10009_Title);
@@ -453,7 +453,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.Qualification.CountryCode = country));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(GetOrCreateTrnRequest.Qualification)}.{nameof(GetOrCreateTrnRequest.Qualification.CountryCode)}",
             expectedError: Properties.StringResources.Errors_10010_Title);
@@ -476,7 +476,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.Qualification.Subject = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(GetOrCreateTrnRequest.Qualification)}.{nameof(GetOrCreateTrnRequest.Qualification.Subject)}",
             expectedError: Properties.StringResources.Errors_10009_Title);
@@ -499,7 +499,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.Qualification.ProviderUkprn = ukprn));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(GetOrCreateTrnRequest.Qualification)}.{nameof(GetOrCreateTrnRequest.Qualification.ProviderUkprn)}",
             expectedError: Properties.StringResources.Errors_10008_Title);
@@ -543,7 +543,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
         var response = await HttpClientWithApiKey.PutAsync($"v2/trn-requests/{requestId}", request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             "Birthdate",
             StringResources.ErrorMessages_BirthDateIsOutOfRange);
@@ -567,7 +567,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
         var response = await HttpClientWithApiKey.PutAsync($"v2/trn-requests/{requestId}", request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             "Birthdate",
             StringResources.ErrorMessages_BirthDateIsOutOfRange);
@@ -594,7 +594,7 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
         var response = await HttpClientWithApiKey.PutAsync($"v2/trn-requests/{requestId}", request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             expectedErrorPropertyName,
             expectedErrorMessage);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTeacherTests.cs
@@ -32,7 +32,7 @@ public class GetTeacherTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, "trn", expectedError: StringResources.ErrorMessages_TRNMustBe7Digits);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, "trn", expectedError: StringResources.ErrorMessages_TRNMustBe7Digits);
     }
 
     [Fact]

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/SetIttOutcomeTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/SetIttOutcomeTests.cs
@@ -47,7 +47,7 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, errorCode: 10001, expectedStatusCode: StatusCodes.Status404NotFound);
+        await AssertEx.JsonResponseIsError(response, expectedErrorCode: 10001, expectedStatusCode: StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, errorCode: 10002, expectedStatusCode: StatusCodes.Status409Conflict);
+        await AssertEx.JsonResponseIsError(response, expectedErrorCode: 10002, expectedStatusCode: StatusCodes.Status409Conflict);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: nameof(requestBody.BirthDate),
             expectedError: "Birthdate is required.");
@@ -135,7 +135,7 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: nameof(requestBody.IttProviderUkprn),
             expectedError: "ITT provider UKPRN is required.");
@@ -165,7 +165,7 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: nameof(requestBody.AssessmentDate),
             expectedError: "Assessment date must be specified when outcome is Pass.");
@@ -199,7 +199,7 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: nameof(requestBody.AssessmentDate),
             expectedError: "Assessment date cannot be specified unless outcome is Pass.");
@@ -229,7 +229,7 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: nameof(requestBody.AssessmentDate),
             expectedError: "QTS date cannot be in the future.");
@@ -272,7 +272,7 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, 10003, expectedStatusCode: StatusCodes.Status400BadRequest);
+        await AssertEx.JsonResponseIsError(response, 10003, expectedStatusCode: StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -358,6 +358,6 @@ public class SetIttOutcomeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, expectedErrorCode, expectedStatusCode: StatusCodes.Status400BadRequest);
+        await AssertEx.JsonResponseIsError(response, expectedErrorCode, expectedStatusCode: StatusCodes.Status400BadRequest);
     }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/SetNpqQualificationTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/SetNpqQualificationTests.cs
@@ -49,7 +49,7 @@ public class SetNpqQualificationTests : ApiTestBase
             CreateRequest(req => req.CompletionDate = new DateOnly(Clock.UtcNow.Year, Clock.UtcNow.Month, Clock.UtcNow.Day)));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(SetNpqQualificationRequest.CompletionDate)}",
             expectedError: Properties.StringResources.Errors_10022_Title);
@@ -71,7 +71,7 @@ public class SetNpqQualificationTests : ApiTestBase
             CreateRequest(req => req.CompletionDate = new DateOnly(Clock.UtcNow.Year, Clock.UtcNow.Month, Clock.UtcNow.Day)));
 
         // Assert
-        await AssertEx.ResponseIsError(response, errorCode: 10001, expectedStatusCode: StatusCodes.Status404NotFound);
+        await AssertEx.JsonResponseIsError(response, expectedErrorCode: 10001, expectedStatusCode: StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class SetNpqQualificationTests : ApiTestBase
             CreateRequest(req => req.CompletionDate = new DateOnly(Clock.UtcNow.Year, Clock.UtcNow.Month, Clock.UtcNow.Day)));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(SetNpqQualificationRequest.QualificationType)}",
             expectedError: Properties.StringResources.Errors_10021_Title);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/UnlockTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/UnlockTeacherTests.cs
@@ -124,6 +124,6 @@ public class UnlockTeacherTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, errorCode: 10014, expectedStatusCode: StatusCodes.Status400BadRequest);
+        await AssertEx.JsonResponseIsError(response, expectedErrorCode: 10014, expectedStatusCode: StatusCodes.Status400BadRequest);
     }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/UpdateTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/UpdateTeacherTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -34,7 +35,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.ProviderUkprn = ""));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.ProviderUkprn)}",
             expectedError: "Initial TeacherTraining ProviderUkprn is required.");
@@ -53,7 +54,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.ProviderUkprn = ukprn));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             propertyName: "Birthdate",
             expectedError: "Birthdate is required.");
@@ -82,7 +83,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.Qualification.Subject2 = "some invalid subject"));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.Subject2)}", ErrorRegistry.SubjectNotFound().Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.Subject2)}", ErrorRegistry.SubjectNotFound().Title);
     }
 
     [Fact]
@@ -108,7 +109,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.Qualification.Subject3 = "some invalid"));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.Subject3)}", ErrorRegistry.SubjectNotFound().Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.Subject3)}", ErrorRegistry.SubjectNotFound().Title);
     }
 
 
@@ -127,7 +128,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining = null));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}", $"'Initial Teacher Training' must not be empty.");
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}", $"'Initial Teacher Training' must not be empty.");
     }
 
     [Fact]
@@ -154,7 +155,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.ProviderUkprn = ukprn));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.ProviderUkprn)}", ErrorRegistry.TeacherHasNoIncompleteIttRecord().Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.ProviderUkprn)}", ErrorRegistry.TeacherHasNoIncompleteIttRecord().Title);
     }
 
     [Fact]
@@ -181,7 +182,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.Subject1 = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Subject1)}", ErrorRegistry.SubjectNotFound().Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Subject1)}", ErrorRegistry.SubjectNotFound().Title);
     }
 
     [Fact]
@@ -208,7 +209,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.Subject2 = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Subject2)}", ErrorRegistry.SubjectNotFound().Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Subject2)}", ErrorRegistry.SubjectNotFound().Title);
     }
 
     [Fact]
@@ -235,7 +236,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.InitialTeacherTraining.Subject3 = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Subject3)}", ErrorRegistry.SubjectNotFound().Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Subject3)}", ErrorRegistry.SubjectNotFound().Title);
     }
 
     [Fact]
@@ -291,7 +292,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.Qualification.CountryCode = country));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.CountryCode)}", ErrorRegistry.CountryNotFound().Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.CountryCode)}", ErrorRegistry.CountryNotFound().Title);
     }
 
     [Fact]
@@ -345,8 +346,13 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.Qualification.Subject = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.Subject)}", ErrorRegistry.SubjectNotFound().Title);
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Subject2)}", ErrorRegistry.SubjectNotFound().Title);
+        await AssertEx.JsonResponseHasValidationErrorsForProperties(
+            response,
+            new Dictionary<string, string>()
+            {
+                { $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.Subject)}", ErrorRegistry.SubjectNotFound().Title },
+                { $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Subject2)}", ErrorRegistry.SubjectNotFound().Title }
+            });
     }
 
     [Fact]
@@ -373,7 +379,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.Qualification.Subject = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.Subject)}", ErrorRegistry.SubjectNotFound().Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.Qualification)}.{nameof(UpdateTeacherRequest.Qualification.Subject)}", ErrorRegistry.SubjectNotFound().Title);
     }
 
     [Fact]
@@ -430,7 +436,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest(req => req.Qualification.Subject = subject));
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Outcome)}", StringResources.Errors_10006_Title);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, $"{nameof(UpdateTeacherRequest.InitialTeacherTraining)}.{nameof(UpdateTeacherRequest.InitialTeacherTraining.Outcome)}", StringResources.Errors_10006_Title);
     }
 
     [Fact]
@@ -483,7 +489,7 @@ public class UpdateTeacherTests : ApiTestBase
             $"v2/teachers/update/{trn}?birthdate={dob.ToString("yyyy-MM-dd")}", request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             expectedErrorPropertyName,
             expectedErrorMessage);
@@ -579,7 +585,7 @@ public class UpdateTeacherTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, errorCode: 10002, expectedStatusCode: StatusCodes.Status409Conflict);
+        await AssertEx.JsonResponseIsError(response, expectedErrorCode: 10002, expectedStatusCode: StatusCodes.Status409Conflict);
     }
 
     [Fact]
@@ -629,7 +635,7 @@ public class UpdateTeacherTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, nameof(UpdateTeacherRequestInitialTeacherTraining.Outcome), StringResources.ErrorMessages_OutcomeMustBeDeferredInTrainingOrUnderAssessment);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, nameof(UpdateTeacherRequestInitialTeacherTraining.Outcome), StringResources.ErrorMessages_OutcomeMustBeDeferredInTrainingOrUnderAssessment);
     }
 
 
@@ -680,7 +686,7 @@ public class UpdateTeacherTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, nameof(UpdateTeacherRequestInitialTeacherTraining.Outcome), StringResources.ErrorMessages_InTrainingOutcomeNotValidForAssessmentOnlyRoute);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, nameof(UpdateTeacherRequestInitialTeacherTraining.Outcome), StringResources.ErrorMessages_InTrainingOutcomeNotValidForAssessmentOnlyRoute);
     }
 
     [Theory]
@@ -743,7 +749,7 @@ public class UpdateTeacherTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(response, nameof(UpdateTeacherRequestInitialTeacherTraining.Outcome), StringResources.ErrorMessages_UnderAssessmentOutcomeOnlyValidForAssessmentOnlyRoute);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, nameof(UpdateTeacherRequestInitialTeacherTraining.Outcome), StringResources.ErrorMessages_UnderAssessmentOutcomeOnlyValidForAssessmentOnlyRoute);
     }
 
     [Fact]
@@ -776,7 +782,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest());
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             $"{nameof(GetOrCreateTrnRequest.InitialTeacherTraining)}",
             StringResources.Errors_10004_Title);
@@ -806,7 +812,7 @@ public class UpdateTeacherTests : ApiTestBase
             CreateRequest());
 
         // Assert
-        await AssertEx.ResponseIsValidationErrorForProperty(
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
             response,
             $"{nameof(GetOrCreateTrnRequest.HusId)}.{nameof(GetOrCreateTrnRequest.HusId)}",
             StringResources.Errors_10018_Title);

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/CreateDateOfBirthChangeTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/CreateDateOfBirthChangeTests.cs
@@ -83,7 +83,7 @@ public class CreateDateOfBirthChangeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, 10001, StatusCodes.Status400BadRequest);
+        await AssertEx.JsonResponseIsError(response, 10001, StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class CreateDateOfBirthChangeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, 10028, StatusCodes.Status400BadRequest);
+        await AssertEx.JsonResponseIsError(response, 10028, StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/CreateNameChangeTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/CreateNameChangeTests.cs
@@ -89,7 +89,7 @@ public class CreateNameChangeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, 10001, StatusCodes.Status400BadRequest);
+        await AssertEx.JsonResponseIsError(response, 10001, StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class CreateNameChangeTests : ApiTestBase
         var response = await HttpClientWithApiKey.SendAsync(request);
 
         // Assert
-        await AssertEx.ResponseIsError(response, 10028, StatusCodes.Status400BadRequest);
+        await AssertEx.JsonResponseIsError(response, 10028, StatusCodes.Status400BadRequest);
     }
 
     [Fact]


### PR DESCRIPTION
Switch to using `System.Text.Json` like we use in the app itself and in ID.

I've ported the `AssertEx` types from ID and made a few fixes, which will be back-ported to ID.