### PR TITLE
Added code to receive user created messages via webhook

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Json/JsonSerializerOptionsExtensions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Json/JsonSerializerOptionsExtensions.cs
@@ -9,6 +9,7 @@ public static class JsonSerializerOptionsExtensions
     public static JsonSerializerOptions AddConverters(this JsonSerializerOptions options)
     {
         options.Converters.Add(new JsonStringEnumConverter());
+        options.Converters.Add(new NotificationEnvelopeConverter());
 
         return options;
     }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Json/NotificationEnvelopeConverter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Json/NotificationEnvelopeConverter.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using QualifiedTeachersApi.Services.GetAnIdentity.WebHooks;
+
+namespace QualifiedTeachersApi.Infrastructure.Json;
+
+public class NotificationEnvelopeConverter : JsonConverter<NotificationEnvelope>
+{
+    public override NotificationEnvelope? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException();
+        }
+
+        Guid? notificationId = null;
+        DateTime? timeUtc = null;
+        string? messageType = null;
+        INotificationMessage? message = null;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                if (!notificationId.HasValue)
+                {
+                    throw new JsonException($"Missing required property {nameof(NotificationEnvelope.NotificationId)}");
+                }
+
+                if (!timeUtc.HasValue)
+                {
+                    throw new JsonException($"Missing required property {nameof(NotificationEnvelope.TimeUtc)}");
+                }
+
+                if (string.IsNullOrEmpty(messageType))
+                {
+                    throw new JsonException($"Missing required property {nameof(NotificationEnvelope.MessageType)}");
+                }
+
+                if (message is null)
+                {
+                    throw new JsonException($"Missing required property {nameof(NotificationEnvelope.Message)}");
+                }
+
+                return new NotificationEnvelope()
+                {
+                    NotificationId = notificationId.Value,
+                    TimeUtc = timeUtc.Value,
+                    MessageType = messageType!,
+                    Message = message!
+                };
+            }
+
+            if (reader.TokenType == JsonTokenType.PropertyName)
+            {
+                var propertyName = reader.GetString();
+                if (string.IsNullOrWhiteSpace(propertyName))
+                {
+                    throw new JsonException("Failed to get property name");
+                }
+
+                reader.Read();
+
+                var caseInsensitive = options.PropertyNameCaseInsensitive;          
+
+                if (propertyName.Equals(nameof(NotificationEnvelope.NotificationId), caseInsensitive ? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture))
+                {
+                    if (reader.TryGetGuid(out var validValue))
+                    {
+                        notificationId = validValue;
+                    }
+                    else
+                    {
+                        throw new JsonException($"Value for {nameof(NotificationEnvelope.NotificationId)} cannot be deserialized to a {typeof(System.Guid).FullName}");
+                    }                    
+                }
+                else if (propertyName.Equals(nameof(NotificationEnvelope.TimeUtc), caseInsensitive ? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture))
+                {
+                    if (reader.TryGetDateTime(out var validValue))
+                    {
+                        timeUtc = validValue;
+                    }
+                    else
+                    {
+                        throw new JsonException($"Value for {nameof(NotificationEnvelope.TimeUtc)} cannot be deserialized to a {typeof(System.DateTime).FullName}");
+                    }
+                }
+                else if (propertyName.Equals(nameof(NotificationEnvelope.MessageType), caseInsensitive ? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture))
+                {
+                    messageType = reader.GetString();
+                }
+                else if (propertyName.Equals(nameof(NotificationEnvelope.Message), caseInsensitive ? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture))
+                {
+                    if (string.IsNullOrEmpty(messageType))
+                    {
+                        throw new JsonException($"Cannot deserialize {nameof(NotificationEnvelope.Message)} property with missing {nameof(NotificationEnvelope.MessageType)}");
+                    }
+
+                    switch (messageType)
+                    {
+                        case UserCreatedMessage.MessageTypeName:
+                            message = JsonSerializer.Deserialize<UserCreatedMessage>(ref reader, options);
+                            break;
+                        case UserUpdatedMessage.MessageTypeName:
+                            message = JsonSerializer.Deserialize<UserUpdatedMessage>(ref reader, options);
+                            break;
+                        default:
+                            throw new JsonException($"{nameof(NotificationEnvelope.MessageType)} '{messageType}' is not supported");
+                    }
+                }
+            }
+        }
+
+        throw new JsonException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, NotificationEnvelope value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, options);
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Json/NotificationEnvelopeConverter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Json/NotificationEnvelopeConverter.cs
@@ -62,7 +62,7 @@ public class NotificationEnvelopeConverter : JsonConverter<NotificationEnvelope>
 
                 reader.Read();
 
