### PR TITLE
More explicit ServiceClient for DqtReportingService

### DIFF
--- a/QualifiedTeachersApi/src/QtCli/Commands.ResetReportingDbChangeCursor.cs
+++ b/QualifiedTeachersApi/src/QtCli/Commands.ResetReportingDbChangeCursor.cs
@@ -32,7 +32,7 @@ public static partial class Commands
             {
                 var serviceProvider = new ServiceCollection()
                     .AddDbContextFactory<DqtContext>(options => DqtContext.ConfigureOptions(options, dbConnectionString))
-                    .AddServiceClient(DqtReportingService.ChangesKey, _ => new ServiceClient(crmConnectionString))
+                    .AddServiceClient(DqtReportingService.CrmClientName, _ => new ServiceClient(crmConnectionString))
                     .BuildServiceProvider();
 
                 var dbContextFactory = serviceProvider.GetRequiredService<IDbContextFactory<DqtContext>>();
@@ -50,7 +50,7 @@ public static partial class Commands
 
                 async Task ProcessChangesForEntityType(string entityType)
                 {
-                    await foreach (var changes in entityChangesService.GetEntityChanges(DqtReportingService.ChangesKey, entityType, emptyColumnSet, pageSize: 10000))
+                    await foreach (var changes in entityChangesService.GetEntityChanges(DqtReportingService.ChangesKey, DqtReportingService.CrmClientName, entityType, emptyColumnSet, pageSize: 10000))
                     {
                     }
                 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/CrmEntityChanges/ICrmEntityChangesService.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/CrmEntityChanges/ICrmEntityChangesService.cs
@@ -6,7 +6,8 @@ namespace QualifiedTeachersApi.Services.CrmEntityChanges;
 public interface ICrmEntityChangesService
 {
     IAsyncEnumerable<IChangedItem[]> GetEntityChanges(
-        string key,
+        string changesKey,
+        string crmClientName,
         string entityLogicalName,
         ColumnSet columns,
         int pageSize = 1000,

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/DqtReportingService.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/DqtReportingService.cs
@@ -17,6 +17,7 @@ namespace QualifiedTeachersApi.Services.DqtReporting;
 public partial class DqtReportingService : BackgroundService
 {
     public const string ChangesKey = "DqtReporting";
+    public const string CrmClientName = "DqtReporting";
     public const string ProcessChangesOperationName = "DqtReporting: process changes";
 
     private const int MaxParameters = 1024;
@@ -186,7 +187,10 @@ public partial class DqtReportingService : BackgroundService
 
         try
         {
-            await foreach (var changes in _crmEntityChangesService.GetEntityChanges(ChangesKey, entityLogicalName, columns, PageSize).WithCancellation(cancellationToken))
+            var changesEnumerable = _crmEntityChangesService.GetEntityChanges(ChangesKey, CrmClientName, entityLogicalName, columns, PageSize)
+                .WithCancellation(cancellationToken);
+
+            await foreach (var changes in changesEnumerable)
             {
                 totalProcessed += changes.Length;
 

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Services/DqtReportingFixture.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Services/DqtReportingFixture.cs
@@ -114,7 +114,8 @@ public class DqtReportingFixture
         }
 
         public IAsyncEnumerable<IChangedItem[]> GetEntityChanges(
-            string key,
+            string changesKey,
+            string serviceClientName,
             string entityLogicalName,
             ColumnSet columns,
             int pageSize = 1000,


### PR DESCRIPTION
Previously we've used the `ChangesKey` for retrieving a named CRM `ServiceClient`. We may want to have multiple change keys to a single named ServiceClient. This adds an additional parameter to avoid the conflation.