### PR TITLE
Added support for sending EYTS awarded emails

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.GetEytsAwardeesForDateRange.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.GetEytsAwardeesForDateRange.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.Xrm.Sdk.Query;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+
+namespace QualifiedTeachersApi.DataStore.Crm;
+
+public partial class DataverseAdapter
+{
+    public async Task<EytsAwardee[]> GetEytsAwardeesForDateRange(DateTime startDate, DateTime endDate)
+    {
+        var filter = new FilterExpression(LogicalOperator.And);
+        filter.AddCondition(dfeta_businesseventaudit.Fields.CreatedOn, ConditionOperator.GreaterEqual, startDate);
+        filter.AddCondition(dfeta_businesseventaudit.Fields.CreatedOn, ConditionOperator.LessThan, endDate);
+        filter.AddCondition(dfeta_businesseventaudit.Fields.dfeta_changedfield, ConditionOperator.Equal, "EYTS Date");
+        filter.AddCondition(dfeta_businesseventaudit.Fields.dfeta_NewValue, ConditionOperator.NotNull);
+        filter.AddCondition(dfeta_businesseventaudit.Fields.dfeta_OldValue, ConditionOperator.Null);
+
+        var query = new QueryExpression(dfeta_businesseventaudit.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(
+                dfeta_businesseventaudit.Fields.CreatedOn,
+                dfeta_businesseventaudit.Fields.dfeta_changedfield,
+                dfeta_businesseventaudit.Fields.dfeta_NewValue,
+                dfeta_businesseventaudit.Fields.dfeta_OldValue,
+                dfeta_businesseventaudit.Fields.dfeta_Person),
+            Criteria = filter
+        };
+
+        AddContactLink(query);
+
+        var result = await _service.RetrieveMultipleAsync(query);
+        return result.Entities
+            .Select(e => e.ToEntity<dfeta_businesseventaudit>())
+            .Select(e => e.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute))
+            .GroupBy(c => c.ContactId)
+            .Select(g => MapContactToEytsAwardee(g.First()))
+            .ToArray();
+
+        static void AddContactLink(QueryExpression query)
+        {
+            var contactLink = query.AddLink(
+            Contact.EntityLogicalName,
+            dfeta_businesseventaudit.Fields.dfeta_Person,
+            Contact.PrimaryIdAttribute,
+            JoinOperator.Inner);
+
+            contactLink.Columns = new ColumnSet(
+                Contact.Fields.Id,
+                Contact.Fields.dfeta_TRN,
+                Contact.Fields.FirstName,
+                Contact.Fields.LastName,
+                Contact.Fields.dfeta_StatedFirstName,
+                Contact.Fields.dfeta_StatedLastName,
+                Contact.Fields.EMailAddress1,
+                Contact.Fields.EMailAddress2);
+            contactLink.EntityAlias = Contact.EntityLogicalName;
+
+            var filter = new FilterExpression();
+            filter.AddCondition(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active);
+            ////filter.AddCondition(Contact.Fields.dfeta_TRN, ConditionOperator.NotNull);
+            var emailAddressFilter = new FilterExpression(LogicalOperator.Or);
+            emailAddressFilter.AddCondition(Contact.Fields.EMailAddress1, ConditionOperator.NotNull);
+            emailAddressFilter.AddCondition(Contact.Fields.EMailAddress2, ConditionOperator.NotNull);
+            filter.AddFilter(emailAddressFilter);
+            contactLink.LinkCriteria = filter;
+
+            AddQtsRegistrationLink(contactLink);
+        }
+
+        static void AddQtsRegistrationLink(LinkEntity contactLink)
+        {
+            var qtsRegistrationLink = contactLink.AddLink(
+            dfeta_qtsregistration.EntityLogicalName,
+            Contact.PrimaryIdAttribute,
+            dfeta_qtsregistration.Fields.dfeta_PersonId,
+            JoinOperator.Inner);
+
+            qtsRegistrationLink.Columns = new ColumnSet(
+                dfeta_qtsregistration.Fields.dfeta_PersonId,
+                dfeta_qtsregistration.Fields.dfeta_EYTSDate,
+                dfeta_qtsregistration.Fields.StateCode);
+            qtsRegistrationLink.EntityAlias = dfeta_qtsregistration.EntityLogicalName;
+
+            var filter = new FilterExpression();
+            filter.AddCondition(dfeta_qtsregistration.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_qtsregistrationState.Active);
+            qtsRegistrationLink.LinkCriteria = filter;
+        }
+    }
+
+    private EytsAwardee MapContactToEytsAwardee(Contact contact)
+    {
+        return new EytsAwardee
+        {
+            TeacherId = contact.ContactId!.Value,
+            Trn = contact.dfeta_TRN,
+            FirstName = contact.ResolveFirstName(),
+            LastName = contact.ResolveLastName(),
+            EmailAddress = contact.EMailAddress1 ?? contact.EMailAddress2
+        };
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
@@ -96,4 +96,6 @@ public interface IDataverseAdapter
     Task<QtsAwardee[]> GetQtsAwardeesForDateRange(DateTime startDate, DateTime endDate);
 
     Task<InternationalQtsAwardee[]> GetInternationalQtsAwardeesForDateRange(DateTime startDate, DateTime endDate);
+
+    Task<EytsAwardee[]> GetEytsAwardeesForDateRange(DateTime startDate, DateTime endDate);
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/Models/EytsAwardee.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/Models/EytsAwardee.cs
@@ -1,0 +1,10 @@
+﻿namespace QualifiedTeachersApi.DataStore.Crm.Models;
+
+public record EytsAwardee
+{
+    public required Guid TeacherId { get; set; }
+    public required string Trn { get; set; }
+    public required string FirstName { get; set; }
+    public required string LastName { get; set; }
+    public required string EmailAddress { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/DqtContext.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/DqtContext.cs
@@ -28,6 +28,10 @@ public class DqtContext : DbContext
 
     public DbSet<InternationalQtsAwardedEmailsJobItem> InternationalQtsAwardedEmailsJobItems => Set<InternationalQtsAwardedEmailsJobItem>();
 
+    public DbSet<EytsAwardedEmailsJob> EytsAwardedEmailsJobs => Set<EytsAwardedEmailsJob>();
+
+    public DbSet<EytsAwardedEmailsJobItem> EytsAwardedEmailsJobItems => Set<EytsAwardedEmailsJobItem>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString)
     {
         if (connectionString != null)

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/EytsAwardedEmailsJobItemMapping.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/EytsAwardedEmailsJobItemMapping.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Infrastructure.EntityFramework;
+
+namespace QualifiedTeachersApi.DataStore.Sql.Mappings;
+
+public class EytsAwardedEmailsJobItemMapping : IEntityTypeConfiguration<EytsAwardedEmailsJobItem>
+{
+    public void Configure(EntityTypeBuilder<EytsAwardedEmailsJobItem> builder)
+    {
+        builder.ToTable("eyts_awarded_emails_job_items");
+        builder.Property(i => i.EytsAwardedEmailsJobId).IsRequired();
+        builder.Property(i => i.PersonId).IsRequired();
+        builder.HasKey(i => new { i.EytsAwardedEmailsJobId, i.PersonId });
+        builder.Property(i => i.Trn).IsRequired().HasMaxLength(7).IsFixedLength();
+        builder.Property(i => i.EmailAddress).IsRequired().HasMaxLength(200);
+        builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
+        builder.HasIndex(i => i.Personalization).HasMethod("gin");
+        builder.HasOne(i => i.EytsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.EytsAwardedEmailsJobId);
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/EytsAwardedEmailsJobMapping.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/EytsAwardedEmailsJobMapping.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+
+namespace QualifiedTeachersApi.DataStore.Sql.Mappings;
+
+public class EytsAwardedEmailsJobMapping : IEntityTypeConfiguration<EytsAwardedEmailsJob>
+{
+    public void Configure(EntityTypeBuilder<EytsAwardedEmailsJob> builder)
+    {
+        builder.ToTable("eyts_awarded_emails_jobs");
+        builder.Property(j => j.EytsAwardedEmailsJobId).IsRequired();
+        builder.HasKey(j => j.EytsAwardedEmailsJobId);
+        builder.Property(j => j.ExecutedUtc).IsRequired();
+        builder.HasIndex(j => j.ExecutedUtc).HasDatabaseName("ix_eyts_awarded_emails_jobs_executed_utc");
+        builder.Property(j => j.AwardedToUtc).IsRequired();
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/EytsAwardedEmailsJob.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/EytsAwardedEmailsJob.cs
@@ -1,0 +1,9 @@
+﻿namespace QualifiedTeachersApi.DataStore.Sql.Models;
+
+public class EytsAwardedEmailsJob
+{
+    public required Guid EytsAwardedEmailsJobId { get; set; }
+    public required DateTime AwardedToUtc { get; set; }
+    public required DateTime ExecutedUtc { get; set; }
+    public List<EytsAwardedEmailsJobItem>? JobItems { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/EytsAwardedEmailsJobItem.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/EytsAwardedEmailsJobItem.cs
@@ -1,0 +1,14 @@
+﻿namespace QualifiedTeachersApi.DataStore.Sql.Models;
+
+public class EytsAwardedEmailsJobItem
+{
+    public const int EmailAddressMaxLength = 200;
+
+    public required Guid EytsAwardedEmailsJobId { get; set; }
+    public EytsAwardedEmailsJob? EytsAwardedEmailsJob { get; set; }
+    public required Guid PersonId { get; set; }
+    public required string Trn { get; set; }
+    public required string EmailAddress { get; set; }
+    public required Dictionary<string, string> Personalization { get; set; }
+    public bool EmailSent { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/EytsAwardedEmailSentEvent.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/EytsAwardedEmailSentEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace QualifiedTeachersApi.Events;
+
+public record EytsAwardedEmailSentEvent : EventBase
+{
+    public required Guid EytsAwardedEmailsJobId { get; set; }
+    public required Guid PersonId { get; set; }
+    public required string EmailAddress { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/BatchSendEytsAwardedEmailsJob.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/BatchSendEytsAwardedEmailsJob.cs
@@ -1,0 +1,90 @@
+﻿using System.Transactions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Sql;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Jobs.Scheduling;
+
+namespace QualifiedTeachersApi.Jobs;
+
+public class BatchSendEytsAwardedEmailsJob
+{
+    private readonly BatchSendEytsAwardedEmailsJobOptions _batchSendEytsAwardedEmailsJobOptions;
+    private readonly DqtContext _dbContext;
+    private readonly IDataverseAdapter _dataverseAdapter;
+    private readonly IBackgroundJobScheduler _backgroundJobScheduler;
+    private readonly IClock _clock;
+
+    public BatchSendEytsAwardedEmailsJob(
+        IOptions<BatchSendEytsAwardedEmailsJobOptions> batchSendEytsAwardedEmailsJobOptions,
+        DqtContext dbContext,
+        IDataverseAdapter dataverseAdapter,
+        IBackgroundJobScheduler backgroundJobScheduler,
+        IClock clock)
+    {
+        _batchSendEytsAwardedEmailsJobOptions = batchSendEytsAwardedEmailsJobOptions.Value;
+        _dbContext = dbContext;
+        _dataverseAdapter = dataverseAdapter;
+        _backgroundJobScheduler = backgroundJobScheduler;
+        _clock = clock;
+    }
+
+    public async Task Execute(CancellationToken cancellationToken)
+    {
+        var lastAwardedToUtc = _batchSendEytsAwardedEmailsJobOptions.InitialLastAwardedToUtc;
+        var lastExecutedJob = await _dbContext.EytsAwardedEmailsJobs.OrderBy(j => j.ExecutedUtc).LastOrDefaultAsync();
+        if (lastExecutedJob != null)
+        {
+            lastAwardedToUtc = lastExecutedJob.AwardedToUtc;
+        }
+
+        // Look for new QTS awards up to the end of the day the configurable amount of days ago to provide a delay between award being given and email being sent.
+        var awardedToUtc = _clock.Today.AddDays(-_batchSendEytsAwardedEmailsJobOptions.EmailDelayDays).ToDateTime();
+
+        var executed = _clock.UtcNow;
+        var startDate = lastAwardedToUtc;
+        var endDate = awardedToUtc;
+        var eytsAwardedEmailsJobId = Guid.NewGuid();
+        var job = new EytsAwardedEmailsJob
+        {
+            EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,
+            AwardedToUtc = awardedToUtc,
+            ExecutedUtc = executed
+        };
+
+        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+        await _dbContext.EytsAwardedEmailsJobs.AddAsync(job, cancellationToken);
+
+        var eytsAwardees = await _dataverseAdapter.GetEytsAwardeesForDateRange(startDate, endDate);
+        foreach (var eytsAwardee in eytsAwardees)
+        {
+            var personalisation = new Dictionary<string, string>()
+            {
+                { "first name", eytsAwardee.FirstName },
+                { "last name", eytsAwardee.LastName },
+            };
+
+            var jobItem = new EytsAwardedEmailsJobItem
+            {
+                EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,
+                PersonId = eytsAwardee.TeacherId,
+                Trn = eytsAwardee.Trn,
+                EmailAddress = eytsAwardee.EmailAddress,
+                Personalization = personalisation
+            };
+
+            await _dbContext.EytsAwardedEmailsJobItems.AddAsync(jobItem, cancellationToken);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        if (eytsAwardees.Length > 0)
+        {
+            await _backgroundJobScheduler.Enqueue<EytsAwardedEmailJobDispatcher>(j => j.Execute(eytsAwardedEmailsJobId));
+        }
+
+        transaction.Complete();
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/BatchSendEytsAwardedEmailsJobOptions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/BatchSendEytsAwardedEmailsJobOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace QualifiedTeachersApi.Jobs.Scheduling;
+
+public class BatchSendEytsAwardedEmailsJobOptions
+{
+    public required DateTime InitialLastAwardedToUtc { get; init; }
+    public required int EmailDelayDays { get; init; }
+    public required string JobSchedule { get; init; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/RecurringJobsOptions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/RecurringJobsOptions.cs
@@ -4,4 +4,5 @@ public class RecurringJobsOptions
 {
     public required BatchSendQtsAwardedEmailsJobOptions BatchSendQtsAwardedEmails { get; init; }
     public required BatchSendInternationalQtsAwardedEmailsJobOptions BatchSendInternationalQtsAwardedEmails { get; init; }
+    public required BatchSendEytsAwardedEmailsJobOptions BatchSendEytsAwardedEmails { get; init; }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/RegisterRecurringJobsHostedService.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/RegisterRecurringJobsHostedService.cs
@@ -28,5 +28,6 @@ public class RegisterRecurringJobsHostedService : IHostedService
     {
         _recurringJobManager.AddOrUpdate<BatchSendQtsAwardedEmailsJob>(nameof(BatchSendQtsAwardedEmailsJob), job => job.Execute(CancellationToken.None), _recurringJobsOptions.BatchSendQtsAwardedEmails.JobSchedule);
         _recurringJobManager.AddOrUpdate<BatchSendInternationalQtsAwardedEmailsJob>(nameof(BatchSendInternationalQtsAwardedEmailsJob), job => job.Execute(CancellationToken.None), _recurringJobsOptions.BatchSendInternationalQtsAwardedEmails.JobSchedule);
+        _recurringJobManager.AddOrUpdate<BatchSendEytsAwardedEmailsJob>(nameof(BatchSendEytsAwardedEmailsJob), job => job.Execute(CancellationToken.None), _recurringJobsOptions.BatchSendEytsAwardedEmails.JobSchedule);
     }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/SendEytsAwardedEmailJob.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/SendEytsAwardedEmailJob.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using QualifiedTeachersApi.DataStore.Sql;
+using QualifiedTeachersApi.Events;
+using QualifiedTeachersApi.Services.AccessYourQualifications;
+using QualifiedTeachersApi.Services.GetAnIdentity.Api.Models;
+using QualifiedTeachersApi.Services.GetAnIdentityApi;
+using QualifiedTeachersApi.Services.Notify;
+
+namespace QualifiedTeachersApi.Jobs;
+
+public class SendEytsAwardedEmailJob
+{
+    private const string EytsAwardedEmailConfirmationTemplateId = "f85babdb-049b-4f32-9579-2a812acc0a2b";
+    private const string LinkToAccessYourQualificationsServicePersonalisationKey = "link to access your teaching qualifications service";
+    private readonly INotificationSender _notificationSender;
+    private readonly DqtContext _dbContext;
+    private readonly IGetAnIdentityApiClient _identityApiClient;
+    private readonly IClock _clock;
+    private readonly AccessYourQualificationsOptions _accessYourQualificationsOptions;
+
+    public SendEytsAwardedEmailJob(
+        INotificationSender notificationSender,
+        DqtContext dbContext,
+        IGetAnIdentityApiClient identityApiClient,
+        IOptions<AccessYourQualificationsOptions> accessYourQualificationsOptions,
+        IClock clock)
+    {
+        _notificationSender = notificationSender;
+        _dbContext = dbContext;
+        _identityApiClient = identityApiClient;
+        _clock = clock;
+        _accessYourQualificationsOptions = accessYourQualificationsOptions.Value;
+    }
+
+    public async Task Execute(Guid eytsAwardedEmailsJobId, Guid personId)
+    {
+        var item = await _dbContext.EytsAwardedEmailsJobItems.SingleAsync(i => i.EytsAwardedEmailsJobId == eytsAwardedEmailsJobId && i.PersonId == personId);
+
+        if (!item.Personalization.ContainsKey(LinkToAccessYourQualificationsServicePersonalisationKey))
+        {
+            var request = new CreateTrnTokenRequest
+            {
+                Trn = item.Trn,
+                Email = item.EmailAddress
+            };
+
+            var tokenResponse = await _identityApiClient.CreateTrnToken(request);
+            item.Personalization[LinkToAccessYourQualificationsServicePersonalisationKey] = $"{_accessYourQualificationsOptions.BaseAddress}/qualifications/start?trn_token={tokenResponse.TrnToken}";
+        }
+
+        await _notificationSender.SendEmail(EytsAwardedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
+        item.EmailSent = true;
+
+        _dbContext.AddEvent(new EytsAwardedEmailSentEvent
+        {
+            EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,
+            PersonId = personId,
+            EmailAddress = item.EmailAddress,
+            CreatedUtc = _clock.UtcNow,
+        });
+
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/ServiceCollectionExtensions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/ServiceCollectionExtensions.cs
@@ -36,12 +36,18 @@ public static class ServiceCollectionExtensions
                     .Bind(configuration.GetSection("RecurringJobs:BatchSendInternationalQtsAwardedEmails"))
                     .ValidateDataAnnotations()
                     .ValidateOnStart();
+                services.AddOptions<BatchSendEytsAwardedEmailsJobOptions>()
+                    .Bind(configuration.GetSection("RecurringJobs:BatchSendEytsAwardedEmails"))
+                    .ValidateDataAnnotations()
+                    .ValidateOnStart();
 
                 services.AddSingleton<IHostedService, RegisterRecurringJobsHostedService>();
                 services.AddTransient<SendQtsAwardedEmailJob>();
                 services.AddTransient<QtsAwardedEmailJobDispatcher>();
                 services.AddTransient<SendInternationalQtsAwardedEmailJob>();
                 services.AddTransient<InternationalQtsAwardedEmailJobDispatcher>();
+                services.AddTransient<SendEytsAwardedEmailJob>();
+                services.AddTransient<EytsAwardedEmailJobDispatcher>();
             }
 
             if (environment.IsProduction())

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230608155854_EytsAwardedEmailsJob.Designer.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230608155854_EytsAwardedEmailsJob.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using QualifiedTeachersApi.DataStore.Sql;
@@ -11,9 +12,11 @@ using QualifiedTeachersApi.DataStore.Sql;
 namespace QualifiedTeachersApi.Migrations
 {
     [DbContext(typeof(DqtContext))]
-    partial class DqtContextModelSnapshot : ModelSnapshot
+    [Migration("20230608155854_EytsAwardedEmailsJob")]
+    partial class EytsAwardedEmailsJob
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230608155854_EytsAwardedEmailsJob.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230608155854_EytsAwardedEmailsJob.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QualifiedTeachersApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class EytsAwardedEmailsJob : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "eyts_awarded_emails_jobs",
+                columns: table => new
+                {
+                    eyts_awarded_emails_job_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    awarded_to_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    executed_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_eyts_awarded_emails_jobs", x => x.eyts_awarded_emails_job_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "eyts_awarded_emails_job_items",
+                columns: table => new
+                {
+                    eyts_awarded_emails_job_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    person_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    trn = table.Column<string>(type: "character(7)", fixedLength: true, maxLength: 7, nullable: false),
+                    email_address = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    personalization = table.Column<string>(type: "jsonb", nullable: false),
+                    email_sent = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_eyts_awarded_emails_job_items", x => new { x.eyts_awarded_emails_job_id, x.person_id });
+                    table.ForeignKey(
+                        name: "fk_eyts_awarded_emails_job_items_eyts_awarded_emails_jobs_eyts",
+                        column: x => x.eyts_awarded_emails_job_id,
+                        principalTable: "eyts_awarded_emails_jobs",
+                        principalColumn: "eyts_awarded_emails_job_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_eyts_awarded_emails_job_items_personalization",
+                table: "eyts_awarded_emails_job_items",
+                column: "personalization")
+                .Annotation("Npgsql:IndexMethod", "gin");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_eyts_awarded_emails_jobs_executed_utc",
+                table: "eyts_awarded_emails_jobs",
+                column: "executed_utc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "eyts_awarded_emails_job_items");
+
+            migrationBuilder.DropTable(
+                name: "eyts_awarded_emails_jobs");
+        }
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetEytsAwardeesForDateRangeTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetEytsAwardeesForDateRangeTests.cs
@@ -1,0 +1,255 @@
+﻿using System.Diagnostics;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.DataverseIntegration;
+
+public class GetEytsAwardeesForDateRangeTests : IAsyncLifetime
+{
+    private CrmClientFixture.TestDataScope _dataScope;
+    private DataverseAdapter _dataverseAdapter;
+    private ITrackedEntityOrganizationService _organizationService;
+
+    public GetEytsAwardeesForDateRangeTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _dataverseAdapter = _dataScope.CreateDataverseAdapter();
+        _organizationService = _dataScope.OrganizationService;
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task GetEytsAwardeesForDateRange_WhenCalledForFixedDataInBuildEnvironment_ReturnsExpectedQtsAwardees()
+    {
+        // Arrange
+        var startDate = new DateTime(2023, 06, 2, 0, 0, 00, DateTimeKind.Utc);
+        var endDate = new DateTime(2023, 06, 3, 0, 0, 00, DateTimeKind.Utc);
+        var expectedCount = 18;
+
+        // Act
+        var eytsAwardees = await _dataverseAdapter.GetEytsAwardeesForDateRange(startDate, endDate);
+
+        // Assert
+        Assert.Equal(expectedCount, eytsAwardees.Count());
+    }
+
+    [Fact]
+    public async Task GetEytsAwardeesForDateRange_WhenCalledForDataGeneratedInTest_ReturnsExpectedQtsAwardees()
+    {
+        // Arrange
+        var teacher1FirstName = Faker.Name.First();
+        var teacher1LastName = Faker.Name.Last();
+        var teacher1EmailAddress1 = Faker.Internet.Email();
+        var teacher1DateOfBirth = new DateOnly(1997, 4, 22);
+        var teacher1EytsDate = new DateOnly(2022, 08, 23);
+        var teacher1EarlyYearsStatusValue = "221"; // Early Years Teacher Status
+
+        var teacher2FirstName = Faker.Name.First();
+        var teacher2LastName = Faker.Name.Last();
+        var teacher2EmailAddress1 = Faker.Internet.Email();
+        var teacher2DateOfBirth = new DateOnly(1997, 4, 23);
+        var teacher2EarlyYearsStatusValue = "220"; // Early Years Trainee
+
+        var teacher3FirstName = Faker.Name.First();
+        var teacher3LastName = Faker.Name.Last();
+        var teacher3EmailAddress2 = Faker.Internet.Email();
+        var teacher3DateOfBirth = new DateOnly(1997, 4, 24);
+        var teacher3EytsDate = new DateOnly(2022, 08, 25);
+        var teacher3EarlyYearsStatusValue = "222"; // Early Years Professional Status
+
+        var teacher4FirstName = Faker.Name.First();
+        var teacher4LastName = Faker.Name.Last();
+        var teacher4StatedFirstName = Faker.Name.First();
+        var teacher4StatedLastName = Faker.Name.Last();
+        var teacher4EmailAddress1 = Faker.Internet.Email();
+        var teacher4EmailAddress2 = Faker.Internet.Email();
+        var teacher4DateOfBirth = new DateOnly(1997, 4, 25);
+        var teacher4EytsDate = new DateOnly(2022, 08, 26);
+        var teacher4EarlyYearsStatusValue = "221"; // Early Years Teacher Status
+
+        var teacher5FirstName = Faker.Name.First();
+        var teacher5LastName = Faker.Name.Last();
+        var teacher5EmailAddress1 = Faker.Internet.Email();
+        var teacher5DateOfBirth = new DateOnly(1997, 4, 26);
+        var teacher5EytsDate = new DateOnly(2022, 08, 27);
+        var teacher5EarlyYearsStatusValue = "222"; // Early Years Professional Status
+
+        var startDate = DateTime.UtcNow;
+        var stopwatch = Stopwatch.StartNew();
+
+        var teacher1Id = await CreateTeacherWithEyts(
+            teacher1FirstName,
+            teacher1LastName,
+            null,
+            null,
+            teacher1EmailAddress1,
+            null,
+            teacher1DateOfBirth,
+            teacher1EytsDate,
+            teacher1EarlyYearsStatusValue);
+
+        await Task.Delay(3000);
+
+        var teacher2Id = await CreateTeacherWithEyts(
+            teacher2FirstName,
+            teacher2LastName,
+            null,
+            null,
+            teacher2EmailAddress1,
+            null,
+            teacher2DateOfBirth,
+            null,
+            teacher2EarlyYearsStatusValue);
+
+        await Task.Delay(3000);
+
+        var teacher3Id = await CreateTeacherWithEyts(
+            teacher3FirstName,
+            teacher3LastName,
+            null,
+            null,
+            null,
+            teacher3EmailAddress2,
+            teacher3DateOfBirth,
+            teacher3EytsDate,
+            teacher3EarlyYearsStatusValue);
+
+        await Task.Delay(3000);
+
+        var teacher4Id = await CreateTeacherWithEyts(
+            teacher4FirstName,
+            teacher4LastName,
+            teacher4StatedFirstName,
+            teacher4StatedLastName,
+            teacher4EmailAddress1,
+            teacher4EmailAddress2,
+            teacher4DateOfBirth,
+            teacher4EytsDate,
+            teacher4EarlyYearsStatusValue);
+
+        // Allow for the fact that we are using "less than" with the end date
+        await Task.Delay(1000);
+
+        stopwatch.Stop();
+        var endDate = startDate.AddSeconds(Math.Ceiling(stopwatch.Elapsed.TotalSeconds));
+
+        await Task.Delay(2000);
+
+        var teacher5Id = await CreateTeacherWithEyts(
+            teacher5FirstName,
+            teacher5LastName,
+            null,
+            null,
+            teacher5EmailAddress1,
+            null,
+            teacher5DateOfBirth,
+            teacher5EytsDate,
+            teacher5EarlyYearsStatusValue);
+
+        // Act
+        var eytsAwardees = await _dataverseAdapter.GetEytsAwardeesForDateRange(startDate, endDate);
+
+        // Assert
+        Assert.Equal(3, eytsAwardees.Count());
+        var teacher1 = eytsAwardees.SingleOrDefault(a => a.TeacherId == teacher1Id);
+        Assert.NotNull(teacher1);
+        Assert.Equal(teacher1FirstName, teacher1.FirstName);
+        Assert.Equal(teacher1LastName, teacher1.LastName);
+        Assert.Equal(teacher1EmailAddress1, teacher1.EmailAddress);
+        var teacher3 = eytsAwardees.SingleOrDefault(a => a.TeacherId == teacher3Id);
+        Assert.NotNull(teacher3);
+        Assert.Equal(teacher3Id, teacher3.TeacherId);
+        Assert.Equal(teacher3FirstName, teacher3.FirstName);
+        Assert.Equal(teacher3LastName, teacher3.LastName);
+        Assert.Equal(teacher3EmailAddress2, teacher3.EmailAddress);
+        var teacher4 = eytsAwardees.SingleOrDefault(a => a.TeacherId == teacher4Id);
+        Assert.NotNull(teacher4);
+        Assert.Equal(teacher4Id, teacher4.TeacherId);
+        Assert.Equal(teacher4StatedFirstName, teacher4.FirstName);
+        Assert.Equal(teacher4StatedLastName, teacher4.LastName);
+        Assert.Equal(teacher4EmailAddress1, teacher4.EmailAddress);
+    }
+
+    private async Task<Guid> CreateTeacherWithEyts(
+        string firstName,
+        string lastName,
+        string? statedFirstName,
+        string? statedLastName,
+        string? emailAddress1,
+        string? emailAddress2,
+        DateOnly dateOfBirth,
+        DateOnly? eytsDate,
+        string earlyYearsStatusValue)
+    {
+        var contact = new Contact()
+        {
+            FirstName = firstName,
+            LastName = lastName,
+            BirthDate = dateOfBirth.ToDateTime(),
+        };
+
+        if (statedFirstName != null)
+        {
+            contact.dfeta_StatedFirstName = statedFirstName;
+        }
+
+        if (statedLastName != null)
+        {
+            contact.dfeta_StatedLastName = statedLastName;
+        }
+
+        if (emailAddress1 != null)
+        {
+            contact.EMailAddress1 = emailAddress1;
+        }
+
+        if (emailAddress2 != null)
+        {
+            contact.EMailAddress2 = emailAddress2;
+        }
+
+        if (eytsDate != null)
+        {
+            contact.dfeta_EYTSDate = eytsDate.ToDateTime();
+        }
+
+        var teacherId = await _organizationService.CreateAsync(contact);
+
+        await _organizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new Contact()
+            {
+                Id = teacherId,
+                dfeta_TRNAllocateRequest = DateTime.UtcNow
+            }
+        });
+
+        await _organizationService.CreateAsync(new dfeta_initialteachertraining()
+        {
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+            dfeta_Result = dfeta_ITTResult.Pass,
+        });
+
+        var earlyYearsTeacherStatus = await _dataverseAdapter.GetEarlyYearsStatus(earlyYearsStatusValue, null);
+        var qtsRegistration = new dfeta_qtsregistration()
+        {
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+            dfeta_EarlyYearsStatusId = new EntityReference(dfeta_earlyyearsstatus.EntityLogicalName, earlyYearsTeacherStatus.Id)
+        };
+
+        if (eytsDate != null)
+        {
+            qtsRegistration.dfeta_EYTSDate = eytsDate.ToDateTime();
+        }
+
+        await _organizationService.CreateAsync(qtsRegistration);
+
+        return teacherId;
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/BatchSendEytsAwardedEmailsJobTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/BatchSendEytsAwardedEmailsJobTests.cs
@@ -1,0 +1,281 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Moq;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Jobs;
+using QualifiedTeachersApi.Jobs.Scheduling;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+public class BatchSendEytsAwardedEmailsJobTests : EytsAwardedEmailJobTestBase
+{
+    public BatchSendEytsAwardedEmailsJobTests(DbFixture dbFixture)
+        : base(dbFixture)
+    {
+    }
+
+    public static TheoryData<DateTime, DateTime?, DateTime, DateTime, DateTime> DateRangeEvaluationTestData { get; } = new()
+    {
+        // Last awarded to date and today minus email delay (3 days) are both within GMT
+        {
+            new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc),
+            null,
+            new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 02, 03, 0, 0, 0, DateTimeKind.Utc)
+        },
+        // Last awarded to date is within GMT and today minus email delay (3 days) is when it switches from GMT to BST
+        {
+            new DateTime(2023, 03, 26, 0, 0, 0, DateTimeKind.Utc),
+            null,
+            new DateTime(2023, 03, 30, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 03, 26, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 03, 27, 0, 0, 0, DateTimeKind.Utc)
+        },
+        // Last awarded to date and today minus email delay (3 days) are both within BST
+        {
+            new DateTime(2023, 04, 01, 0, 0, 0, DateTimeKind.Utc),
+            null,
+            new DateTime(2023, 04, 05, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 04, 01, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 04, 02, 0, 0, 0, DateTimeKind.Utc)
+        },
+        // Last awarded to date is within BST and today minus email delay (3 days) is when it switches from BST to GMT
+        {
+            new DateTime(2023, 10, 29, 0, 0, 0, DateTimeKind.Utc),
+            null,
+            new DateTime(2023, 11, 02, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 10, 29, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 10, 30, 0, 0, 0, DateTimeKind.Utc)
+        },
+        // Last awarded to date from previous job is used if available (rather than initial last awarded to date from config)
+        {
+            new DateTime(2022, 05, 23, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 02, 03, 0, 0, 0, DateTimeKind.Utc)
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(DateRangeEvaluationTestData))]
+    public async Task Execute_ForMultipleScenarios_EvaluatesDateRangeCorrectly(
+        DateTime initialLastAwardedToUtc,
+        DateTime? previousJobLastAwardedToUtc,
+        DateTime utcNow,
+        DateTime startExpected,
+        DateTime endExpected)
+    {
+        // Arrange
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var dataverseAdapter = new Mock<IDataverseAdapter>();
+        if (previousJobLastAwardedToUtc.HasValue)
+        {
+            var previousJob = new EytsAwardedEmailsJob
+            {
+                EytsAwardedEmailsJobId = Guid.NewGuid(),
+                AwardedToUtc = previousJobLastAwardedToUtc.Value,
+                ExecutedUtc = utcNow.AddDays(-1)
+            };
+            await dbContext.EytsAwardedEmailsJobs.AddAsync(previousJob);
+            await dbContext.SaveChangesAsync();
+        }
+
+        var jobOptions = Options.Create(
+            new BatchSendEytsAwardedEmailsJobOptions
+            {
+                EmailDelayDays = 3,
+                InitialLastAwardedToUtc = initialLastAwardedToUtc,
+                JobSchedule = "0 8 * * *"
+            });
+
+        clock.UtcNow = utcNow;
+
+        DateTime startActual = DateTime.MinValue;
+        DateTime endActual = DateTime.MaxValue;
+        dataverseAdapter
+            .Setup(d => d.GetEytsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(new EytsAwardee[] { })
+            .Callback<DateTime, DateTime>(
+                (start, end) =>
+                {
+                    startActual = start;
+                    endActual = end;
+                });
+
+        var job = new BatchSendEytsAwardedEmailsJob(
+            jobOptions,
+            dbContext,
+            dataverseAdapter.Object,
+            backgroundJobScheduler.Object,
+            clock);
+
+        // Act
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(startExpected, startActual);
+        Assert.Equal(endExpected, endActual);
+    }
+
+    [Fact]
+    public async Task Execute_WhenHasAwardeesForDateRange_UpdatesDatabaseAndEnqueuesJobToSendEmail()
+    {
+        // Arrange
+        var initialLastAwardedToUtc = new DateTime(2023, 02, 03, 0, 0, 0, DateTimeKind.Utc);
+        var today = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var dataverseAdapter = new Mock<IDataverseAdapter>();
+        var jobOptions = Options.Create(
+            new BatchSendEytsAwardedEmailsJobOptions
+            {
+                EmailDelayDays = 3,
+                InitialLastAwardedToUtc = initialLastAwardedToUtc,
+                JobSchedule = "0 8 * * *"
+            });
+
+        clock.UtcNow = today;
+
+        var eytsAwardee1 = new EytsAwardee
+        {
+            TeacherId = Guid.NewGuid(),
+            Trn = "1234567",
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            EmailAddress = Faker.Internet.Email()
+        };
+
+        var eytsAwardees = new[] { eytsAwardee1 };
+
+        dataverseAdapter
+            .Setup(d => d.GetEytsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(eytsAwardees);
+
+        var job = new BatchSendEytsAwardedEmailsJob(
+            jobOptions,
+            dbContext,
+            dataverseAdapter.Object,
+            backgroundJobScheduler.Object,
+            clock);
+
+        // Act
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        var jobItem = await dbContext.EytsAwardedEmailsJobItems.SingleOrDefaultAsync(i => i.PersonId == eytsAwardee1.TeacherId);
+        Assert.NotNull(jobItem);
+        Assert.Equal(eytsAwardee1.Trn, jobItem.Trn);
+        Assert.Equal(eytsAwardee1.EmailAddress, jobItem.EmailAddress);
+        Assert.Equal(eytsAwardee1.FirstName, jobItem.Personalization["first name"]);
+        Assert.Equal(eytsAwardee1.LastName, jobItem.Personalization["last name"]);
+
+        backgroundJobScheduler
+            .Verify(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<EytsAwardedEmailJobDispatcher, Task>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_WhenDoesNotHaveAwardeesForDateRange_UpdatesDatabaseOnly()
+    {
+        // Arrange
+        var initialLastAwardedToUtc = new DateTime(2023, 02, 03, 0, 0, 0, DateTimeKind.Utc);
+        var today = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var dataverseAdapter = new Mock<IDataverseAdapter>();
+        var jobOptions = Options.Create(
+            new BatchSendEytsAwardedEmailsJobOptions
+            {
+                EmailDelayDays = 3,
+                InitialLastAwardedToUtc = initialLastAwardedToUtc,
+                JobSchedule = "0 8 * * *"
+            });
+
+        clock.UtcNow = today;
+
+        dataverseAdapter
+            .Setup(d => d.GetEytsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(new EytsAwardee[] { });
+
+        var job = new BatchSendEytsAwardedEmailsJob(
+            jobOptions,
+            dbContext,
+            dataverseAdapter.Object,
+            backgroundJobScheduler.Object,
+            clock);
+
+        // Act
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        var jobInfo = await dbContext.EytsAwardedEmailsJobs.SingleOrDefaultAsync(j => j.ExecutedUtc == today);
+        Assert.NotNull(jobInfo);
+
+        backgroundJobScheduler
+            .Verify(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<EytsAwardedEmailJobDispatcher, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_WhenEnqueueFails_DoesNotUpdateDatabase()
+    {
+        // Arrange
+        var initialLastAwardedToUtc = new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc);
+        var today = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var dataverseAdapter = new Mock<IDataverseAdapter>();
+        var jobOptions = Options.Create(
+            new BatchSendEytsAwardedEmailsJobOptions
+            {
+                EmailDelayDays = 3,
+                InitialLastAwardedToUtc = initialLastAwardedToUtc,
+                JobSchedule = "0 8 * * *"
+            });
+
+        clock.UtcNow = today;
+
+        var eytsAwardee1 = new EytsAwardee
+        {
+            TeacherId = Guid.NewGuid(),
+            Trn = "1234567",
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            EmailAddress = Faker.Internet.Email()
+        };
+
+        var eytsAwardees = new[] { eytsAwardee1 };
+
+        dataverseAdapter
+            .Setup(d => d.GetEytsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(eytsAwardees);
+
+        backgroundJobScheduler
+            .Setup(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<EytsAwardedEmailJobDispatcher, Task>>>()))
+            .Throws<Exception>();
+
+        var job = new BatchSendEytsAwardedEmailsJob(
+            jobOptions,
+            dbContext,
+            dataverseAdapter.Object,
+            backgroundJobScheduler.Object,
+            clock);
+
+        // Act
+        await Assert.ThrowsAsync<Exception>(() => job.Execute(CancellationToken.None));
+
+        // Assert
+        var jobInfo = await dbContext.EytsAwardedEmailsJobs.SingleOrDefaultAsync(j => j.ExecutedUtc == today);
+        Assert.Null(jobInfo);
+        var jobItem = await dbContext.EytsAwardedEmailsJobItems.SingleOrDefaultAsync(i => i.PersonId == eytsAwardee1.TeacherId);
+        Assert.Null(jobItem);
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/EytsAwardedEmailJobCollection.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/EytsAwardedEmailJobCollection.cs
@@ -1,0 +1,8 @@
+﻿using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+[CollectionDefinition("EytsAwardedEmailJob")]
+public class EytsAwardedEmailJobCollection
+{
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/EytsAwardedEmailJobDispatcherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/EytsAwardedEmailJobDispatcherTests.cs
@@ -1,0 +1,106 @@
+﻿using Moq;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Jobs;
+using QualifiedTeachersApi.Jobs.Scheduling;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+public class EytsAwardedEmailJobDispatcherTests : EytsAwardedEmailJobTestBase
+{
+    public EytsAwardedEmailJobDispatcherTests(DbFixture dbFixture)
+        : base(dbFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Execute_WhenCalled_EnqueuesSendEmailJobForAllUnsentItems()
+    {
+        // Arrange
+        var utcNow = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var eytsAwardedEmailsJobId = Guid.NewGuid();
+        var teacher1PersonId = Guid.NewGuid();
+        var teacher1Trn = "1234567";
+        var teacher1EmailAddress = Faker.Internet.Email();
+        var teacher1FirstName = Faker.Name.First();
+        var teacher1LastName = Faker.Name.Last();
+        var teacher1Personalisation = new Dictionary<string, string>()
+        {
+            { "first name", teacher1FirstName },
+            { "last name", teacher1LastName },
+        };
+        var teacher2PersonId = Guid.NewGuid();
+        var teacher2Trn = "1234567";
+        var teacher2EmailAddress = Faker.Internet.Email();
+        var teacher2FirstName = Faker.Name.First();
+        var teacher2LastName = Faker.Name.Last();
+        var teacher2Personalisation = new Dictionary<string, string>()
+        {
+            { "first name", teacher1FirstName },
+            { "last name", teacher1LastName },
+        };
+        var teacher3PersonId = Guid.NewGuid();
+        var teacher3Trn = "1234567";
+        var teacher3EmailAddress = Faker.Internet.Email();
+        var teacher3FirstName = Faker.Name.First();
+        var teacher3LastName = Faker.Name.Last();
+        var teacher3Personalisation = new Dictionary<string, string>()
+        {
+            { "first name", teacher1FirstName },
+            { "last name", teacher1LastName },
+        };
+
+        var batchJob = new EytsAwardedEmailsJob
+        {
+            EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,
+            AwardedToUtc = utcNow.AddDays(-1),
+            ExecutedUtc = utcNow
+        };
+        dbContext.EytsAwardedEmailsJobs.Add(batchJob);
+
+        var jobItem1 = new EytsAwardedEmailsJobItem
+        {
+            EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,
+            PersonId = teacher1PersonId,
+            Trn = teacher1Trn,
+            EmailAddress = teacher1EmailAddress,
+            Personalization = teacher1Personalisation,
+            EmailSent = false
+        };
+        dbContext.EytsAwardedEmailsJobItems.Add(jobItem1);
+        var jobItem2 = new EytsAwardedEmailsJobItem
+        {
+            EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,
+            PersonId = teacher2PersonId,
+            Trn = teacher2Trn,
+            EmailAddress = teacher2EmailAddress,
+            Personalization = teacher2Personalisation,
+            EmailSent = true
+        };
+        dbContext.EytsAwardedEmailsJobItems.Add(jobItem2);
+        var jobItem3 = new EytsAwardedEmailsJobItem
+        {
+            EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,
+            PersonId = teacher3PersonId,
+            Trn = teacher3Trn,
+            EmailAddress = teacher3EmailAddress,
+            Personalization = teacher3Personalisation,
+            EmailSent = false
+        };
+        dbContext.EytsAwardedEmailsJobItems.Add(jobItem3);
+        await dbContext.SaveChangesAsync();
+
+        var dispatcher = new EytsAwardedEmailJobDispatcher(
+            dbContext,
+            backgroundJobScheduler.Object);
+
+        // Act
+        await dispatcher.Execute(eytsAwardedEmailsJobId);
+
+        // Assert
+        backgroundJobScheduler
+            .Verify(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<SendEytsAwardedEmailJob, Task>>>()), Times.Exactly(2));
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/EytsAwardedEmailJobTestBase.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/EytsAwardedEmailJobTestBase.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+[Collection("EytsAwardedEmailJob")]
+public abstract class EytsAwardedEmailJobTestBase : IAsyncLifetime
+{
+    public EytsAwardedEmailJobTestBase(DbFixture dbFixture)
+    {
+        DbFixture = dbFixture;
+    }
+
+    public DbFixture DbFixture { get; }
+
+    public async Task InitializeAsync()
+    {
+        using var dbContext = DbFixture.GetDbContext();
+        await dbContext.Database.ExecuteSqlAsync($"delete from eyts_awarded_emails_jobs");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}


### PR DESCRIPTION
### Context

We have a process for sending emails to QTS awardees and we want a similar process for EYTS recipients.

### Changes proposed in this pull request

Create a new job similar to that for QTS recipients but for those people receiving EYTS. (Those people can be identified by looking at the dfeta_eytsdate attribute instead of dfeta_qtsdate).

### Guidance to review

DB + Background jobs + tests

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
