### PR TITLE
Add slugid getorcreatetrnrequest

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/CreateTeacherCommand.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/CreateTeacherCommand.cs
@@ -23,6 +23,7 @@ public class CreateTeacherCommand
     public DateOnly? QtsDate { get; set; }
     public bool? InductionRequired { get; set; }
     public bool? UnderNewOverseasRegulations { get; set; }
+    public string SlugId { get; set; }
 }
 
 public class CreateTeacherCommandAddress

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using Microsoft.Xrm.Sdk.Metadata;
 using QualifiedTeachersApi.DataStore.Crm.Models;
+using static QualifiedTeachersApi.DataStore.Crm.DataverseAdapter;
 
 namespace QualifiedTeachersApi.DataStore.Crm;
 
@@ -92,6 +93,8 @@ public interface IDataverseAdapter
     Task<Incident[]> GetIncidentsByContactId(Guid contactId, IncidentState? state, string[] columnNames);
 
     Task<EntityMetadata> GetEntityMetadata(string entityLogicalName, EntityFilters entityFilters = EntityFilters.Default);
+
+    Task<Contact[]> GetTeachersByInitialTeacherTrainingSlugId(string slugId, string[] columnNames, RequestBuilder requestBuilder, bool activeOnly = true);
 
     Task<QtsAwardee[]> GetQtsAwardeesForDateRange(DateTime startDate, DateTime endDate);
 

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/Models/AttributeConstraints.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/Models/AttributeConstraints.cs
@@ -16,5 +16,6 @@ public static class AttributeConstraints
         public const int Address1_CityMaxLength = 80;
         public const int Address1_PostalCodeLength = 20;
         public const int Address1_CountryMaxLength = 80;
+        public const int SlugId_MaxLength = 150;
     }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Properties/StringResources.Designer.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Properties/StringResources.Designer.cs
@@ -142,6 +142,24 @@ namespace QualifiedTeachersApi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SlugId can only be provided for trainee teachers..
+        /// </summary>
+        public static string ErrorMessages_SlugIdCanOnlyBeProvidedForTraineeTeachers {
+            get {
+                return ResourceManager.GetString("ErrorMessages.SlugIdCanOnlyBeProvidedForTraineeTeachers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to slugid must be 150 characters or fewer.
+        /// </summary>
+        public static string ErrorMessages_SlugIdMustBe150CharactersOrFewer {
+            get {
+                return ResourceManager.GetString("ErrorMessages.SlugIdMustBe150CharactersOrFewer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to TRN must consist of 7 digits.
         /// </summary>
         public static string ErrorMessages_TRNMustBe7Digits {

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Properties/StringResources.resx
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Properties/StringResources.resx
@@ -144,6 +144,12 @@
   <data name="ErrorMessages.RequestIdMustBe100CharactersOrFewer" xml:space="preserve">
     <value>requestId must be 100 characters or fewer</value>
   </data>
+  <data name="ErrorMessages.SlugIdCanOnlyBeProvidedForTraineeTeachers" xml:space="preserve">
+    <value>SlugId can only be provided for trainee teachers.</value>
+  </data>
+  <data name="ErrorMessages.SlugIdMustBe150CharactersOrFewer" xml:space="preserve">
+    <value>slugid must be 150 characters or fewer</value>
+  </data>
   <data name="ErrorMessages.TRNMustBe7Digits" xml:space="preserve">
     <value>TRN must consist of 7 digits</value>
   </data>

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -139,7 +139,8 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
                     null,
                 QtsDate = request.QtsDate,
                 InductionRequired = request.InductionRequired,
-                UnderNewOverseasRegulations = request.UnderNewOverseasRegulations
+                UnderNewOverseasRegulations = request.UnderNewOverseasRegulations,
+                SlugId = request.SlugId
             });
 
             if (!createTeacherResult.Succeeded)
@@ -172,7 +173,8 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
             Trn = trn,
             Status = status,
             QtsDate = qtsDate,
-            PotentialDuplicate = status == TrnRequestStatus.Pending
+            PotentialDuplicate = status == TrnRequestStatus.Pending,
+            SlugId = request.SlugId
         };
     }
 

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetTrnRequestHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/GetTrnRequestHandler.cs
@@ -61,7 +61,8 @@ public class GetTrnRequestHandler : IRequestHandler<GetTrnRequest, TrnRequestInf
             Status = status,
             Trn = trn,
             QtsDate = qtsDate,
-            PotentialDuplicate = status == TrnRequestStatus.Pending
+            PotentialDuplicate = status == TrnRequestStatus.Pending,
+            SlugId = teacher.dfeta_SlugId
         };
     }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Requests/GetOrCreateTrnRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Requests/GetOrCreateTrnRequest.cs
@@ -40,6 +40,7 @@ public class GetOrCreateTrnRequest : IRequest<TrnRequestInfo>
     public bool? InductionRequired { get; set; }
     public Guid? IdentityUserId { get; set; }
     public bool? UnderNewOverseasRegulations { get; set; }
+    public string SlugId { get; set; }
 }
 
 public class GetOrCreateTrnRequestAddress

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/TrnRequestInfo.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/TrnRequestInfo.cs
@@ -17,6 +17,8 @@ public class TrnRequestInfo
 
     [JsonIgnore]
     public bool WasCreated { get; set; }
