### PR TITLE
Deploy DB changes from app's Docker container

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -4,8 +4,8 @@ inputs:
   environment_name:
     description: 'The name of the environment'
     required: true
-  docker_image:
-    description: 'The Docker image to deploy to the environment'
+  api_docker_image:
+    description: 'The API Docker image to deploy to the environment'
     required: true
   azure_credentials:
     description: 'JSON object containing a service principal that can read from Azure Key Vault'
@@ -79,7 +79,6 @@ runs:
       with:
         creds: ${{ inputs.azure_credentials }}
 
-    # get TFSTATE-CONTAINER-ACCESS-KEY
     - run: |
         TFSTATE_CONTAINER_ACCESS_KEY="$(az storage account keys list -g ${{ env.resource_group_name }} -n ${{ env.storage_account_name }} | jq -r '.[0].value')"
         echo "::add-mask::$TFSTATE_CONTAINER_ACCESS_KEY"
@@ -97,23 +96,12 @@ runs:
         terraform_version: 1.0.10
         terraform_wrapper: false
 
-    - name: Download migrations
-      uses: actions/download-artifact@v2
-      with:
-        name: migrations
-        path: migrations
-
     - uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
         CF_USERNAME: ${{ steps.get_secrets.outputs.PAAS-USER }}
         CF_PASSWORD: ${{ steps.get_secrets.outputs.PAAS-PASSWORD }}
         CF_SPACE_NAME: ${{ env.paas_space }}
         INSTALL_CONDUIT: true
-
-    - name: Set environment variables
-      shell: bash
-      run: |
-        echo "MIGRATIONS_FILE=$(realpath ./migrations/script.sql)" >> $GITHUB_ENV
 
     - name: Terraform
       id: terraform
