### PR TITLE
Ensure results from Find operation have a TRN

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
@@ -1086,7 +1086,8 @@ public partial class DataverseAdapter : IDataverseAdapter
             {
                 Conditions =
                 {
-                    new ConditionExpression(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active)
+                    new ConditionExpression(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active),
+                    new ConditionExpression(Contact.Fields.dfeta_TRN, ConditionOperator.NotNull)
                 },
                 Filters =
                 {


### PR DESCRIPTION
We've had an error in prod ID because the result from a Find call doesn't have a TRN.