### PR TITLE
Add read-only mode

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Filters/SupportsReadOnlyMode.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Filters/SupportsReadOnlyMode.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace QualifiedTeachersApi.Filters;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+public class SupportsReadOnlyModeAttribute : Attribute, IActionModelConvention, IControllerModelConvention
+{
+    public void Apply(ActionModel action)
+    {
+        action.Properties.Add(typeof(SupportsReadOnlyModeMarker), SupportsReadOnlyModeMarker.Instance);
+    }
+
+    public void Apply(ControllerModel controller)
+    {
+        controller.Properties.Add(typeof(SupportsReadOnlyModeMarker), SupportsReadOnlyModeMarker.Instance);
+    }
+}
+
+public class SupportsReadOnlyModeMarker
+{
+    private SupportsReadOnlyModeMarker() { }
+
+    public static SupportsReadOnlyModeMarker Instance { get; } = new();
+}
+
+public class ReadOnlyModeFilterFactory : IFilterFactory, IOrderedFilter
+{
+    public bool IsReusable => true;
+
+    public int Order => int.MinValue;
+
+    public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+    {
+        return serviceProvider.GetRequiredService<ReadOnlyModeFilter>();
+    }
+}
+
+public class ReadOnlyModeFilter : IActionFilter
+{
+    private readonly IConfiguration _configuration;
+
+    public ReadOnlyModeFilter(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+    }
+
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (_configuration.GetValue<bool>("ReadOnlyMode"))
+        {
+            var supportsReadOnlyModeMarker = context.ActionDescriptor.GetProperty<SupportsReadOnlyModeMarker>();
+
+            if (supportsReadOnlyModeMarker is null)
+            {
+                context.Result = new StatusCodeResult(StatusCodes.Status503ServiceUnavailable);
+            }
+        }
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Program.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Program.cs
@@ -153,6 +153,7 @@ public class Program
                 options.Filters.Add(new CrmServiceProtectionFaultExceptionFilter());
                 options.Filters.Add(new DefaultErrorExceptionFilter(statusCode: StatusCodes.Status400BadRequest));
                 options.Filters.Add(new ValidationExceptionFilter());
+                options.Filters.Add(new ReadOnlyModeFilterFactory());
 
                 options.Conventions.Add(new ApiVersionConvention());
                 options.Conventions.Add(new AuthorizationPolicyConvention());
@@ -247,6 +248,7 @@ public class Program
         services.AddSingleton<ISchemaGenerator, Infrastructure.Swagger.SchemaGenerator>();
         services.AddSingleton<IClock, Clock>();
         services.AddMemoryCache();
+        services.AddSingleton<ReadOnlyModeFilter>();
 
         services.AddHttpClient("EvidenceFiles", client =>
         {

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V1/Controllers/TeachersController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V1/Controllers/TeachersController.cs
@@ -1,6 +1,6 @@
-#nullable disable
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using QualifiedTeachersApi.Filters;
 using QualifiedTeachersApi.Infrastructure.Logging;
 using QualifiedTeachersApi.V1.Requests;
 using QualifiedTeachersApi.V1.Responses;
@@ -10,6 +10,7 @@ namespace QualifiedTeachersApi.V1.Controllers;
 
 [ApiController]
 [Route("teachers")]
+[SupportsReadOnlyMode]
 public class TeachersController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Controllers/IttProvidersController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Controllers/IttProvidersController.cs
@@ -1,6 +1,6 @@
-﻿#nullable disable
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using QualifiedTeachersApi.Filters;
 using QualifiedTeachersApi.V2.Requests;
 using QualifiedTeachersApi.V2.Responses;
 using Swashbuckle.AspNetCore.Annotations;
@@ -9,6 +9,7 @@ namespace QualifiedTeachersApi.V2.Controllers;
 
 [ApiController]
 [Route("itt-providers")]
+[SupportsReadOnlyMode]
 public class IttProvidersController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Controllers/NpqQualificationsController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Controllers/NpqQualificationsController.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using QualifiedTeachersApi.Filters;
 using QualifiedTeachersApi.V2.Requests;
@@ -9,6 +8,7 @@ namespace QualifiedTeachersApi.V2.Controllers;
 
 [ApiController]
 [Route("npq-qualifications")]
+[SupportsReadOnlyMode]
 public class NpqQualificationsController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Controllers/TeachersController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Controllers/TeachersController.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using QualifiedTeachersApi.Filters;
 using QualifiedTeachersApi.Infrastructure.Logging;
@@ -23,6 +22,7 @@ public class TeachersController : Controller
     [HttpGet("find")]
     [SwaggerOperation(summary: "Returns teachers matching the specified criteria")]
     [ProducesResponseType(typeof(FindTeachersResponse), StatusCodes.Status200OK)]
+    [SupportsReadOnlyMode]
     public async Task<IActionResult> FindTeachers(FindTeachersRequest request)
     {
         var response = await _mediator.Send(request);
@@ -34,6 +34,7 @@ public class TeachersController : Controller
         summary: "Teacher",
         description: "Get an individual teacher by their TRN")]
     [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
+    [SupportsReadOnlyMode]
     public async Task<IActionResult> GetTeacher([FromRoute] GetTeacherRequest request)
     {
         var response = await _mediator.Send(request);

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Controllers/UnlockTeacherController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Controllers/UnlockTeacherController.cs
@@ -1,6 +1,6 @@
-﻿#nullable disable
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using QualifiedTeachersApi.Filters;
 using QualifiedTeachersApi.V2.Requests;
 using QualifiedTeachersApi.V2.Responses;
 using Swashbuckle.AspNetCore.Annotations;
@@ -9,6 +9,7 @@ namespace QualifiedTeachersApi.V2.Controllers;
 
 [ApiController]
 [Route("unlock-teacher")]
+[SupportsReadOnlyMode]
 public class UnlockTeacherController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/CertificatesController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/CertificatesController.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using QualifiedTeachersApi.Filters;
 using QualifiedTeachersApi.Infrastructure.Security;
 using QualifiedTeachersApi.V3.Requests;
 using Swashbuckle.AspNetCore.Annotations;
@@ -11,6 +12,7 @@ namespace QualifiedTeachersApi.V3.Controllers;
 [ApiController]
 [Route("certificates")]
 [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
+[SupportsReadOnlyMode]
 public class CertificatesController : Controller
 {
     private readonly IMediator _mediator;

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeacherController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeacherController.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using QualifiedTeachersApi.Filters;
 using QualifiedTeachersApi.Infrastructure.ModelBinding;
 using QualifiedTeachersApi.Infrastructure.Security;
 using QualifiedTeachersApi.V3.Requests;
@@ -12,6 +13,7 @@ namespace QualifiedTeachersApi.V3.Controllers;
 
 [ApiController]
 [Route("teacher")]
+[SupportsReadOnlyMode]
 public class TeacherController : Controller
 {
     private readonly IMediator _mediator;

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeachersController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/TeachersController.cs
@@ -1,6 +1,7 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using QualifiedTeachersApi.Filters;
 using QualifiedTeachersApi.Infrastructure.ModelBinding;
 using QualifiedTeachersApi.Infrastructure.Security;
 using QualifiedTeachersApi.V3.Requests;
@@ -12,6 +13,7 @@ namespace QualifiedTeachersApi.V3.Controllers;
 [ApiController]
 [Route("teachers")]
 [Authorize(AuthorizationPolicies.ApiKey)]
+[SupportsReadOnlyMode]
 public class TeachersController : ControllerBase
 {
     private readonly IMediator _mediator;


### PR DESCRIPTION
When we move the DQT API from PAAS to AKS we want to do it without impacting the availability of services that depend on the API. The reason for the migration incurring down time is the database move; writes need to be stopped to the existing DB so that it can be copied and restored in the new DB without missing any data. Most of our endpoints don’t actually use the DB, they talk to CRM directly, so we don’t need to take these endpoints down.

This change adds a filter that checks the `ReadOnlyMode` value from configuration. If that value is `true`, requests to any endpoints that are not decorated with `SupportsReadOnlyMode` will return a `503` response.