-                var caseInsensitive = options.PropertyNameCaseInsensitive;          
+                var caseInsensitive = options.PropertyNameCaseInsensitive;
 
                 if (propertyName.Equals(nameof(NotificationEnvelope.NotificationId), caseInsensitive ? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture))
                 {
@@ -73,7 +73,7 @@ public class NotificationEnvelopeConverter : JsonConverter<NotificationEnvelope>
                     else
                     {
                         throw new JsonException($"Value for {nameof(NotificationEnvelope.NotificationId)} cannot be deserialized to a {typeof(System.Guid).FullName}");
-                    }                    
+                    }
                 }
                 else if (propertyName.Equals(nameof(NotificationEnvelope.TimeUtc), caseInsensitive ? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture))
                 {

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/INotificationMessage.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/INotificationMessage.cs
@@ -1,0 +1,5 @@
+﻿namespace QualifiedTeachersApi.Services.GetAnIdentity.WebHooks;
+
+public interface INotificationMessage
+{
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/NotificationEnvelope.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/NotificationEnvelope.cs
@@ -7,5 +7,5 @@ public record NotificationEnvelope
     public required Guid NotificationId { get; init; }
     public required DateTime TimeUtc { get; init; }
     public required string MessageType { get; init; }
-    public required object Message { get; init; }
+    public required INotificationMessage Message { get; init; }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/UserCreatedHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/UserCreatedHandler.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+
+namespace QualifiedTeachersApi.Services.GetAnIdentity.WebHooks;
+
+public class UserCreatedHandler : IRequestHandler<UserCreatedRequest>
+{
+    private static readonly TimeSpan _lockTimeout = TimeSpan.FromMinutes(1);
+
+    private readonly IDataverseAdapter _dataverseAdapter;
+    private readonly IDistributedLockService _distributedLockService;
+    private readonly ILogger<UserCreatedHandler> _logger;
+
+    public UserCreatedHandler(
+        IDataverseAdapter dataverseAdapter,
+        IDistributedLockService distributedLockService,
+        ILogger<UserCreatedHandler> logger)
+    {
+        _dataverseAdapter = dataverseAdapter;
+        _distributedLockService = distributedLockService;
+        _logger = logger;
+    }
+
+    public async Task Handle(UserCreatedRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Trn is null)
+        {
+            return;
+        }
+
+        await using var trnLock = await _distributedLockService.AcquireLock(request.Trn, _lockTimeout);
+
+        var teacher = await _dataverseAdapter.GetTeacherByTrn(
+            request.Trn,
+            columnNames: new[]
+            {
+                Contact.Fields.dfeta_TRN,
+                Contact.Fields.dfeta_TSPersonID,
+                Contact.Fields.EMailAddress1,
+                Contact.Fields.MobilePhone,
+                Contact.Fields.dfeta_LastIdentityUpdate
+            });
+
+        if (teacher == null)
+        {
+            _logger.LogWarning("No active contact record found for TRN {trn}", request.Trn);
+            return;
+        }
+
+        if (request.UpdateTimeUtc > (teacher.dfeta_LastIdentityUpdate ?? DateTime.MinValue))
+        {
+            await _dataverseAdapter.UpdateTeacherIdentityInfo(new UpdateTeacherIdentityInfoCommand()
+            {
+                TeacherId = teacher.Id,
+                IdentityUserId = request.UserId,
+                EmailAddress = request.EmailAddress,
+                MobilePhone = request.MobileNumber,
+                UpdateTimeUtc = request.UpdateTimeUtc
+            });
+        }
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/UserCreatedMessage.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/UserCreatedMessage.cs
@@ -1,8 +1,8 @@
 ﻿namespace QualifiedTeachersApi.Services.GetAnIdentity.WebHooks;
 
-public record UserUpdatedMessage : INotificationMessage
+public record UserCreatedMessage : INotificationMessage
 {
-    public const string MessageTypeName = "UserUpdated";
+    public const string MessageTypeName = "UserCreated";
 
     public required User User { get; init; }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/UserCreatedRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/GetAnIdentity/WebHooks/UserCreatedRequest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using MediatR;
+
+namespace QualifiedTeachersApi.Services.GetAnIdentity.WebHooks;
+
+public class UserCreatedRequest : IRequest
+{
+    public required Guid UserId { get; set; }
+    public required string? Trn { get; init; }
+    public required string EmailAddress { get; set; }
+    public required string? MobileNumber { get; set; }
+    public required DateTime UpdateTimeUtc { get; set; }
+}


### PR DESCRIPTION
### Context

We’re adding a new web hook message type for when users are created. We need to handle this and update the corresponding DQT record in the same way we do for the UserUpdated messages.

### Changes proposed in this pull request

Change to webhook receiver endpoint and additional handler for user created messages.

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
