### PR TITLE
Base DQT reporting service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,10 @@ jobs:
     outputs:
       api_docker_image: ${{ steps.image_tags.outputs.api_tag }}
 
+    env:
+      MSSQL_DB: dqtreports
+      MSSQL_PASSWORD: SuperS3cretPassw0rd
+
     services:
       postgres:
         image: postgres
@@ -54,6 +58,19 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: ${{ env.MSSQL_PASSWORD }}
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -Q 'select 1' -b -o /dev/null"
+          --health-interval 60s
+          --health-timeout 30s
+          --health-start-period 20s
+          --health-retries 3
 
     steps:
     - uses: actions/checkout@v3
@@ -155,6 +172,9 @@ jobs:
         SKIP_DATAVERSE_TESTS: ${{ github.event.inputs.skip_dataverse_tests }}
       shell: bash
 
+    - name: Create test reporting database
+      run: docker exec $(docker ps --latest --quiet) /opt/mssql-tools/bin/sqlcmd -U "sa" -P "$MSSQL_PASSWORD" -Q "create database $MSSQL_DB; alter database $MSSQL_DB set ALLOW_SNAPSHOT_ISOLATION on;"
+
     - name: Tests
       uses: ./.github/workflows/actions/test
       if: github.event_name != 'push'
@@ -162,14 +182,15 @@ jobs:
         test_project_path: QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests
         report_name: "Test results"
         dotnet_test_args: >-
-          -e IntegrationTests_CrmUrl="${{ env.INTEGRATIONTESTS_CRMURL }}"
-          -e IntegrationTests_CrmClientId="${{ env.INTEGRATIONTESTS_CRMCLIENTID }}"
-          -e IntegrationTests_CrmClientSecret="${{ env.INTEGRATIONTESTS_CRMCLIENTSECRET }}"
-          -e IntegrationTests_BuildEnvLockBlobUri="${{ env.INTEGRATIONTESTS_BUILDENVLOCKBLOBURI }}"
-          -e IntegrationTests_BuildEnvLockBlobSasToken="${{ env.INTEGRATIONTESTS_BUILDENVLOCKBLOBSASTOKEN }}"
-          -e IntegrationTests_TrnGenerationApi__BaseAddress="${{ env.INTEGRATIONTESTS_BUILDENVTRNGENERATIONAPIBASEADDRESS }}"
-          -e IntegrationTests_TrnGenerationApi__ApiKey="${{ env.INTEGRATIONTESTS_BUILDENVTRNGENERATIONAPIAPIKEY }}"
+          -e CrmUrl="${{ env.INTEGRATIONTESTS_CRMURL }}"
+          -e CrmClientId="${{ env.INTEGRATIONTESTS_CRMCLIENTID }}"
+          -e CrmClientSecret="${{ env.INTEGRATIONTESTS_CRMCLIENTSECRET }}"
+          -e BuildEnvLockBlobUri="${{ env.INTEGRATIONTESTS_BUILDENVLOCKBLOBURI }}"
+          -e BuildEnvLockBlobSasToken="${{ env.INTEGRATIONTESTS_BUILDENVLOCKBLOBSASTOKEN }}"
+          -e TrnGenerationApi__BaseAddress="${{ env.INTEGRATIONTESTS_BUILDENVTRNGENERATIONAPIBASEADDRESS }}"
+          -e TrnGenerationApi__ApiKey="${{ env.INTEGRATIONTESTS_BUILDENVTRNGENERATIONAPIAPIKEY }}"
           -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=qtapi;Database=qtapi"
+          -e DqtReporting__ReportingDbConnectionString="Data Source=(local); Initial Catalog=${{ env.MSSQL_DB }}; User=sa; Password=${{ env.MSSQL_PASSWORD }}; TrustServerCertificate=True"
           ${{ steps.get_test_filter.outputs.filter_arg }}
 
     - name: Publish

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
 using QualifiedTeachersApi.DataStore.Crm.Models;
 using QualifiedTeachersApi.Services.TrnGenerationApi;
