### PR TITLE
Reduce DqtReportingService metrics to the one we actually use

### DIFF
--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Services/DqtReportingFixture.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Services/DqtReportingFixture.cs
@@ -44,7 +44,7 @@ public class DqtReportingFixture
             await service.LoadEntityMetadata();
 
             changesObserver.OnNext(new IChangedItem[] { changedItem });
-            var processTask = service.ProcessChangesForEntityType(Contact.EntityLogicalName, _ => { }, CancellationToken.None);
+            var processTask = service.ProcessChangesForEntityType(Contact.EntityLogicalName, CancellationToken.None);
             changesObserver.OnCompleted();
             await processTask;
         });


### PR DESCRIPTION
I went a little overboard when adding metrics to the first iteration of the `DqtReportingService`. In reality, we only use one: total updates processed. This PR removes the fine grained metrics to emit only one - `updates processed`. We issue one of those for each entity type, instead of one per tick of the timer. 