### PR TITLE
Ensure Option<T> properties are not required

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Json/Modifiers.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Json/Modifiers.cs
@@ -28,6 +28,7 @@ public static class Modifiers
 
                 property.ShouldSerialize = CreateShouldSerializePredicate(property.PropertyType);
                 property.CustomConverter = (JsonConverter)Activator.CreateInstance(typeof(OptionJsonConverter<>).MakeGenericType(underlyingType))!;
+                property.IsRequired = false;
             }
         }
 


### PR DESCRIPTION
The whole point of `Option<T>` properties is that they're optional.