### PR TITLE
Don't try to create DB on startup

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Program.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Program.cs
@@ -378,12 +378,6 @@ public class Program
             });
 
             app.UseMigrationsEndPoint();
-
-            using (var scope = app.Services.CreateScope())
-            {
-                var context = scope.ServiceProvider.GetRequiredService<DqtContext>();
-                context.Database.EnsureCreated();
-            }
         }
 
         if (env.IsProduction())


### PR DESCRIPTION
We now have better ways of setting up a DB for development; this is just extra startup cost.