@@ -124,7 +112,6 @@ runs:
       env:
         ARM_ACCESS_KEY: ${{ env.TFSTATE_CONTAINER_ACCESS_KEY }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
-        TF_VAR_api_docker_image: ${{ inputs.docker_image }}
+        TF_VAR_api_docker_image: ${{ inputs.api_docker_image }}
         TF_VAR_api_app_version: ${{ env.api_version }}
-        TF_VAR_migrations_file: ${{ env.MIGRATIONS_FILE }}
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     concurrency: build
 
     outputs:
-      docker_image: ${{ env.tag }}
+      api_docker_image: ${{ steps.image_tags.outputs.api_tag }}
 
     services:
       postgres:
@@ -163,36 +163,16 @@ jobs:
           -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=qtapi;Database=qtapi"
           ${{ steps.get_test_filter.outputs.filter_arg }}
 
-    # TODO Use migration bundles when https://github.com/dotnet/efcore/issues/25555 is fixed
-    - name: Generate migrations artifact
-      run: |
-        mkdir migrations
-        migrations_file=migrations/script.sql
-
-        dotnet tool install --global dotnet-ef
-        dotnet ef migrations script --idempotent --output $migrations_file --configuration Release --project src/QualifiedTeachersApi/QualifiedTeachersApi.csproj --no-build
-
-        # Remove the BOM
-        sed -i $'1s/^\uFEFF//' $migrations_file
-
-        # Ensure any errors return a non-zero exit code when migrations are applied
-        echo "$(echo "\set ON_ERROR_STOP true"; echo ""; cat $migrations_file)" > $migrations_file
-      working-directory: QualifiedTeachersApi
-
-    - name: Publish migrations
-      uses: actions/upload-artifact@v3
-      with:
-        name: migrations
-        path: QualifiedTeachersApi/migrations
-
     - name: Publish
-      run: dotnet publish --configuration Release --no-build src/QualifiedTeachersApi/QualifiedTeachersApi.csproj
+      run: |
+        dotnet publish --configuration Release --no-build src/QualifiedTeachersApi/QualifiedTeachersApi.csproj
+        dotnet publish --configuration Release --no-build src/QtCli/QtCli.csproj
       working-directory: QualifiedTeachersApi
 
-    - name: Docker image tag
-      id: image
+    - name: Get Docker image tags
+      id: image_tags
       run: |
-        echo "tag=$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):$GITHUB_SHA"  >> $GITHUB_ENV
+        echo "api_tag=$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):api-$GITHUB_SHA" >> $GITHUB_OUTPUT
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
@@ -201,12 +181,13 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Docker build & push
+    - name: API Docker build & push
       uses: docker/build-push-action@v4
       with:
-        context: QualifiedTeachersApi/src/QualifiedTeachersApi
+        context: QualifiedTeachersApi/
+        file: QualifiedTeachersApi/src/QualifiedTeachersApi/Dockerfile
         push: true
-        tags: ${{ env.tag }}
+        tags: ${{ steps.image_tags.outputs.api_tag }}
         build-args: |
           GIT_SHA=${{ github.sha }}
 
@@ -259,7 +240,7 @@ jobs:
       id: deploy
       with:
         environment_name: dev
-        docker_image: ${{ needs.build.outputs.docker_image }}
+        api_docker_image: ${{ needs.build.outputs.api_docker_image }}
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
         terraform_vars: dev.tfvars.json
         terraform_backend_vars: dev.backend.tfvars
@@ -335,7 +316,7 @@ jobs:
       id: deploy
       with:
         environment_name: test
-        docker_image: ${{ needs.build.outputs.docker_image }}
+        api_docker_image: ${{ needs.build.outputs.api_docker_image }}
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
         terraform_vars: test.tfvars.json
         terraform_backend_vars: test.backend.tfvars
@@ -360,7 +341,7 @@ jobs:
       id: deploy
       with:
         environment_name: pre-production
-        docker_image: ${{ needs.build.outputs.docker_image }}
+        api_docker_image: ${{ needs.build.outputs.api_docker_image }}
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
         terraform_vars: pre-production.tfvars.json
         terraform_backend_vars: pre-production.backend.tfvars
@@ -385,7 +366,7 @@ jobs:
       id: deploy
       with:
         environment_name: production
-        docker_image: ${{ needs.build.outputs.docker_image }}
+        api_docker_image: ${{ needs.build.outputs.api_docker_image }}
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
         terraform_vars: production.tfvars.json
         terraform_backend_vars: production.backend.tfvars

--- a/QualifiedTeachersApi/QualifiedTeachersApi.sln
+++ b/QualifiedTeachersApi/QualifiedTeachersApi.sln
@@ -14,6 +14,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QualifiedTeachersApi.TestCommon", "tests\QualifiedTeachersApi.TestCommon\QualifiedTeachersApi.TestCommon.csproj", "{DFE6654C-3222-4B20-A871-79581928D3B2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{837E2941-F1CC-41EF-A652-B605101B2E84}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{91DCFC76-6636-4AC1-B81C-7F8AE1F22116}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QtCli", "src\QtCli\QtCli.csproj", "{2956469E-A5F8-4874-BA08-DF6A166F820A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,9 +66,27 @@ Global
 		{DFE6654C-3222-4B20-A871-79581928D3B2}.Release|x64.Build.0 = Release|Any CPU
 		{DFE6654C-3222-4B20-A871-79581928D3B2}.Release|x86.ActiveCfg = Release|Any CPU
 		{DFE6654C-3222-4B20-A871-79581928D3B2}.Release|x86.Build.0 = Release|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Debug|x64.Build.0 = Debug|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Debug|x86.Build.0 = Debug|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Release|x64.ActiveCfg = Release|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Release|x64.Build.0 = Release|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Release|x86.ActiveCfg = Release|Any CPU
+		{2956469E-A5F8-4874-BA08-DF6A166F820A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{051023DD-EAFE-4CDF-B4B0-ECF3C0AFDEF4} = {837E2941-F1CC-41EF-A652-B605101B2E84}
+		{963D2704-ADB2-4A7F-9B96-0C09D657D5F6} = {91DCFC76-6636-4AC1-B81C-7F8AE1F22116}
+		{DFE6654C-3222-4B20-A871-79581928D3B2} = {91DCFC76-6636-4AC1-B81C-7F8AE1F22116}
+		{2956469E-A5F8-4874-BA08-DF6A166F820A} = {837E2941-F1CC-41EF-A652-B605101B2E84}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {61D239F9-888B-4D01-84BC-9276C92383EA}

--- a/QualifiedTeachersApi/src/QtCli/Program.cs
+++ b/QualifiedTeachersApi/src/QtCli/Program.cs
@@ -1,0 +1,44 @@
+﻿using System.CommandLine;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using QualifiedTeachersApi.DataStore.Sql;
+
+var configuration = new ConfigurationBuilder()
+    .AddUserSecrets("QualifiedTeachersApi")
+    .Build();
+
+var rootCommand = new RootCommand("Development tools for the Qualified Teachers API.")
+{
+    CreateMigrateDbCommand()
+};
+
+return await rootCommand.InvokeAsync(args);
+
+Command CreateMigrateDbCommand()
+{
+    var connectionStringOption = new Option<string>("--connection-string")
+    {
+        IsRequired = true
+    };
+
+    var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
+    if (configuredConnectionString is not null)
+    {
+        connectionStringOption.SetDefaultValue(configuredConnectionString);
+    }
+
+    var migrateDbCommand = new Command("migrate-db", "Migrate the database to the latest version.")
+    {
+        connectionStringOption
+    };
+
+    migrateDbCommand.SetHandler(
+        async (string connectionString) =>
+        {
+            using var dbContext = new DqtContext(connectionString);
+            await dbContext.Database.MigrateAsync();
+        },
+        connectionStringOption);
+
+    return migrateDbCommand;
+}

--- a/QualifiedTeachersApi/src/QtCli/QtCli.csproj
+++ b/QualifiedTeachersApi/src/QtCli/QtCli.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" /> <!-- Fixes build warning -->
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QualifiedTeachersApi\QualifiedTeachersApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Dockerfile
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Dockerfile
@@ -2,12 +2,15 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
 ARG GIT_SHA
 ENV GitSha ${GIT_SHA}
-COPY bin/Release/net7.0/publish/ App/
+COPY src/QualifiedTeachersApi/bin/Release/net7.0/publish/ App/
+COPY src/QtCli/bin/Release/net7.0/publish/ QtCli/
 WORKDIR /App
 
 # install required fonts for PdfSharpCore
 RUN sed -i'.bak' 's/$/ contrib/' /etc/apt/sources.list
 RUN apt-get update; apt-get install -y ttf-mscorefonts-installer fontconfig
 
-ENTRYPOINT ["dotnet", "QualifiedTeachersApi.dll"]
+RUN apt-get install -y jq
+
+ENTRYPOINT ["/bin/bash", "entrypoint.sh"]
 EXPOSE 80

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/QualifiedTeachersApi.csproj
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/QualifiedTeachersApi.csproj
@@ -63,4 +63,10 @@
     <Using Include="QualifiedTeachersApi.DataStore.Crm.Models.Task" Alias="CrmTask" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="entrypoint.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/entrypoint.sh
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+if [ "$CF_INSTANCE_INDEX" == "0" ]; then
+  HOST=$(echo "$VCAP_SERVICES" | jq -r '.postgres[0].credentials.host')
+  DATABASE=$(echo "$VCAP_SERVICES" | jq -r '.postgres[0].credentials.name')
+  USERNAME=$(echo "$VCAP_SERVICES" | jq -r '.postgres[0].credentials.username')
+  PASSWORD=$(echo "$VCAP_SERVICES" | jq -r '.postgres[0].credentials.password')
+  PORT=$(echo "$VCAP_SERVICES" | jq -r '.postgres[0].credentials.port')
+
+  CONNECTION_STRING="Host=$HOST;Database=$DATABASE;Username=$USERNAME;Password='$PASSWORD';Port=$PORT;SslMode=Require;TrustServerCertificate=true"
+
+  echo "Applying database migrations..."
+  dotnet /QtCli/QtCli.dll migrate-db --connection-string "$CONNECTION_STRING"
+  echo "Done applying database migrations"
+fi
+
+dotnet /App/QualifiedTeachersApi.dll

--- a/terraform/api-app.tf
+++ b/terraform/api-app.tf
@@ -60,21 +60,6 @@ resource "azurerm_application_insights" "api_app_insights" {
   application_type    = "web"
 }
 
-resource "null_resource" "migrations" {
-  count = var.migrations_file == "" ? 0 : 1
-  triggers = {
-    migrations = "${sha1(file(var.migrations_file))}"
-  }
-
-  provisioner "local-exec" {
-    command = "cf target -s ${var.paas_space} && cf conduit ${cloudfoundry_service_instance.postgres.name} -- psql -f ${var.migrations_file}"
-  }
-
-  depends_on = [
-    cloudfoundry_service_instance.postgres
-  ]
-}
-
 resource "cloudfoundry_service_instance" "redis" {
   name         = var.redis_name
   space        = data.cloudfoundry_space.space.id
@@ -112,7 +97,6 @@ resource "cloudfoundry_app" "api" {
   }
 
   depends_on = [
-    null_resource.migrations,
     azurerm_application_insights.api_app_insights
   ]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -89,11 +89,6 @@ variable "redis_service_plan" {
   default = "tiny-6_x"
 }
 
-variable "migrations_file" {
-  type    = string
-  default = ""
-}
-
 variable "statuscake_alerts" {
   type = map(any)
 }


### PR DESCRIPTION
Adds the beginnings of a new CLI app with DB migration the only support command for now.

Bundles this CLI tool with the API app itself and adds an entrypoint.sh script that deploys the DB changes from the app's container instead of via Terraform.

This tool will be extended in future for both the AKS migration (to run migrations from an init container, perhaps) and also to deploy changes to the MSSQL reporting DB.