### PR TITLE
Fix migration in prod

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/Migrations/0006_Incident_msdyn_copilotengaged.sql
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Services/DqtReporting/Migrations/0006_Incident_msdyn_copilotengaged.sql
@@ -1,1 +1,2 @@
-alter table incident add msdyn_copilotengaged bit
+if not exists (select 1 from information_schema.columns where table_name = 'incident' and column_name = 'msdyn_copilotengaged')
+    alter table incident add msdyn_copilotengaged bit


### PR DESCRIPTION
Somehow this column already exists in prod; I suspect it may be that the prod CRM instance had this column added before we turned off Data Export Service.