### PR TITLE
Add tooling to upgrade the reporting DB schema

### DIFF
--- a/QualifiedTeachersApi/src/QtCli/Commands.MigrateDb.cs
+++ b/QualifiedTeachersApi/src/QtCli/Commands.MigrateDb.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore;
+using QualifiedTeachersApi.DataStore.Sql;
+
+namespace QtCli;
+
+public static partial class Commands
+{
+    public static Command CreateMigrateDbCommand(IConfiguration configuration)
+    {
+        var connectionStringOption = new Option<string>("--connection-string")
+        {
+            IsRequired = true
+        };
+
+        var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
+        if (configuredConnectionString is not null)
+        {
+            connectionStringOption.SetDefaultValue(configuredConnectionString);
+        }
+
+        var migrateDbCommand = new Command("migrate-db", "Migrate the database to the latest version.")
+        {
+            connectionStringOption
+        };
+
+        migrateDbCommand.SetHandler(
+            async (string connectionString) =>
+            {
+                using var dbContext = new DqtContext(connectionString);
+                await dbContext.Database.MigrateAsync();
+            },
+            connectionStringOption);
+
+        return migrateDbCommand;
+    }
+}

--- a/QualifiedTeachersApi/src/QtCli/Commands.MigrateReportingDb.cs
+++ b/QualifiedTeachersApi/src/QtCli/Commands.MigrateReportingDb.cs
@@ -1,0 +1,35 @@
+﻿using QualifiedTeachersApi.Services.DqtReporting;
+
+namespace QtCli;
+
+public static partial class Commands
+{
+    public static Command CreateMigrateReportingDbCommand(IConfiguration configuration)
+    {
+        var connectionStringOption = new Option<string>("--connection-string")
+        {
+            IsRequired = true
+        };
+
+        var configuredConnectionString = configuration["DqtReporting:ReportingDbConnectionString"];
+        if (configuredConnectionString is not null)
+        {
+            connectionStringOption.SetDefaultValue(configuredConnectionString);
+        }
+
+        var migrateDbCommand = new Command("migrate-reporting-db", "Migrate the SQL Server reporting database to the latest version.")
+        {
+            connectionStringOption
+        };
+
+        migrateDbCommand.SetHandler(
+            (string connectionString) =>
+            {
+                var migrator = new Migrator(connectionString);
+                migrator.MigrateDb();
+            },
+            connectionStringOption);
+
+        return migrateDbCommand;
+    }
+}

--- a/QualifiedTeachersApi/src/QtCli/Commands.ResetReportingDbJournal.cs
+++ b/QualifiedTeachersApi/src/QtCli/Commands.ResetReportingDbJournal.cs
@@ -1,0 +1,35 @@
+﻿using QualifiedTeachersApi.Services.DqtReporting;
+
+namespace QtCli;
+
+public static partial class Commands
+{
+    public static Command CreateResetReportingDbJournalCommand(IConfiguration configuration)
+    {
+        var connectionStringOption = new Option<string>("--connection-string")
+        {
+            IsRequired = true
+        };
+
+        var configuredConnectionString = configuration["DqtReporting:ReportingDbConnectionString"];
+        if (configuredConnectionString is not null)
+        {
+            connectionStringOption.SetDefaultValue(configuredConnectionString);
+        }
+
+        var migrateDbCommand = new Command("reset-reporting-db-journal", "Reset the migrations journal table to Initial.sql.")
+        {
+            connectionStringOption
+        };
+
+        migrateDbCommand.SetHandler(
+            (string connectionString) =>
+            {
+                var migrator = new Migrator(connectionString);
+                migrator.ResetJournal("Initial.sql");
+            },
+            connectionStringOption);
+
+        return migrateDbCommand;
+    }
+}

--- a/QualifiedTeachersApi/src/QtCli/Program.cs
+++ b/QualifiedTeachersApi/src/QtCli/Program.cs
@@ -1,7 +1,6 @@
-﻿using System.CommandLine;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using QualifiedTeachersApi.DataStore.Sql;
+﻿global using System.CommandLine;
+global using Microsoft.Extensions.Configuration;
+using QtCli;
 
 var configuration = new ConfigurationBuilder()
     .AddUserSecrets("QualifiedTeachersApi")
@@ -9,36 +8,9 @@ var configuration = new ConfigurationBuilder()
 
 var rootCommand = new RootCommand("Development tools for the Qualified Teachers API.")
 {
-    CreateMigrateDbCommand()
+    Commands.CreateMigrateDbCommand(configuration),
+    Commands.CreateMigrateReportingDbCommand(configuration),
+    Commands.CreateResetReportingDbJournalCommand(configuration),
 };
 
 return await rootCommand.InvokeAsync(args);