+
+    public string? SlugId { get; set; }
 }
 
 public class TrnRequestInfoExample : IExampleProvider<TrnRequestInfo>

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Validators/GetOrCreateTrnRequestValidator.cs
@@ -220,5 +220,15 @@ public class GetOrCreateTrnRequestValidator : AbstractValidator<GetOrCreateTrnRe
             .When(r => r.TeacherType == CreateTeacherType.OverseasQualifiedTeacher, ApplyConditionTo.CurrentValidator)
             .Null()
             .When(r => r.TeacherType != CreateTeacherType.OverseasQualifiedTeacher, ApplyConditionTo.CurrentValidator);
+
+        RuleFor(r => r.SlugId)
+            .MaximumLength(AttributeConstraints.Contact.SlugId_MaxLength)
+            .WithMessage(Properties.StringResources.ErrorMessages_SlugIdMustBe150CharactersOrFewer);
+
+        RuleFor(r => r.SlugId)
+            .Empty()
+            .When(x => x.TeacherType != CreateTeacherType.TraineeTeacher)
+            .WithMessage(Properties.StringResources.ErrorMessages_SlugIdCanOnlyBeProvidedForTraineeTeachers);
+
     }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/CreateTeacherTests.cs
@@ -435,6 +435,139 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
     }
 
     [Fact]