@@ -1188,6 +1189,17 @@ public partial class DataverseAdapter : IDataverseAdapter
         var result = await _service.RetrieveMultipleAsync(query);
 
         return result.Entities.Select(e => e.ToEntity<Incident>()).ToArray();
+    }
+
+    public async Task<EntityMetadata> GetEntityMetadata(string entityLogicalName, EntityFilters entityFilters = EntityFilters.Default)
+    {
+        var entityResponse = (RetrieveEntityResponse)await _service.ExecuteAsync(new RetrieveEntityRequest()
+        {
+            LogicalName = entityLogicalName,
+            EntityFilters = entityFilters
+        });
+
+        return entityResponse.EntityMetadata;
     }
 
     public RequestBuilder CreateMultipleRequestBuilder() => RequestBuilder.CreateMultiple(_service);

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Threading.Tasks;
+using Microsoft.Xrm.Sdk.Metadata;
 using QualifiedTeachersApi.DataStore.Crm.Models;
 
 namespace QualifiedTeachersApi.DataStore.Crm;
@@ -89,4 +90,6 @@ public interface IDataverseAdapter
     Task<Subject> GetSubjectByTitle(string title, string[] columnNames);
 
     Task<Incident[]> GetIncidentsByContactId(Guid contactId, IncidentState? state, string[] columnNames);
+
+    Task<EntityMetadata> GetEntityMetadata(string entityLogicalName, EntityFilters entityFilters = EntityFilters.Default);
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Program.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Program.cs
@@ -38,6 +38,7 @@ using QualifiedTeachersApi.Infrastructure.Swagger;
 using QualifiedTeachersApi.Services;
 using QualifiedTeachersApi.Services.Certificates;
 using QualifiedTeachersApi.Services.CrmEntityChanges;
+using QualifiedTeachersApi.Services.DqtReporting;
 using QualifiedTeachersApi.Services.GetAnIdentityApi;
 using QualifiedTeachersApi.Services.TrnGenerationApi;
 using QualifiedTeachersApi.Validation;
@@ -255,6 +256,7 @@ public class Program
         services.AddIdentityApi(configuration, env);
         services.AddCertificateGeneration(builder.Configuration);
         services.AddCrmEntityChanges();
