### PR TITLE
Ported the Events feature from get an identity

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/DqtContext.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/DqtContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Events;
 
 namespace QualifiedTeachersApi.DataStore.Sql;
 
@@ -17,6 +18,8 @@ public class DqtContext : DbContext
 
     public DbSet<EntityChangesJournal> EntityChangesJournals => Set<EntityChangesJournal>();
 
+    public DbSet<Event> Events => Set<Event>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString)
     {
         if (connectionString != null)
@@ -30,6 +33,11 @@ public class DqtContext : DbContext
 
         optionsBuilder
             .UseSnakeCaseNamingConvention();
+    }
+
+    public void AddEvent(EventBase @event)
+    {
+        Events.Add(Event.FromEventBase(@event));
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/EventMapping.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/EventMapping.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+
+namespace QualifiedTeachersApi.DataStore.Sql.Mappings;
+
+public class EventMapping : IEntityTypeConfiguration<Event>
+{
+    public void Configure(EntityTypeBuilder<Event> builder)
+    {
+        builder.ToTable("events");
+        builder.Property(e => e.EventId).IsRequired().ValueGeneratedOnAdd();
+        builder.Property(e => e.EventName).IsRequired().HasMaxLength(200);
+        builder.Property(e => e.Created).IsRequired();
+        builder.Property(e => e.Payload).IsRequired().HasColumnType("jsonb");
+        builder.Property(e => e.Published);
+        builder.HasKey(e => e.EventId);
+        builder.HasIndex(e => e.Payload).HasMethod("gin");
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/Event.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/Event.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using QualifiedTeachersApi.Events;
+
+namespace QualifiedTeachersApi.DataStore.Sql.Models;
+
+public class Event
+{
+    private static readonly JsonSerializerOptions _serializerOptions = new();
+
+    public long EventId { get; set; }
+    public required string EventName { get; init; }
+    public required DateTime Created { get; init; }
+    public required string Payload { get; init; }
+    public bool Published { get; set; }
+
+    public static Event FromEventBase(EventBase @event)
+    {
+        var eventName = @event.GetType().Name;
+        var payload = JsonSerializer.Serialize(@event, inputType: @event.GetType(), _serializerOptions);
+
+        return new Event()
+        {
+            Created = @event.CreatedUtc,
+            EventName = eventName,
+            Payload = payload
+        };
+    }
+
+    public EventBase ToEventBase()
+    {
+        var eventTypeName = $"{typeof(EventBase).Namespace}.{EventName}";
+        var eventType = Type.GetType(eventTypeName) ??
+            throw new Exception($"Could not find event type '{eventTypeName}'.");
+
+        return (EventBase)JsonSerializer.Deserialize(Payload, eventType, _serializerOptions)!;
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/DummyEvent.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/DummyEvent.cs
@@ -1,0 +1,12 @@
+﻿namespace QualifiedTeachersApi.Events;
+
+/// <summary>
+/// A dummy event to be able to test the background publishing service.
+/// </summary>
+/// <remarks>
+/// This can be removed and replaced in the tests by a "real" event once we've create some.
+/// </remarks>
+public record DummyEvent : EventBase
+{
+    public required string DummyProperty { get; init; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/EventBase.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/EventBase.cs
@@ -1,0 +1,6 @@
+namespace QualifiedTeachersApi.Events;
+
+public abstract record EventBase
+{
+    public required DateTime CreatedUtc { get; init; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/Processing/IEventObserver.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/Processing/IEventObserver.cs
@@ -1,0 +1,6 @@
+namespace QualifiedTeachersApi.Events.Processing;
+
+public interface IEventObserver
+{
+    Task OnEventSaved(EventBase @event);
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/Processing/NoopEventObserver.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/Processing/NoopEventObserver.cs
@@ -1,0 +1,6 @@
+namespace QualifiedTeachersApi.Events.Processing;
+
+public class NoopEventObserver : IEventObserver
+{
+    public Task OnEventSaved(EventBase @event) => Task.CompletedTask;
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/Processing/PublishEventsBackgroundService.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/Processing/PublishEventsBackgroundService.cs
@@ -1,0 +1,92 @@
+using Microsoft.EntityFrameworkCore;
+using QualifiedTeachersApi.DataStore.Sql;
+
+namespace QualifiedTeachersApi.Events.Processing;
+
+public class PublishEventsBackgroundService : BackgroundService
+{
+    private const int BatchSize = 10;
+
+    private static readonly TimeSpan _pollInterval = TimeSpan.FromMinutes(1);
+
+    private readonly IEventObserver _eventObserver;
+    private readonly IDbContextFactory<DqtContext> _dbContextFactory;
+    private readonly ILogger<PublishEventsBackgroundService> _logger;
+
+    public PublishEventsBackgroundService(
+        IEventObserver eventObserver,
+        IDbContextFactory<DqtContext> dbContextFactory,
+        ILogger<PublishEventsBackgroundService> logger)
+    {
+        _eventObserver = eventObserver;
+        _dbContextFactory = dbContextFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var timer = new PeriodicTimer(_pollInterval);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await PublishEvents(stoppingToken);
+        }
+    }
+
+    // public for testing
+    public async Task PublishEvents(CancellationToken cancellationToken)
+    {
+        using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        // The ID of the last processed event for this tick of the timer.
+        // This is fed into the query to ensure we won't process the same event multiple times in the same timer tick
+        // (in cases where publishing the event failed).
+        long lastProcessedEventId = 0;
+
+        // How many events were processed in this batch.
+        // If processedCount < BatchSize there are no more events to process.
+        int processedCount;
+
+        do
+        {
+            using var txn = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+            var unpublishedEvents = await dbContext.Events
+                .FromSql($"select * from events where published is false and event_id > {lastProcessedEventId} for update skip locked limit {BatchSize}")
+                .ToListAsync(cancellationToken: cancellationToken);
+
+            if (unpublishedEvents.Count == 0)
+            {
+                processedCount = 0;
+                continue;
+            }
+
+            foreach (var e in unpublishedEvents)
+            {
+                try
+                {
+                    var eventBase = e.ToEventBase();
+                    await _eventObserver.OnEventSaved(eventBase);
+
+                    e.Published = true;
+
+                    _logger.LogDebug("Successfully published {EventType} event {EventId}.", e.EventName, e.EventId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to publish event {EventId}.", e.EventId);
+                }
+                finally
+                {
+                    lastProcessedEventId = e.EventId;
+                }
+            }
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+            await txn.CommitAsync(cancellationToken);
+
+            processedCount = unpublishedEvents.Count;
+        }
+        while (processedCount == BatchSize);
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/Processing/ServiceCollectionExtensions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/Processing/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+namespace QualifiedTeachersApi.Events.Processing.EventPublishing;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddEventPublishing(
+        this IServiceCollection services,
+        IWebHostEnvironment environment)
+    {
+        if (!environment.IsUnitTests())
+        {
+            services.AddSingleton<IHostedService, PublishEventsBackgroundService>();
+        }
+
+        services.AddSingleton<IEventObserver, NoopEventObserver>();
+
+        return services;
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230522115339_Events.Designer.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230522115339_Events.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using QualifiedTeachersApi.DataStore.Sql;
@@ -11,9 +12,11 @@ using QualifiedTeachersApi.DataStore.Sql;
 namespace QualifiedTeachersApi.Migrations
 {
     [DbContext(typeof(DqtContext))]
-    partial class DqtContextModelSnapshot : ModelSnapshot
+    [Migration("20230522115339_Events")]
+    partial class Events
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230522115339_Events.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230522115339_Events.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace QualifiedTeachersApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class Events : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "events",
+                columns: table => new
+                {
+                    event_id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    event_name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    payload = table.Column<string>(type: "jsonb", nullable: false),
+                    published = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_events", x => x.event_id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_events_payload",
+                table: "events",
+                column: "payload")
+                .Annotation("Npgsql:IndexMethod", "gin");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "events");
+        }
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DisableParallelization.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DisableParallelization.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests;
+
+[CollectionDefinition(nameof(DisableParallelization), DisableParallelization = true)]
+public class DisableParallelization : ICollectionFixture<ApiFixture> { }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Events/Processing/PublishEventsBackgroundServiceTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Events/Processing/PublishEventsBackgroundServiceTests.cs
@@ -1,0 +1,121 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Events;
+using QualifiedTeachersApi.Events.Processing;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Events.Processing;
+
+[Collection(nameof(DisableParallelization))]
+public class PublishEventsBackgroundServiceTests : IClassFixture<DbFixture>, IAsyncLifetime
+{
+    private readonly DbFixture _dbFixture;
+
+    public PublishEventsBackgroundServiceTests(DbFixture dbFixture)
+    {
+        _dbFixture = dbFixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        using var dbContext = _dbFixture.GetDbContext();
+        await dbContext.Database.ExecuteSqlAsync($"delete from events");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task PublishEvents_PublishesUnpublishEventsAndSetsPublishedFlag()
+    {
+        // Arrange
+        using var dbContext = _dbFixture.GetDbContext();
+        var @event = CreateDummyEvent();
+        dbContext.AddEvent(@event);
+        await dbContext.SaveChangesAsync();
+        var dbEvent = dbContext.ChangeTracker.Entries<Event>().Last().Entity;
+
+        var eventObserver = new TestableEventObserver();
+
+        var logger = new NullLogger<PublishEventsBackgroundService>();
+
+        var service = new PublishEventsBackgroundService(eventObserver, _dbFixture.GetDbContextFactory(), logger);
+
+        // Act
+        await service.PublishEvents(CancellationToken.None);
+
+        // Assert
+        Assert.Collection(eventObserver.Events, e => e.Equals(@event));
+
+        await dbContext.Entry(dbEvent).ReloadAsync();
+        Assert.True(dbEvent.Published);
+    }
+
+    [Fact]
+    public async Task PublishEvents_DoesNotPublishAlreadyPublishedEvent()
+    {
+        // Arrange
+        using var dbContext = _dbFixture.GetDbContext();
+        var @event = CreateDummyEvent();
+        dbContext.AddEvent(@event);
+        dbContext.ChangeTracker.Entries<Event>().Last().Entity.Published = true;
+        await dbContext.SaveChangesAsync();
+
+        var eventObserver = new TestableEventObserver();
+
+        var logger = new NullLogger<PublishEventsBackgroundService>();
+
+        var service = new PublishEventsBackgroundService(eventObserver, _dbFixture.GetDbContextFactory(), logger);
+
+        // Act
+        await service.PublishEvents(CancellationToken.None);
+
+        // Assert
+        Assert.Empty(eventObserver.Events);
+    }
+
+    [Fact]
+    public async Task PublishEvents_EventObserverThrows_DoesNotThrow()
+    {
+        // Arrange
+        using var dbContext = _dbFixture.GetDbContext();
+        var @event = CreateDummyEvent();
+        dbContext.AddEvent(@event);
+        await dbContext.SaveChangesAsync();
+        var dbEvent = dbContext.ChangeTracker.Entries<Event>().Last().Entity;
+
+        var eventObserver = new Mock<IEventObserver>();
+        var publishException = new Exception("Bang!");
+        eventObserver.Setup(mock => mock.OnEventSaved(It.IsAny<EventBase>())).ThrowsAsync(publishException);
+
+        var logger = new Mock<ILogger<PublishEventsBackgroundService>>();
+
+        var service = new PublishEventsBackgroundService(eventObserver.Object, _dbFixture.GetDbContextFactory(), logger.Object);
+
+        // Act
+        await service.PublishEvents(CancellationToken.None);
+
+        // Assert
+        // Can't easily assert that logging has happened here due to extension methods
+    }
+
+    private EventBase CreateDummyEvent() => new DummyEvent()
+    {
+        DummyProperty = Faker.Name.FullName(),
+        CreatedUtc = TestableClock.Initial.ToUniversalTime()
+    };
+
+    private class TestableEventObserver : IEventObserver
+    {
+        private readonly List<EventBase> _events = new();
+
+        public IReadOnlyCollection<EventBase> Events => _events.AsReadOnly();
+
+        public Task OnEventSaved(EventBase @event)
+        {
+            _events.Add(@event);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
### Context

For the automated QTS emails we need to log who we’ve emailed and when. ID uses an event system that is used to record all data changes that works well and could be replicated here and used everywhere for TRS going forward.

### Changes proposed in this pull request

Port code from identity.

### Guidance to review

There are no "real" events yet so a DummyEvent has been temporarily created to allow the event publishing to be tested.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