-
-Command CreateMigrateDbCommand()
-{
-    var connectionStringOption = new Option<string>("--connection-string")
-    {
-        IsRequired = true
-    };
-
-    var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
-    if (configuredConnectionString is not null)
-    {
-        connectionStringOption.SetDefaultValue(configuredConnectionString);
-    }
-
-    var migrateDbCommand = new Command("migrate-db", "Migrate the database to the latest version.")
-    {
-        connectionStringOption
-    };
-
-    migrateDbCommand.SetHandler(
-        async (string connectionString) =>
-        {
-            using var dbContext = new DqtContext(connectionString);
-            await dbContext.Database.MigrateAsync();
-        },
-        connectionStringOption);
-
-    return migrateDbCommand;
-}

--- a/QualifiedTeachersApi/src/QtCli/Properties/launchSettings.json
+++ b/QualifiedTeachersApi/src/QtCli/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "migrate-db": {
+      "commandName": "Project",
+      "commandLineArgs": "migrate-db"
+    },
+    "migrate-reporting-db": {
+      "commandName": "Project",
+      "commandLineArgs": "migrate-reporting-db"
+    },
+    "reset-reporting-db-journal": {
+      "commandName": "Project",
+      "commandLineArgs": "reset-reporting-db-journal"
+    }
+  }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/QualifiedTeachersApi.csproj
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/QualifiedTeachersApi.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="6.0.4" />
     <PackageReference Include="AspNetCoreRateLimit.Redis" Version="1.0.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
     <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
@@ -67,6 +68,10 @@
     <None Update="entrypoint.sh">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\*.sql" />
   </ItemGroup>
 
 </Project>

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/Migrator.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/Migrator.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using DbUp;
+using DbUp.Engine;
+using DbUp.Engine.Output;
+using DbUp.Engine.Transactions;
+using DbUp.ScriptProviders;
+using Microsoft.Extensions.Logging;
+
+namespace QualifiedTeachersApi.Services.DqtReporting;
+
+public class Migrator
+{
+    private readonly UpgradeEngine _upgradeEngine;
+
+    public Migrator(string connectionString, ILogger? logger = null)
+    {
+        var builder = DeployChanges.To
+            .SqlDatabase(connectionString)
+            .LogScriptOutput()
+            .WithTransaction()
+            .JournalToSqlTable("dbo", "__SchemaVersions")
+            .WithScripts(new DqtReportingMigrationsScriptProvider());
+
+        if (logger is not null)
+        {
+            builder.LogTo(new LoggerUpgradeLogWrapper(logger));
+        }
+        else
+        {
+            builder.LogToConsole();
+        }
+
+        _upgradeEngine = builder.Build();
+    }
+
+    public void MigrateDb()
+    {
+        var upgradeResult = _upgradeEngine.PerformUpgrade();
+
+        if (!upgradeResult.Successful)
+        {
+            throw upgradeResult.Error;
+        }
+    }
+
+    public void ResetJournal(string migrationName)
+    {
+        var upgradeResult = _upgradeEngine.MarkAsExecuted(migrationName);
+
+        if (!upgradeResult.Successful)
+        {
+            throw upgradeResult.Error;
+        }
+    }
+
+    private class LoggerUpgradeLogWrapper : IUpgradeLog
+    {
+        private readonly ILogger _logger;
+
+        public LoggerUpgradeLogWrapper(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void WriteError(string format, params object[] args)
+        {
+            _logger.LogError(format, args);
+        }
+
+        public void WriteInformation(string format, params object[] args)
+        {
+            _logger.LogInformation(format, args);
+        }
+
+        public void WriteWarning(string format, params object[] args)
+        {
+            _logger.LogWarning(format, args);
+        }
+    }
+
+    private class DqtReportingMigrationsScriptProvider : IScriptProvider
+    {
+        public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
+        {
+            var innerProvider = new EmbeddedScriptProvider(
+                typeof(Migrator).Assembly,
+                filter: name => name.Contains(".DqtReporting.Migrations.") && name.EndsWith(".sql"),
+                Encoding.UTF8);
+
+            var scripts = innerProvider.GetScripts(connectionManager);
+
+            return scripts.Select(s => new SqlScript(Path.GetFileName(RemoveNamespaceFromScriptName(s.Name)), s.Contents));
+
+            static string RemoveNamespaceFromScriptName(string name) =>
+                name[(name.IndexOf("Migrations") + "Migrations".Length + 1)..];
+        }
+    }
+}


### PR DESCRIPTION
Since we're inheriting an existing schema, using SQL scripts is going to be the simplest way for performing updates. This adds DbUp and some tooling around it to update the DB.

In addition, there's another command to update DbUp's journal table to mark `Initial.sql` is applied; we will need this when we roll the process out onto the existing databases since they'll already have this schema in place.