### PR TITLE
Bugfix to handle ITT records with no establishmentid

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
@@ -281,7 +281,7 @@ public partial class DataverseAdapter
 
             List<dfeta_initialteachertraining> matching = new List<dfeta_initialteachertraining>();
             var activeForProvider = ittRecords
-                .Where(r => r.dfeta_EstablishmentId.Id == ittProviderId && r.StateCode == dfeta_initialteachertrainingState.Active)
+                .Where(r => r.dfeta_EstablishmentId?.Id == ittProviderId && r.StateCode == dfeta_initialteachertrainingState.Active)
                 .ToArray();
 
             // All incomplete qts/eyts records, regardless of provider


### PR DESCRIPTION
### Context

When fetching ITT records that are not associated with an establishment, the api fails and returns a 500 error. This fixes this problem.

### Changes proposed in this pull request

bug fix.

### Guidance to review



### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
