### PR TITLE
Ignore tag changes on Azure resources

### DIFF
--- a/terraform/api-app.tf
+++ b/terraform/api-app.tf
@@ -59,6 +59,12 @@ resource "azurerm_application_insights" "api_app_insights" {
   resource_group_name = var.resource_group_name
   location            = "West Europe"
   application_type    = "web"
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "cloudfoundry_service_instance" "redis" {

--- a/terraform/dqt-reporting.tf
+++ b/terraform/dqt-reporting.tf
@@ -6,6 +6,12 @@ resource "azurerm_mssql_server" "reporting_server" {
   version                      = "12.0"
   administrator_login          = yamldecode(data.azurerm_key_vault_secret.secrets["REPORTING-DB"].value)["USERNAME"]
   administrator_login_password = yamldecode(data.azurerm_key_vault_secret.secrets["REPORTING-DB"].value)["PASSWORD"]
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_mssql_firewall_rule" "reporting_server_paas_access" {
@@ -23,4 +29,10 @@ resource "azurerm_mssql_database" "reporting_db" {
   collation   = "SQL_Latin1_General_CP1_CI_AS"
   max_size_gb = 10
   sku_name    = "S0"
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -11,6 +11,12 @@ resource "azurerm_storage_account" "app-storage" {
   blob_properties {
     last_access_time_enabled = true
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "azurerm_storage_container" "certificates" {


### PR DESCRIPTION
Tags are automatically applied in our Azure subscriptions. Without this Terraform thinks a change is required on every run.