### PR TITLE
Make teacher_id column of trn_requests table non-nullable

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230519120619_RequiredTrnRequestTeacherId.Designer.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230519120619_RequiredTrnRequestTeacherId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using QualifiedTeachersApi.DataStore.Sql;
@@ -11,9 +12,11 @@ using QualifiedTeachersApi.DataStore.Sql;
 namespace QualifiedTeachersApi.Migrations
 {
     [DbContext(typeof(DqtContext))]
-    partial class DqtContextModelSnapshot : ModelSnapshot
+    [Migration("20230519120619_RequiredTrnRequestTeacherId")]
+    partial class RequiredTrnRequestTeacherId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230519120619_RequiredTrnRequestTeacherId.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230519120619_RequiredTrnRequestTeacherId.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QualifiedTeachersApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class RequiredTrnRequestTeacherId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "teacher_id",
+                table: "trn_requests",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "teacher_id",
+                table: "trn_requests",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+    }
+}


### PR DESCRIPTION
A previous change made the model property non-nullable, this updates the DB schema to match.