+    public async Task Given_itt_slugid_exists_request_succeeds_and_creates_review_task()
+    {
+        // Arrange
+        var slugId = Guid.NewGuid().ToString();
+        var teachercommand1 = new CreateTeacherCommand()
+        {
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            BirthDate = Faker.Identification.DateOfBirth(),
+            GenderCode = Contact_GenderCode.Female,
+            InitialTeacherTraining = new()
+            {
+                ProviderUkprn = "10044534",  // ARK Teacher Training
+                ProgrammeStartDate = new(2020, 4, 1),
+                ProgrammeEndDate = new(2020, 10, 10),
+                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
+                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
+            },
+            SlugId = slugId
+        };
+
+        //teacher has ITT record with slugid that exists because it was created above
+        var teachercommand2 = new CreateTeacherCommand()
+        {
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            BirthDate = Faker.Identification.DateOfBirth(),
+            GenderCode = Contact_GenderCode.Female,
+            InitialTeacherTraining = new()
+            {
+                ProviderUkprn = "10044534",  // ARK Teacher Training
+                ProgrammeStartDate = new(2020, 4, 1),
+                ProgrammeEndDate = new(2020, 10, 10),
+                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
+                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
+
+            },
+            SlugId = slugId
+        };
+        var (result1, transactionRequest1) = await _dataverseAdapter.CreateTeacherImpl(teachercommand1);
+
+        // Act
+        var (result2, transactionRequest2) = await _dataverseAdapter.CreateTeacherImpl(teachercommand2);
+
+        // Assert
+        Assert.True(result1.Succeeded);
+        transactionRequest1.AssertDoesNotContainCreateRequest<CrmTask>();
+        Assert.True(result2.Succeeded);
+        transactionRequest2.AssertContainsCreateRequest<CrmTask>(x => x.Description.Contains($"- ITT SlugId: '{slugId}'"));
+    }
+
+    [Fact]
+    public async Task Given_slugid_does_not_exist_request_succeeds_and_does_not_creates_review_task()
+    {
+        // Arrange
+        var slugId = Guid.NewGuid().ToString();
+        var teachercommand1 = new CreateTeacherCommand()
+        {
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            BirthDate = Faker.Identification.DateOfBirth(),
+            GenderCode = Contact_GenderCode.Female,
+            InitialTeacherTraining = new()
+            {
+                ProviderUkprn = "10044534",  // ARK Teacher Training
+                ProgrammeStartDate = new(2020, 4, 1),
+                ProgrammeEndDate = new(2020, 10, 10),
+                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
+                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
+            },
+            SlugId = slugId
+        };
+
+        // Act
+        var (result1, transactionRequest1) = await _dataverseAdapter.CreateTeacherImpl(teachercommand1);
+
+        // Assert
+        Assert.True(result1.Succeeded);
+        transactionRequest1.AssertDoesNotContainCreateRequest<CrmTask>();
+    }
+
+    [Fact]
+    public async Task Given_teacher_slugid_exists_request_succeeds_and_creates_review_task()
+    {
+        // Arrange
+        var slugId = Guid.NewGuid().ToString();
+        var teachercommand1 = new CreateTeacherCommand()
+        {
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            BirthDate = Faker.Identification.DateOfBirth(),
+            GenderCode = Contact_GenderCode.Female,
+            InitialTeacherTraining = new()
+            {
+                ProviderUkprn = "10044534",  // ARK Teacher Training
+                ProgrammeStartDate = new(2020, 4, 1),
+                ProgrammeEndDate = new(2020, 10, 10),
+                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
+                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
+            },
+            SlugId = slugId
+        };
+
+        //teacher with slugid already exists because it was created above
+        var teachercommand2 = new CreateTeacherCommand()
+        {
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            BirthDate = Faker.Identification.DateOfBirth(),
+            GenderCode = Contact_GenderCode.Female,
+            InitialTeacherTraining = new()
+            {
+                ProviderUkprn = "10044534",  // ARK Teacher Training
+                ProgrammeStartDate = new(2020, 4, 1),
+                ProgrammeEndDate = new(2020, 10, 10),
+                ProgrammeType = dfeta_ITTProgrammeType.GraduateTeacherProgramme,
+                IttQualificationAim = dfeta_ITTQualificationAim.Professionalstatusandacademicaward
+            },
+            SlugId = slugId
+        };
+        var (result1, transactionRequest1) = await _dataverseAdapter.CreateTeacherImpl(teachercommand1);
+
+        // Act
+        var (result2, transactionRequest2) = await _dataverseAdapter.CreateTeacherImpl(teachercommand2);
+
+        // Assert
+        Assert.True(result1.Succeeded);
+        transactionRequest1.AssertDoesNotContainCreateRequest<CrmTask>();
+        Assert.True(result2.Succeeded);
+        transactionRequest2.AssertContainsCreateRequest<CrmTask>(x => x.Description.Contains($"- SlugId: '{slugId}'"));
+    }
+
+    [Fact]
     public async Task Given_husid_exists_request_succeeds_and_creates_review_task()
     {
         // Arrange
@@ -779,6 +912,7 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
         var firstName2 = Faker.Name.First();
         var middleName = Faker.Name.Middle();
         var lastName = Faker.Name.Last();
+        var slugId = Guid.NewGuid().ToString();
 
         var command = new CreateTeacherCommand()
         {
@@ -790,6 +924,7 @@ public class CreateTeacherTests : IClassFixture<CreateTeacherFixture>, IAsyncLif
             StatedLastName = lastName,
             BirthDate = Faker.Identification.DateOfBirth(),
             EmailAddress = Faker.Internet.Email(),
+            SlugId = slugId,
             Address = new()
             {
                 AddressLine1 = Faker.Address.StreetAddress(),

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetTeachersByInitialTeacherTrainingSlugIdTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetTeachersByInitialTeacherTrainingSlugIdTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Xrm.Sdk;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.DataverseIntegration;
+
+public class GetTeachersByInitialTeacherTrainingSlugIdTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly DataverseAdapter _dataverseAdapter;
+    private readonly ITrackedEntityOrganizationService _organizationService;
+    private readonly TestableClock _clock;
+
+    public GetTeachersByInitialTeacherTrainingSlugIdTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _dataverseAdapter = _dataScope.CreateDataverseAdapter();
+        _organizationService = _dataScope.OrganizationService;
+        _clock = crmClientFixture.Clock;
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+
+    [Fact]
+    public async Task Given_no_itt_records_exist_with_slugid_return_empty_collection()
+    {
+        // Arrange
+        var slugId = Guid.NewGuid().ToString();
+
+        // Act
+        var result = await _dataverseAdapter.GetTeachersByInitialTeacherTrainingSlugId(slugId, columnNames: new[] { Contact.Fields.dfeta_TRN }, null);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Given_multiple_itt_records_exist_with_slugid_return_associated_teachers()
+    {
+        // Arrange
+        var slugId = Guid.NewGuid().ToString();
+        var teacher1Id = await _organizationService.CreateAsync(new Contact() { FirstName = "test" });
+        await _organizationService.CreateAsync(new dfeta_initialteachertraining() { dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacher1Id), dfeta_SlugId = slugId });
+        var teacher2Id = await _organizationService.CreateAsync(new Contact() { FirstName = "testing" });
+        await _organizationService.CreateAsync(new dfeta_initialteachertraining() { dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacher2Id), dfeta_SlugId = slugId });
+
+        // Act
+        var result = await _dataverseAdapter.GetTeachersByInitialTeacherTrainingSlugId(slugId, columnNames: new[] { Contact.Fields.dfeta_TRN }, null);
+
+        // Assert
+        Assert.NotEmpty(result);
+        Assert.Collection(result,
+            item1 =>
+            {
+                Assert.Equal(teacher1Id, item1.Id);
+            },
+            item2 =>
+            {
+                Assert.Equal(teacher2Id, item2.Id);
+            }
+        );
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTrnRequestTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/GetTrnRequestTests.cs
@@ -62,13 +62,15 @@ public class GetTrnRequestTests : ApiTestBase
         // Arrange
         var requestId = Guid.NewGuid().ToString();
         var teacherId = Guid.NewGuid();
+        var slugId = Guid.NewGuid().ToString();
 
         ApiFixture.DataverseAdapter
             .Setup(mock => mock.GetTeacher(teacherId, /* resolveMerges: */ It.IsAny<string[]>(), true))
             .ReturnsAsync(new Contact()
             {
                 Id = teacherId,
-                dfeta_TRN = null
+                dfeta_TRN = null,
+                dfeta_SlugId = slugId
             });
 
         await WithDbContext(async dbContext =>
@@ -96,6 +98,7 @@ public class GetTrnRequestTests : ApiTestBase
                 trn = (string)null,
                 qtsDate = (DateOnly?)null,
                 potentialDuplicate = true,
+                slugId = slugId
             },
             expectedStatusCode: StatusCodes.Status200OK);
     }
@@ -107,13 +110,15 @@ public class GetTrnRequestTests : ApiTestBase
         var requestId = Guid.NewGuid().ToString();
         var teacherId = Guid.NewGuid();
         var trn = "1234567";
+        var slugId = Guid.NewGuid().ToString();
 
         ApiFixture.DataverseAdapter
             .Setup(mock => mock.GetTeacher(teacherId, /* resolveMerges: */ It.IsAny<string[]>(), true))
             .ReturnsAsync(new Contact()
             {
                 Id = teacherId,
-                dfeta_TRN = trn
+                dfeta_TRN = trn,
+                dfeta_SlugId = slugId
             });
 
         await WithDbContext(async dbContext =>
@@ -141,6 +146,7 @@ public class GetTrnRequestTests : ApiTestBase
                 trn = trn,
                 qtsDate = (DateOnly?)null,
                 potentialDuplicate = false,
+                slugId = slugId
             },
             expectedStatusCode: StatusCodes.Status200OK);
     }


### PR DESCRIPTION
### Context

SlugId is required to be passed to the create endpoint so that register can do a 1-2-1 lookup of a record on the dqt api, rather than doing a dob match. This PR adds slugid to the body of the create request for contact & Initial Teacher Training.

https://trello.com/c/cawVJEpO/5523-add-slugid-to-create-dqt-api-getorcreateteacher-endpoint

### Changes proposed in this pull request

- Add SlugId to body of request.
- Update tests
- Make sure that a duplicate task is created when slugid is used by another contact.
- Include SlugId on the GetTeacherRequest
- Include SlugId on the GetOrCreateTeacher response if a duplicate is detected.
- Add Validation so that slugid is required if teachertype is traineeteacher.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