+        services.AddDqtReporting(builder.Configuration, env);
 
         if (env.EnvironmentName != "Testing")
         {

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/CrmEntityChanges/DataverseCrmEntityChangesService.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/CrmEntityChanges/DataverseCrmEntityChangesService.cs
@@ -9,12 +9,12 @@ using QualifiedTeachersApi.DataStore.Sql;
 
 namespace QualifiedTeachersApi.Services.CrmEntityChanges;
 
-public class CrmEntityChangesService : ICrmEntityChangesService
+public class DataverseCrmEntityChangesService : ICrmEntityChangesService
 {
     private readonly IDbContextFactory<DqtContext> _dbContextFactory;
     private readonly IOrganizationServiceAsync _organizationService;
 
-    public CrmEntityChangesService(IDbContextFactory<DqtContext> dbContextFactory, IOrganizationServiceAsync organizationService)
+    public DataverseCrmEntityChangesService(IDbContextFactory<DqtContext> dbContextFactory, IOrganizationServiceAsync organizationService)
     {
         _dbContextFactory = dbContextFactory;
         _organizationService = organizationService;
@@ -23,7 +23,7 @@ public class CrmEntityChangesService : ICrmEntityChangesService
     public async IAsyncEnumerable<IChangedItem[]> GetEntityChanges(
         string key,
         string entityLogicalName,
-        int pageSize = 1000,
+        int pageSize,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/CrmEntityChanges/ServiceCollectionExtensions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/CrmEntityChanges/ServiceCollectionExtensions.cs
@@ -6,7 +6,7 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddCrmEntityChanges(this IServiceCollection services)
     {
-        services.AddSingleton<ICrmEntityChangesService, CrmEntityChangesService>();
+        services.AddSingleton<ICrmEntityChangesService, DataverseCrmEntityChangesService>();
 
         return services;
     }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/DqtReportingOptions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/DqtReportingOptions.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace QualifiedTeachersApi.Services.DqtReporting;
+
+public class DqtReportingOptions
+{
+    [Required]
+    public required int PollIntervalSeconds { get; set; }
+
+    [Required]
+    public required string[] Entities { get; set; }
+
+    [Required]
+    public required string ReportingDbConnectionString { get; set; }
+
+    [Required]
+    public required bool ProcessAllEntityTypesConcurrently { get; set; }
+
+    [Required]
+    public required bool RunService { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/DqtReportingService.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/DqtReportingService.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Metadata;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.Services.CrmEntityChanges;
+
+namespace QualifiedTeachersApi.Services.DqtReporting;
+
+public class DqtReportingService : BackgroundService
+{
+    private const string ChangesKey = "DqtReporting";
+    private const string IdColumnName = "Id";
+
+    private readonly DqtReportingOptions _options;
+    private readonly ICrmEntityChangesService _crmEntityChangesService;
+    private readonly IDataverseAdapter _dataverseAdapter;
+    private readonly ILogger<DqtReportingService> _logger;
+    private readonly Dictionary<string, EntityMetadata> _entityMetadata = new();
+
+    public DqtReportingService(
+        IOptions<DqtReportingOptions> optionsAccessor,
+        ICrmEntityChangesService crmEntityChangesService,
+        IDataverseAdapter dataverseAdapter,
+        ILogger<DqtReportingService> logger)
+    {
+        _options = optionsAccessor.Value;
+        _crmEntityChangesService = crmEntityChangesService;
+        _dataverseAdapter = dataverseAdapter;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await LoadEntityMetadata();
+
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(_options.PollIntervalSeconds));
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                await ProcessChanges(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed polling for entity changes.");
+            }
+        }
+    }
+
+    internal async Task LoadEntityMetadata()
+    {
+        foreach (var entity in _options.Entities)
+        {
+            var entityMetadata = await _dataverseAdapter.GetEntityMetadata(entity, EntityFilters.Default | EntityFilters.Attributes);
+
+            if (entityMetadata.ChangeTrackingEnabled != true)
+            {
+                throw new Exception($"Entity '{entity}' does not have change tracking enabled.");
+            }
+
+            _entityMetadata[entity] = entityMetadata;
+        }
+    }
+
+    internal Task ProcessChanges(CancellationToken cancellationToken) =>
+        Parallel.ForEachAsync(
+            _options.Entities,
+            new ParallelOptions()
+            {
+                MaxDegreeOfParallelism = _options.ProcessAllEntityTypesConcurrently ? _options.Entities.Length : 1,
+                CancellationToken = cancellationToken
+            },
+            (entityType, ct) => new ValueTask(ProcessChangesForEntityType(entityType, ct)));
+
+    internal async Task ProcessChangesForEntityType(string entityLogicalName, CancellationToken cancellationToken)
+    {
+        await foreach (var changes in _crmEntityChangesService.GetEntityChanges(ChangesKey, entityLogicalName).WithCancellation(cancellationToken))
+        {
+            var newOrUpdatedItems = new List<NewOrUpdatedItem>();
+            var removedOrDeletedItems = new List<RemovedOrDeletedItem>();
+
+            foreach (var change in changes)
+            {
+                if (change is NewOrUpdatedItem newOrUpdatedItem)
+                {
+                    newOrUpdatedItems.Add(newOrUpdatedItem);
+                }
+                else if (change is RemovedOrDeletedItem removedOrDeletedItem)
+                {
+                    removedOrDeletedItems.Add(removedOrDeletedItem);
+                }
+                else
+                {
+                    throw new Exception($"Received unknown change type: '{change.GetType().Name}'.");
+                }
+            }
+
+            await HandleNewOrUpdatedItems(newOrUpdatedItems, cancellationToken);
+            await HandleRemovedOrDeletedItems(removedOrDeletedItems, cancellationToken);
+        }
+    }
+
+    private async Task HandleNewOrUpdatedItems(
+        IReadOnlyCollection<NewOrUpdatedItem> newOrUpdatedItems,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (newOrUpdatedItems.Count == 0)
+        {
+            return;
+        }
+
+        var entityLogicalName = newOrUpdatedItems.First().NewOrUpdatedEntity.LogicalName;
+        var entities = newOrUpdatedItems.Select(e => e.NewOrUpdatedEntity);
+
+        foreach (var entity in entities)
+        {
+            var command = CreateUpsertRowCommand(entity);
+            await ExecuteCommand(command, cancellationToken);
+        }
+    }
+
+    private async Task HandleRemovedOrDeletedItems(
+        IReadOnlyCollection<RemovedOrDeletedItem> removedOrDeletedItems,
+        CancellationToken cancellationToken)
+    {
+        if (removedOrDeletedItems.Count == 0)
+        {
+            return;
+        }
+
+        var entityLogicalName = removedOrDeletedItems.First().RemovedItem.LogicalName;
+        var ids = removedOrDeletedItems.Select(e => e.RemovedItem.Id).ToArray();
+
+        var command = CreateDeleteRowsCommand(entityLogicalName, ids);
+        await ExecuteCommand(command, cancellationToken);
+    }
+
+    private async Task ExecuteCommand(SqlCommand command, CancellationToken cancellationToken)
+    {
+        using var conn = new SqlConnection(_options.ReportingDbConnectionString);
+        await conn.OpenAsync();
+
+        command.Connection = conn;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private SqlCommand CreateDeleteRowsCommand(string entityLogicalName, IReadOnlyCollection<Guid> ids)
+    {
+        var tableName = entityLogicalName;
+        var idParameters = ids.Select((id, i) => new SqlParameter($"@id{i}", id)).ToArray();
+
+        var command = new SqlCommand(
+            $"delete from [{tableName}] where [{IdColumnName}] in ({string.Join(", ", idParameters.Select(p => $"{p.ParameterName}"))})");
+
+        command.Parameters.AddRange(idParameters);
+
+        return command;
+    }
+
+    private SqlCommand CreateUpsertRowCommand(Entity entity)
+    {
+        var entityMetadata = _entityMetadata[entity.LogicalName];
+        var tableName = entityMetadata.LogicalName;
+        var primaryKeyColumnName = entityMetadata.PrimaryIdAttribute;
+
+        var sortedAttrs = entityMetadata.Attributes.OrderBy(a => a.ColumnNumber).Select(a => a.LogicalName).ToArray();
+
+        var parametersAndColumns = entity.Attributes
+            .OrderBy(a => Array.IndexOf(sortedAttrs, a.Key))
+            .Select((a, i) => (
+                ColumnName: a.Key == primaryKeyColumnName ? IdColumnName : a.Key,
+                Parameter: new SqlParameter($"@p{i}", MapCrmAttributeValueToParameterValue(a.Value))))
+            .ToArray();
+
+        var sqlBuilder = new StringBuilder();
+        sqlBuilder.AppendLine($"merge into [{tableName}] as target");
+        sqlBuilder.AppendLine("using (select");
+        sqlBuilder.AppendJoin(",\n", parametersAndColumns.Select(a => $"\t{a.Parameter.ParameterName} as [{a.ColumnName}]"));
+        sqlBuilder.AppendLine("\n)as source");
+        sqlBuilder.AppendLine($"on source.[{IdColumnName}] = target.[{IdColumnName}]");
+        sqlBuilder.AppendLine("when matched then update set");
+        sqlBuilder.AppendJoin(",\n", parametersAndColumns.Where(p => p.ColumnName != IdColumnName).Select(p => $"\t[{p.ColumnName}] = {p.Parameter.ParameterName}"));
+        sqlBuilder.AppendLine("\nwhen not matched then insert (");
+        sqlBuilder.AppendJoin(",\n", parametersAndColumns.Select(p => $"\t{p.ColumnName}"));
+        sqlBuilder.AppendLine("\n) values (");
+        sqlBuilder.AppendJoin(",\n", parametersAndColumns.Select(p => $"\t{p.Parameter.ParameterName}"));
+        sqlBuilder.AppendLine("\n);");
+
+        var command = new SqlCommand(sqlBuilder.ToString());
+        command.Parameters.AddRange(parametersAndColumns.Select(p => p.Parameter).ToArray());
+
+        return command;
+
+        static object MapCrmAttributeValueToParameterValue(object value) => value switch
+        {
+            OptionSetValue optionSetValue => optionSetValue.Value,
+            EntityReference entityReference => entityReference.Id,
+            _ => value
+        };
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/Migrator.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/Migrator.cs
@@ -7,6 +7,7 @@ using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
 using DbUp.ScriptProviders;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 
 namespace QualifiedTeachersApi.Services.DqtReporting;
@@ -14,6 +15,7 @@ namespace QualifiedTeachersApi.Services.DqtReporting;
 public class Migrator
 {
     private readonly UpgradeEngine _upgradeEngine;
+    private readonly string _connectionString;
 
     public Migrator(string connectionString, ILogger? logger = null)
     {
@@ -34,6 +36,18 @@ public class Migrator
         }
 
         _upgradeEngine = builder.Build();
+        _connectionString = connectionString;
+    }
+
+    public void DropAllTables()
+    {
+        using var conn = new SqlConnection(_connectionString);
+        conn.Open();
+
+        var cmd = new SqlCommand("sp_MSforeachtable", conn);
+        cmd.CommandType = System.Data.CommandType.StoredProcedure;
+        cmd.Parameters.Add(new SqlParameter("@command1", "DROP TABLE ?"));
+        cmd.ExecuteNonQuery();
     }
 
     public void MigrateDb()

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/ServiceCollectionExtensions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/ServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace QualifiedTeachersApi.Services.DqtReporting;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddDqtReporting(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IWebHostEnvironment environment)
+    {
+        if (configuration.GetValue<bool>("DqtReporting:RunService"))
+        {
+            services.AddOptions<DqtReportingOptions>()
+                .Bind(configuration.GetSection("DqtReporting"))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            services.AddSingleton<IHostedService, DqtReportingService>();
+        }
+
+        return services;
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.Development.json
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.Development.json
@@ -15,7 +15,10 @@
   },
   "ApiClients": {
     "developer": {
-      "ApiKey": [ "developer" ] 
+      "ApiKey": [ "developer" ]
     }
+  },
+  "DqtReporting": {
+    "ProcessAllEntityTypesConcurrently": false
   }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.json
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.json
@@ -23,5 +23,13 @@
   },
   "AllowedHosts": "*",
   "FeatureManagement": {
+  },
+  "DqtReporting": {
+    "PollIntervalSeconds": 300,
+    "Entities": [
+      "contact"
+    ],
+    "ProcessAllEntityTypesConcurrently": true,
+    "RunService": false
   }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/ApiTestBase.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/ApiTestBase.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DbFixture.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DbFixture.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using QualifiedTeachersApi.DataStore.Sql;
+using QualifiedTeachersApi.Tests.Infrastructure;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests;
+
+public class DbFixture : IAsyncLifetime
+{
+    public DbFixture(TestConfiguration testConfiguration, DbHelper dbHelper)
+    {
+        Configuration = testConfiguration.Configuration;
+        ConnectionString = Configuration.GetConnectionString("DefaultConnection") ??
+            throw new Exception("Connection string DefaultConnection is missing.");
+        DbHelper = dbHelper;
+        Services = GetServices();
+    }
+
+    public IConfiguration Configuration { get; }
+
+    public string ConnectionString { get; }
+
+    public DbHelper DbHelper { get; }
+
+    public IServiceProvider Services { get; }
+
+    public DqtContext GetDbContext() => Services.GetRequiredService<DqtContext>();
+
+    public IDbContextFactory<DqtContext> GetDbContextFactory() => Services.GetRequiredService<IDbContextFactory<DqtContext>>();
+
+    public async Task InitializeAsync()
+    {
+        await DbHelper.EnsureSchema();
+    }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
+
+    private IServiceProvider GetServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDbContext<DqtContext>(
+            options => DqtContext.ConfigureOptions(options, ConnectionString),
+            contextLifetime: ServiceLifetime.Transient);
+
+        services.AddDbContextFactory<DqtContext>(
+            options => DqtContext.ConfigureOptions(options, ConnectionString));
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Infrastructure/TestConfiguration.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Infrastructure/TestConfiguration.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace QualifiedTeachersApi.Tests.Infrastructure;
+
+public class TestConfiguration
+{
+    public IConfiguration Configuration { get; } =
+        new ConfigurationBuilder()
+            .AddUserSecrets<ApiFixture>(optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/QualifiedTeachersApi.Tests.csproj
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/QualifiedTeachersApi.Tests.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Respawn" Version="6.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Xunit.DependencyInjection" Version="8.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Services/DqtReportingFixture.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Services/DqtReportingFixture.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Moq;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using QualifiedTeachersApi.Services.CrmEntityChanges;
+using QualifiedTeachersApi.Services.DqtReporting;
+using QualifiedTeachersApi.Services.TrnGenerationApi;
+using QualifiedTeachersApi.Tests.Infrastructure;
+
+namespace QualifiedTeachersApi.Tests.Services;
+
+public class DqtReportingFixture
+{
+    private readonly ServiceClient _serviceClient;
+    private readonly IMemoryCache _memoryCache;
+
+    public DqtReportingFixture(TestConfiguration testConfiguration, ServiceClient serviceClient, IMemoryCache memoryCache)
+    {
+        _serviceClient = serviceClient;
+        _memoryCache = memoryCache;
+        ReportingDbConnectionString = testConfiguration.Configuration["DqtReporting:ReportingDbConnectionString"] ??
+            throw new Exception("DqtReporting:ReportingDbConnectionString configuration key is missing.");
+
+        var migrator = new Migrator(ReportingDbConnectionString);
+        migrator.DropAllTables();
+        migrator.MigrateDb();
+    }
+
+    public string ReportingDbConnectionString { get; }
+
+    public Task PublishChangedItemAndConsume(IChangedItem changedItem) =>
+        WithService(async (service, changesObserver) =>
+        {
+            await service.LoadEntityMetadata();
+
+            changesObserver.OnNext(new IChangedItem[] { changedItem });
+            var processTask = service.ProcessChangesForEntityType(Contact.EntityLogicalName, CancellationToken.None);
+            changesObserver.OnCompleted();
+            await processTask;
+        });
+
+    public async Task WithService(Func<DqtReportingService, IObserver<IChangedItem[]>, Task> action)
+    {
+        var options = Options.Create(new DqtReportingOptions()
+        {
+            Entities = new[] { Contact.EntityLogicalName },
+            PollIntervalSeconds = 60,
+            ProcessAllEntityTypesConcurrently = false,
+            ReportingDbConnectionString = ReportingDbConnectionString,
+            RunService = true
+        });
+
+        using var crmEntityChangesService = new TestableCrmEntityChangesService();
+        var changesObserver = crmEntityChangesService.GetChangedItemsObserver(Contact.EntityLogicalName);
+
+        var trnGenerationApiClient = Mock.Of<ITrnGenerationApiClient>();
+
+        var dataverseAdapter = new DataverseAdapter(_serviceClient, new TestableClock(), _memoryCache, trnGenerationApiClient);
+
+        var logger = new NullLogger<DqtReportingService>();
+
+        var service = new DqtReportingService(
+            options,
+            crmEntityChangesService,
+            dataverseAdapter,
+            logger);
+
+        await action(service, changesObserver);
+    }
+
+    private class TestableCrmEntityChangesService : ICrmEntityChangesService, IDisposable
+    {
+        private readonly ConcurrentDictionary<string, System.Reactive.Subjects.ReplaySubject<IChangedItem[]>> _entityTypeSubjects = new();
+        private bool _disposed = false;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            var subjects = _entityTypeSubjects.Values.ToArray();
+
+            foreach (var s in subjects)
+            {
+                s.Dispose();
+            }
+
+            _entityTypeSubjects.Clear();
+            _disposed = true;
+        }
+
+        public IObserver<IChangedItem[]> GetChangedItemsObserver(string entityLogicalName)
+        {
+            ThrowIfDisposed();
+
+            return _entityTypeSubjects.GetOrAdd(entityLogicalName, _ => new System.Reactive.Subjects.ReplaySubject<IChangedItem[]>());
+        }
+
+        public IAsyncEnumerable<IChangedItem[]> GetEntityChanges(
+            string key,
+            string entityLogicalName,
+            int pageSize = 1000,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            var subject = _entityTypeSubjects.GetOrAdd(entityLogicalName, _ => new System.Reactive.Subjects.ReplaySubject<IChangedItem[]>());
+            return subject.ToAsyncEnumerable();
+        }
+
+        private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Services/DqtReportingServiceTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Services/DqtReportingServiceTests.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Xrm.Sdk;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Services;
+
+public class DqtReportingServiceTests : IClassFixture<DqtReportingFixture>
+{
+    private readonly DqtReportingFixture _fixture;
+
+    public DqtReportingServiceTests(DqtReportingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ProcessChangesForEntityType_WritesNewRecordToDatabase()
+    {
+        // Arrange
+        var contactId = Guid.NewGuid();
+        var newContact = new Contact()
+        {
+            Id = contactId,
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+        };
+        newContact.Attributes.Add(Contact.PrimaryIdAttribute, contactId);
+
+        var newItem = new NewOrUpdatedItem(ChangeType.NewOrUpdated, newContact);
+
+        // Act
+        await _fixture.PublishChangedItemAndConsume(newItem);
+
+        // Assert
+        var row = await GetRowById(Contact.EntityLogicalName, contactId);
+        Assert.NotNull(row);
+        Assert.Equal(newContact.Id, row["Id"]);
+        Assert.Equal(newContact.FirstName, row["firstname"]);
+        Assert.Equal(newContact.LastName, row["lastname"]);
+    }
+
+    [Fact]
+    public async Task ProcessChangesForEntityType_WritesUpdatedRecordToDatabase()
+    {
+        // Arrange
+        var contactId = Guid.NewGuid();
+
+        await InsertRow(Contact.EntityLogicalName, new Dictionary<string, object?>()
+        {
+            { "Id", contactId },
+            { "firstname", Faker.Name.First() },
+            { "lastname", Faker.Name.Last() }
+        });
+
+        var updatedContact = new Contact()
+        {
+            Id = contactId,
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+        };
+        updatedContact.Attributes.Add(Contact.PrimaryIdAttribute, contactId);
+
+        var newItem = new NewOrUpdatedItem(ChangeType.NewOrUpdated, updatedContact);
+
+        // Act
+        await _fixture.PublishChangedItemAndConsume(newItem);
+
+        // Assert
+        var row = await GetRowById(Contact.EntityLogicalName, contactId);
+        Assert.NotNull(row);
+        Assert.Equal(updatedContact.Id, row["Id"]);
+        Assert.Equal(updatedContact.FirstName, row["firstname"]);
+        Assert.Equal(updatedContact.LastName, row["lastname"]);
+    }
+
+    [Fact]
+    public async Task ProcessChangesForEntityType_DeletesRemovedRecordFromDatabase()
+    {
+        // Arrange
+        var contactId = Guid.NewGuid();
+
+        await InsertRow(Contact.EntityLogicalName, new Dictionary<string, object?>()
+        {
+            { "Id", contactId },
+            { "firstname", Faker.Name.First() },
+            { "lastname", Faker.Name.Last() }
+        });
+
+        var removedItem = new RemovedOrDeletedItem(
+            ChangeType.RemoveOrDeleted,
+            new EntityReference(Contact.EntityLogicalName, contactId));
+
+        // Act
+        await _fixture.PublishChangedItemAndConsume(removedItem);
+
+        // Assert
+        var row = await GetRowById(Contact.EntityLogicalName, contactId);
+        Assert.Null(row);
+    }
+
+    private async Task<IReadOnlyDictionary<string, object?>?> GetRowById(string tableName, Guid id)
+    {
+        using var sqlConnection = new SqlConnection(_fixture.ReportingDbConnectionString);
+        await sqlConnection.OpenAsync();
+
+        var cmd = new SqlCommand($"select * from {tableName} where id = @id");
+        cmd.Connection = sqlConnection;
+        cmd.Parameters.Add(new SqlParameter("@id", id));
+
+        using var reader = await cmd.ExecuteReaderAsync();
+
+        if (await reader.ReadAsync())
+        {
+            var data = new object[reader.FieldCount];
+            reader.GetValues(data);
+
+            return data
+                .Select((value, index) => (Value: value == DBNull.Value ? null : value, FieldName: reader.GetName(index)))
+                .ToDictionary(t => t.FieldName, t => t.Value);
+        }
+
+        return null;
+    }
+
+    private async Task InsertRow(string tableName, IReadOnlyDictionary<string, object?> columns)
+    {
+        using var sqlConnection = new SqlConnection(_fixture.ReportingDbConnectionString);
+        await sqlConnection.OpenAsync();
+
+        var cmd = new SqlCommand(
+            $"insert into {tableName} ({string.Join(", ", columns.Keys)}) values ({string.Join(", ", columns.Keys.Select((_, i) => $"@p{i}"))})");
+        cmd.Connection = sqlConnection;
+
+        var columnValues = columns.Values.ToArray();
+        for (var i = 0; i < columns.Count; i++)
+        {
+            cmd.Parameters.Add(new SqlParameter($"@p{i}", columnValues[i]));
+        }
+
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Startup.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Startup.cs
@@ -1,6 +1,8 @@
-﻿#nullable disable
+﻿using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using QualifiedTeachersApi.Tests.DataverseIntegration;
+using QualifiedTeachersApi.Tests.Infrastructure;
 
 namespace QualifiedTeachersApi.Tests;
 
@@ -8,6 +10,16 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        var testConfiguration = new TestConfiguration();
+        var dbHelper = new DbHelper(testConfiguration.Configuration.GetConnectionString("DefaultConnection") ??
+            throw new Exception("Connection string DefaultConnection is missing."));
+        var apiFixture = new ApiFixture(testConfiguration, dbHelper);
+
+        apiFixture.Initialize().GetAwaiter().GetResult();
+
+        services.AddSingleton(testConfiguration);
+        services.AddSingleton(dbHelper);
+        services.AddSingleton(apiFixture);
         services.AddSingleton<CrmClientFixture>();
         services.AddMemoryCache();
     }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Startup.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.PowerPlatform.Dataverse.Client;
 using QualifiedTeachersApi.Tests.DataverseIntegration;
 using QualifiedTeachersApi.Tests.Infrastructure;
 
@@ -17,10 +18,20 @@ public class Startup
 
         apiFixture.Initialize().GetAwaiter().GetResult();
 
+        services.AddSingleton(GetCrmServiceClient(testConfiguration.Configuration));
         services.AddSingleton(testConfiguration);
         services.AddSingleton(dbHelper);
         services.AddSingleton(apiFixture);
         services.AddSingleton<CrmClientFixture>();
         services.AddMemoryCache();
+
+        // This is wrapped up in Task.Run because the ServiceClient constructor can deadlock in some environments (e.g. CI).
+        // InitServiceAsync().Result within Microsoft.PowerPlatform.Dataverse.Client.ConnectionService.GetCachedService() looks to be the culprit
+        static ServiceClient GetCrmServiceClient(IConfiguration configuration) => Task.Run(() =>
+            new ServiceClient(
+                new Uri(configuration["CrmUrl"] ?? throw new Exception("CrmUrl configuration key is missing.")),
+                configuration["CrmClientId"] ?? throw new Exception("CrmClientId configuration key is missing."),
+                configuration["CrmClientSecret"] ?? throw new Exception("CrmClientSecret configuration key is missing."),
+                useUniqueInstance: true)).Result;
     }
 }


### PR DESCRIPTION
Adds the core implementation of the DQT Reporting service. This uses the `ICrmEntityChangesService` previously added and writes the results to a SQL Server DB. 

For now this is disabled on deployed environments until we've got the initial migration, configuration and monitoring components added.