### PR TITLE
Added support for generating induction completed emails in a background job

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/IDataverseAdapter.cs
@@ -98,4 +98,6 @@ public interface IDataverseAdapter
     Task<InternationalQtsAwardee[]> GetInternationalQtsAwardeesForDateRange(DateTime startDate, DateTime endDate);
 
     Task<EytsAwardee[]> GetEytsAwardeesForDateRange(DateTime startDate, DateTime endDate);
+
+    Task<InductionCompletee[]> GetInductionCompleteesForDateRange(DateTime startDate, DateTime endDate);
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/Models/InductionCompletee.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/Models/InductionCompletee.cs
@@ -1,0 +1,10 @@
+﻿namespace QualifiedTeachersApi.DataStore.Crm.Models;
+
+public record InductionCompletee
+{
+    public required Guid TeacherId { get; set; }
+    public required string Trn { get; set; }
+    public required string FirstName { get; set; }
+    public required string LastName { get; set; }
+    public required string EmailAddress { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/DqtContext.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/DqtContext.cs
@@ -32,6 +32,10 @@ public class DqtContext : DbContext
 
     public DbSet<EytsAwardedEmailsJobItem> EytsAwardedEmailsJobItems => Set<EytsAwardedEmailsJobItem>();
 
+    public DbSet<InductionCompletedEmailsJob> InductionCompletedEmailsJobs => Set<InductionCompletedEmailsJob>();
+
+    public DbSet<InductionCompletedEmailsJobItem> InductionCompletedEmailsJobItems => Set<InductionCompletedEmailsJobItem>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString)
     {
         if (connectionString != null)

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/InductionCompletedEmailsJobItemMapping.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/InductionCompletedEmailsJobItemMapping.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Infrastructure.EntityFramework;
+
+namespace QualifiedTeachersApi.DataStore.Sql.Mappings;
+
+public class InductionCompletedEmailsJobItemMapping : IEntityTypeConfiguration<InductionCompletedEmailsJobItem>
+{
+    public void Configure(EntityTypeBuilder<InductionCompletedEmailsJobItem> builder)
+    {
+        builder.ToTable("induction_completed_emails_job_items");
+        builder.Property(i => i.InductionCompletedEmailsJobId).IsRequired();
+        builder.Property(i => i.PersonId).IsRequired();
+        builder.HasKey(i => new { i.InductionCompletedEmailsJobId, i.PersonId });
+        builder.Property(i => i.Trn).IsRequired().HasMaxLength(7).IsFixedLength();
+        builder.Property(i => i.EmailAddress).IsRequired().HasMaxLength(200);
+        builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
+        builder.HasIndex(i => i.Personalization).HasMethod("gin");
+        builder.HasOne(i => i.InductionCompletedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.InductionCompletedEmailsJobId);
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/InductionCompletedEmailsJobMapping.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Mappings/InductionCompletedEmailsJobMapping.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+
+namespace QualifiedTeachersApi.DataStore.Sql.Mappings;
+
+public class InductionCompletedEmailsJobMapping : IEntityTypeConfiguration<InductionCompletedEmailsJob>
+{
+    public void Configure(EntityTypeBuilder<InductionCompletedEmailsJob> builder)
+    {
+        builder.ToTable("induction_completed_emails_jobs");
+        builder.Property(j => j.InductionCompletedEmailsJobId).IsRequired();
+        builder.HasKey(j => j.InductionCompletedEmailsJobId);
+        builder.Property(j => j.ExecutedUtc).IsRequired();
+        builder.HasIndex(j => j.ExecutedUtc).HasDatabaseName("ix_induction_completed_emails_jobs_executed_utc");
+        builder.Property(j => j.AwardedToUtc).IsRequired();
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/InductionCompletedEmailsJob.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/InductionCompletedEmailsJob.cs
@@ -1,0 +1,9 @@
+﻿namespace QualifiedTeachersApi.DataStore.Sql.Models;
+
+public class InductionCompletedEmailsJob
+{
+    public required Guid InductionCompletedEmailsJobId { get; set; }
+    public required DateTime AwardedToUtc { get; set; }
+    public required DateTime ExecutedUtc { get; set; }
+    public List<InductionCompletedEmailsJobItem>? JobItems { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/InductionCompletedEmailsJobItem.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Sql/Models/InductionCompletedEmailsJobItem.cs
@@ -1,0 +1,14 @@
+﻿namespace QualifiedTeachersApi.DataStore.Sql.Models;
+
+public class InductionCompletedEmailsJobItem
+{
+    public const int EmailAddressMaxLength = 200;
+
+    public required Guid InductionCompletedEmailsJobId { get; set; }
+    public InductionCompletedEmailsJob? InductionCompletedEmailsJob { get; set; }
+    public required Guid PersonId { get; set; }
+    public required string Trn { get; set; }
+    public required string EmailAddress { get; set; }
+    public required Dictionary<string, string> Personalization { get; set; }
+    public bool EmailSent { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/InductionCompletedEmailSentEvent.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Events/InductionCompletedEmailSentEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace QualifiedTeachersApi.Events;
+
+public record InductionCompletedEmailSentEvent : EventBase
+{
+    public required Guid InductionCompletedEmailsJobId { get; set; }
+    public required Guid PersonId { get; set; }
+    public required string EmailAddress { get; set; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/BatchSendInductionCompletedEmailsJob.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/BatchSendInductionCompletedEmailsJob.cs
@@ -1,0 +1,90 @@
+﻿using System.Transactions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Sql;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Jobs.Scheduling;
+
+namespace QualifiedTeachersApi.Jobs;
+
+public class BatchSendInductionCompletedEmailsJob
+{
+    private readonly BatchSendInductionCompletedEmailsJobOptions _batchSendInductionCompletedEmailsJobOptions;
+    private readonly DqtContext _dbContext;
+    private readonly IDataverseAdapter _dataverseAdapter;
+    private readonly IBackgroundJobScheduler _backgroundJobScheduler;
+    private readonly IClock _clock;
+
+    public BatchSendInductionCompletedEmailsJob(
+        IOptions<BatchSendInductionCompletedEmailsJobOptions> batchSendInductionCompletedEmailsJobOptions,
+        DqtContext dbContext,
+        IDataverseAdapter dataverseAdapter,
+        IBackgroundJobScheduler backgroundJobScheduler,
+        IClock clock)
+    {
+        _batchSendInductionCompletedEmailsJobOptions = batchSendInductionCompletedEmailsJobOptions.Value;
+        _dbContext = dbContext;
+        _dataverseAdapter = dataverseAdapter;
+        _backgroundJobScheduler = backgroundJobScheduler;
+        _clock = clock;
+    }
+
+    public async Task Execute(CancellationToken cancellationToken)
+    {
+        var lastAwardedToUtc = _batchSendInductionCompletedEmailsJobOptions.InitialLastAwardedToUtc;
+        var lastExecutedJob = await _dbContext.InductionCompletedEmailsJobs.OrderBy(j => j.ExecutedUtc).LastOrDefaultAsync();
+        if (lastExecutedJob != null)
+        {
+            lastAwardedToUtc = lastExecutedJob.AwardedToUtc;
+        }
+
+        // Look for new QTS awards up to the end of the day the configurable amount of days ago to provide a delay between award being given and email being sent.
+        var awardedToUtc = _clock.Today.AddDays(-_batchSendInductionCompletedEmailsJobOptions.EmailDelayDays).ToDateTime();
+
+        var executed = _clock.UtcNow;
+        var startDate = lastAwardedToUtc;
+        var endDate = awardedToUtc;
+        var inductionCompletedEmailsJobId = Guid.NewGuid();
+        var job = new InductionCompletedEmailsJob
+        {
+            InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+            AwardedToUtc = awardedToUtc,
+            ExecutedUtc = executed
+        };
+
+        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+        await _dbContext.InductionCompletedEmailsJobs.AddAsync(job, cancellationToken);
+
+        var inductionCompletees = await _dataverseAdapter.GetInductionCompleteesForDateRange(startDate, endDate);
+        foreach (var inductionCompletee in inductionCompletees)
+        {
+            var personalisation = new Dictionary<string, string>()
+            {
+                { "first name", inductionCompletee.FirstName },
+                { "last name", inductionCompletee.LastName },
+            };
+
+            var jobItem = new InductionCompletedEmailsJobItem
+            {
+                InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+                PersonId = inductionCompletee.TeacherId,
+                Trn = inductionCompletee.Trn,
+                EmailAddress = inductionCompletee.EmailAddress,
+                Personalization = personalisation
+            };
+
+            await _dbContext.InductionCompletedEmailsJobItems.AddAsync(jobItem, cancellationToken);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        if (inductionCompletees.Length > 0)
+        {
+            await _backgroundJobScheduler.Enqueue<InductionCompletedEmailJobDispatcher>(j => j.Execute(inductionCompletedEmailsJobId));
+        }
+
+        transaction.Complete();
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/InductionCompletedEmailJobDispatcher.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/InductionCompletedEmailJobDispatcher.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore;
+using QualifiedTeachersApi.DataStore.Sql;
+using QualifiedTeachersApi.Jobs.Scheduling;
+
+namespace QualifiedTeachersApi.Jobs;
+
+public class InductionCompletedEmailJobDispatcher
+{
+    private readonly DqtContext _dbContext;
+    private readonly IBackgroundJobScheduler _backgroundJobScheduler;
+
+    public InductionCompletedEmailJobDispatcher(
+        DqtContext dbContext,
+        IBackgroundJobScheduler backgroundJobScheduler)
+    {
+        _dbContext = dbContext;
+        _backgroundJobScheduler = backgroundJobScheduler;
+    }
+
+    public async Task Execute(Guid inductionCompletedEmailsJobId)
+    {
+        var jobItems = await _dbContext.InductionCompletedEmailsJobItems
+            .Where(i => i.InductionCompletedEmailsJobId == inductionCompletedEmailsJobId && i.EmailSent == false)
+            .ToListAsync();
+
+        foreach (var jobItem in jobItems)
+        {
+            await _backgroundJobScheduler.Enqueue<SendInductionCompletedEmailJob>(j => j.Execute(inductionCompletedEmailsJobId, jobItem.PersonId));
+        }
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/BatchSendInductionCompletedEmailsJobOptions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/BatchSendInductionCompletedEmailsJobOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace QualifiedTeachersApi.Jobs.Scheduling;
+
+public class BatchSendInductionCompletedEmailsJobOptions
+{
+    public required DateTime InitialLastAwardedToUtc { get; init; }
+    public required int EmailDelayDays { get; init; }
+    public required string JobSchedule { get; init; }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/RecurringJobsOptions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/Scheduling/RecurringJobsOptions.cs
@@ -5,4 +5,5 @@ public class RecurringJobsOptions
     public required BatchSendQtsAwardedEmailsJobOptions BatchSendQtsAwardedEmails { get; init; }
     public required BatchSendInternationalQtsAwardedEmailsJobOptions BatchSendInternationalQtsAwardedEmails { get; init; }
     public required BatchSendEytsAwardedEmailsJobOptions BatchSendEytsAwardedEmails { get; init; }
+    public required BatchSendInductionCompletedEmailsJobOptions BatchSendInductionCompletedEmails { get; init; }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/SendInductionCompletedEmailJob.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/SendInductionCompletedEmailJob.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using QualifiedTeachersApi.DataStore.Sql;
+using QualifiedTeachersApi.Events;
+using QualifiedTeachersApi.Services.AccessYourQualifications;
+using QualifiedTeachersApi.Services.GetAnIdentity.Api.Models;
+using QualifiedTeachersApi.Services.GetAnIdentityApi;
+using QualifiedTeachersApi.Services.Notify;
+
+namespace QualifiedTeachersApi.Jobs;
+
+public class SendInductionCompletedEmailJob
+{
+    private const string InductionCompletedEmailConfirmationTemplateId = "8029faa8-8409-4423-a717-c142dfd2ba86";
+    private const string LinkToAccessYourQualificationsServicePersonalisationKey = "link to access your teaching qualifications service";
+    private readonly INotificationSender _notificationSender;
+    private readonly DqtContext _dbContext;
+    private readonly IGetAnIdentityApiClient _identityApiClient;
+    private readonly IClock _clock;
+    private readonly AccessYourQualificationsOptions _accessYourQualificationsOptions;
+
+    public SendInductionCompletedEmailJob(
+        INotificationSender notificationSender,
+        DqtContext dbContext,
+        IGetAnIdentityApiClient identityApiClient,
+        IOptions<AccessYourQualificationsOptions> accessYourQualificationsOptions,
+        IClock clock)
+    {
+        _notificationSender = notificationSender;
+        _dbContext = dbContext;
+        _identityApiClient = identityApiClient;
+        _clock = clock;
+        _accessYourQualificationsOptions = accessYourQualificationsOptions.Value;
+    }
+
+    public async Task Execute(Guid inductionCompletedEmailsJobId, Guid personId)
+    {
+        var item = await _dbContext.InductionCompletedEmailsJobItems.SingleAsync(i => i.InductionCompletedEmailsJobId == inductionCompletedEmailsJobId && i.PersonId == personId);
+
+        if (!item.Personalization.ContainsKey(LinkToAccessYourQualificationsServicePersonalisationKey))
+        {
+            var request = new CreateTrnTokenRequest
+            {
+                Trn = item.Trn,
+                Email = item.EmailAddress
+            };
+
+            var tokenResponse = await _identityApiClient.CreateTrnToken(request);
+            item.Personalization[LinkToAccessYourQualificationsServicePersonalisationKey] = $"{_accessYourQualificationsOptions.BaseAddress}/qualifications/start?trn_token={tokenResponse.TrnToken}";
+        }
+
+        await _notificationSender.SendEmail(InductionCompletedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
+        item.EmailSent = true;
+
+        _dbContext.AddEvent(new InductionCompletedEmailSentEvent
+        {
+            InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+            PersonId = personId,
+            EmailAddress = item.EmailAddress,
+            CreatedUtc = _clock.UtcNow,
+        });
+
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/ServiceCollectionExtensions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Jobs/ServiceCollectionExtensions.cs
@@ -40,6 +40,10 @@ public static class ServiceCollectionExtensions
                     .Bind(configuration.GetSection("RecurringJobs:BatchSendEytsAwardedEmails"))
                     .ValidateDataAnnotations()
                     .ValidateOnStart();
+                services.AddOptions<BatchSendEytsAwardedEmailsJobOptions>()
+                    .Bind(configuration.GetSection("RecurringJobs:BatchSendInductionCompletedEmails"))
+                    .ValidateDataAnnotations()
+                    .ValidateOnStart();
 
                 services.AddSingleton<IHostedService, RegisterRecurringJobsHostedService>();
                 services.AddTransient<SendQtsAwardedEmailJob>();
@@ -48,6 +52,8 @@ public static class ServiceCollectionExtensions
                 services.AddTransient<InternationalQtsAwardedEmailJobDispatcher>();
                 services.AddTransient<SendEytsAwardedEmailJob>();
                 services.AddTransient<EytsAwardedEmailJobDispatcher>();
+                services.AddTransient<SendInductionCompletedEmailJob>();
+                services.AddTransient<InductionCompletedEmailJobDispatcher>();
             }
 
             if (environment.IsProduction())

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230609143020_InductionCompletedEmailsJob.Designer.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230609143020_InductionCompletedEmailsJob.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using QualifiedTeachersApi.DataStore.Sql;
@@ -11,9 +12,11 @@ using QualifiedTeachersApi.DataStore.Sql;
 namespace QualifiedTeachersApi.Migrations
 {
     [DbContext(typeof(DqtContext))]
-    partial class DqtContextModelSnapshot : ModelSnapshot
+    [Migration("20230609143020_InductionCompletedEmailsJob")]
+    partial class InductionCompletedEmailsJob
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230609143020_InductionCompletedEmailsJob.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Migrations/20230609143020_InductionCompletedEmailsJob.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QualifiedTeachersApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class InductionCompletedEmailsJob : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "induction_completed_emails_jobs",
+                columns: table => new
+                {
+                    induction_completed_emails_job_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    awarded_to_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    executed_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_induction_completed_emails_jobs", x => x.induction_completed_emails_job_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "induction_completed_emails_job_items",
+                columns: table => new
+                {
+                    induction_completed_emails_job_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    person_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    trn = table.Column<string>(type: "character(7)", fixedLength: true, maxLength: 7, nullable: false),
+                    email_address = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    personalization = table.Column<string>(type: "jsonb", nullable: false),
+                    email_sent = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_induction_completed_emails_job_items", x => new { x.induction_completed_emails_job_id, x.person_id });
+                    table.ForeignKey(
+                        name: "fk_induction_completed_emails_job_items_induction_completed_em",
+                        column: x => x.induction_completed_emails_job_id,
+                        principalTable: "induction_completed_emails_jobs",
+                        principalColumn: "induction_completed_emails_job_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_induction_completed_emails_job_items_personalization",
+                table: "induction_completed_emails_job_items",
+                column: "personalization")
+                .Annotation("Npgsql:IndexMethod", "gin");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_induction_completed_emails_jobs_executed_utc",
+                table: "induction_completed_emails_jobs",
+                column: "executed_utc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "induction_completed_emails_job_items");
+
+            migrationBuilder.DropTable(
+                name: "induction_completed_emails_jobs");
+        }
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetInductionCompleteesForDateRangeTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetInductionCompleteesForDateRangeTests.cs
@@ -1,0 +1,276 @@
+﻿using System.Diagnostics;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.DataverseIntegration;
+
+public class GetInductionCompleteesForDateRangeTests : IAsyncLifetime
+{
+    private CrmClientFixture.TestDataScope _dataScope;
+    private DataverseAdapter _dataverseAdapter;
+    private ITrackedEntityOrganizationService _organizationService;
+
+    public GetInductionCompleteesForDateRangeTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _dataverseAdapter = _dataScope.CreateDataverseAdapter();
+        _organizationService = _dataScope.OrganizationService;
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task GetInductionCompleteesForDateRange_WhenCalledForDataGeneratedInTest_ReturnsExpectedQtsAwardees()
+    {
+        // Arrange
+        var teacher1FirstName = Faker.Name.First();
+        var teacher1LastName = Faker.Name.Last();
+        var teacher1EmailAddress1 = Faker.Internet.Email();
+        var teacher1DateOfBirth = new DateOnly(1997, 4, 22);
+        var teacher1QtsDate = new DateOnly(2022, 08, 23);
+        var teacher1StatusValue = "100"; // Qualified Teacher: Assessment Only Route
+        var teacher1InitialInductionStatus = dfeta_InductionStatus.InProgress;
+        var teacher1FinalInductionStatus = dfeta_InductionStatus.Pass;
+
+        var teacher2FirstName = Faker.Name.First();
+        var teacher2LastName = Faker.Name.Last();
+        var teacher2EmailAddress1 = Faker.Internet.Email();
+        var teacher2DateOfBirth = new DateOnly(1997, 4, 23);
+        var teacher2QtsDate = new DateOnly(2022, 08, 24);
+        var teacher2StatusValue = "100"; // Qualified Teacher: Assessment Only Route
+        var teacher2FinalInductionStatus = dfeta_InductionStatus.FailedinWales;
+
+        var teacher3FirstName = Faker.Name.First();
+        var teacher3LastName = Faker.Name.Last();
+        var teacher3EmailAddress2 = Faker.Internet.Email();
+        var teacher3DateOfBirth = new DateOnly(1997, 4, 24);
+        var teacher3QtsDate = new DateOnly(2022, 08, 25);
+        var teacher3StatusValue = "71"; // Qualified teacher (trained)
+        var teacher3FinalInductionStatus = dfeta_InductionStatus.Pass;
+
+        var teacher4FirstName = Faker.Name.First();
+        var teacher4LastName = Faker.Name.Last();
+        var teacher4StatedFirstName = Faker.Name.First();
+        var teacher4StatedLastName = Faker.Name.Last();
+        var teacher4EmailAddress1 = Faker.Internet.Email();
+        var teacher4EmailAddress2 = Faker.Internet.Email();
+        var teacher4DateOfBirth = new DateOnly(1997, 4, 25);
+        var teacher4QtsDate = new DateOnly(2022, 08, 26);
+        var teacher4StatusValue = "100"; // Qualified Teacher: Assessment Only Route
+        var teacher4InitialInductionStatus = dfeta_InductionStatus.InProgress;
+        var teacher4FinalInductionStatus = dfeta_InductionStatus.Pass;
+
+        var teacher5FirstName = Faker.Name.First();
+        var teacher5LastName = Faker.Name.Last();
+        var teacher5EmailAddress1 = Faker.Internet.Email();
+        var teacher5DateOfBirth = new DateOnly(1997, 4, 26);
+        var teacher5QtsDate = new DateOnly(2022, 08, 27);
+        var teacher5StatusValue = "71"; // Qualified teacher (trained)
+        var teacher5FinalInductionStatus = dfeta_InductionStatus.Pass;
+
+        var startDate = DateTime.UtcNow;
+        var stopwatch = Stopwatch.StartNew();
+
+        var teacher1Id = await CreateTeacherWithInduction(
+            teacher1FirstName,
+            teacher1LastName,
+            null,
+            null,
+            teacher1EmailAddress1,
+            null,
+            teacher1DateOfBirth,
+            teacher1QtsDate,
+            teacher1StatusValue,
+            teacher1InitialInductionStatus,
+            teacher1FinalInductionStatus);
+
+        await Task.Delay(3000);
+
+        var teacher2Id = await CreateTeacherWithInduction(
+            teacher2FirstName,
+            teacher2LastName,
+            null,
+            null,
+            teacher2EmailAddress1,
+            null,
+            teacher2DateOfBirth,
+            teacher2QtsDate,
+            teacher2StatusValue,
+            null,
+            teacher2FinalInductionStatus);
+
+        await Task.Delay(3000);
+
+        var teacher3Id = await CreateTeacherWithInduction(
+            teacher3FirstName,
+            teacher3LastName,
+            null,
+            null,
+            null,
+            teacher3EmailAddress2,
+            teacher3DateOfBirth,
+            teacher3QtsDate,
+            teacher3StatusValue,
+            null,
+            teacher3FinalInductionStatus);
+
+        await Task.Delay(3000);
+
+        var teacher4Id = await CreateTeacherWithInduction(
+            teacher4FirstName,
+            teacher4LastName,
+            teacher4StatedFirstName,
+            teacher4StatedLastName,
+            teacher4EmailAddress1,
+            teacher4EmailAddress2,
+            teacher4DateOfBirth,
+            teacher4QtsDate,
+            teacher4StatusValue,
+            teacher4InitialInductionStatus,
+            teacher4FinalInductionStatus);
+
+        // Allow for the fact that we are using "less than" with the end date
+        await Task.Delay(1000);
+
+        stopwatch.Stop();
+        var endDate = startDate.AddSeconds(Math.Ceiling(stopwatch.Elapsed.TotalSeconds));
+
+        await Task.Delay(2000);
+
+        var teacher5Id = await CreateTeacherWithInduction(
+            teacher5FirstName,
+            teacher5LastName,
+            null,
+            null,
+            teacher5EmailAddress1,
+            null,
+            teacher5DateOfBirth,
+            teacher5QtsDate,
+            teacher5StatusValue,
+            null,
+            teacher5FinalInductionStatus);
+
+        // Act
+        var inductionCompletees = await _dataverseAdapter.GetInductionCompleteesForDateRange(startDate, endDate);
+
+        // Assert
+        Assert.Equal(3, inductionCompletees.Count());
+        var teacher1 = inductionCompletees.SingleOrDefault(a => a.TeacherId == teacher1Id);
+        Assert.NotNull(teacher1);
+        Assert.Equal(teacher1FirstName, teacher1.FirstName);
+        Assert.Equal(teacher1LastName, teacher1.LastName);
+        Assert.Equal(teacher1EmailAddress1, teacher1.EmailAddress);
+        var teacher3 = inductionCompletees.SingleOrDefault(a => a.TeacherId == teacher3Id);
+        Assert.NotNull(teacher3);
+        Assert.Equal(teacher3Id, teacher3.TeacherId);
+        Assert.Equal(teacher3FirstName, teacher3.FirstName);
+        Assert.Equal(teacher3LastName, teacher3.LastName);
+        Assert.Equal(teacher3EmailAddress2, teacher3.EmailAddress);
+        var teacher4 = inductionCompletees.SingleOrDefault(a => a.TeacherId == teacher4Id);
+        Assert.NotNull(teacher4);
+        Assert.Equal(teacher4Id, teacher4.TeacherId);
+        Assert.Equal(teacher4StatedFirstName, teacher4.FirstName);
+        Assert.Equal(teacher4StatedLastName, teacher4.LastName);
+        Assert.Equal(teacher4EmailAddress1, teacher4.EmailAddress);
+    }
+
+    private async Task<Guid> CreateTeacherWithInduction(
+        string firstName,
+        string lastName,
+        string? statedFirstName,
+        string? statedLastName,
+        string? emailAddress1,
+        string? emailAddress2,
+        DateOnly dateOfBirth,
+        DateOnly qtsDate,
+        string teacherStatusValue,
+        dfeta_InductionStatus? initialInductionStatus,
+        dfeta_InductionStatus finalInductionStatus)
+    {
+        var contact = new Contact()
+        {
+            FirstName = firstName,
+            LastName = lastName,
+            BirthDate = dateOfBirth.ToDateTime(),
+            dfeta_QTSDate = qtsDate.ToDateTime()
+        };
+
+        if (statedFirstName != null)
+        {
+            contact.dfeta_StatedFirstName = statedFirstName;
+        }
+
+        if (statedLastName != null)
+        {
+            contact.dfeta_StatedLastName = statedLastName;
+        }
+
+        if (emailAddress1 != null)
+        {
+            contact.EMailAddress1 = emailAddress1;
+        }
+
+        if (emailAddress2 != null)
+        {
+            contact.EMailAddress2 = emailAddress2;
+        }
+
+        var teacherId = await _organizationService.CreateAsync(contact);
+
+        await _organizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new Contact()
+            {
+                Id = teacherId,
+                dfeta_TRNAllocateRequest = DateTime.UtcNow
+            }
+        });
+
+        await _organizationService.CreateAsync(new dfeta_initialteachertraining()
+        {
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+            dfeta_Result = dfeta_ITTResult.Pass,
+        });
+
+        var teacherStatus = await _dataverseAdapter.GetTeacherStatus(teacherStatusValue, null);
+        await _organizationService.CreateAsync(new dfeta_qtsregistration()
+        {
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+            dfeta_TeacherStatusId = new EntityReference(dfeta_teacherstatus.EntityLogicalName, teacherStatus.Id),
+            dfeta_QTSDate = qtsDate.ToDateTime()
+        });
+
+        if (initialInductionStatus != null)
+        {
+            var inductionId = await _organizationService.CreateAsync(new dfeta_induction()
+            {
+                dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+                dfeta_InductionStatus = initialInductionStatus
+            });
+
+            await _organizationService.ExecuteAsync(new UpdateRequest()
+            {
+                Target = new dfeta_induction()
+                {
+                    Id = inductionId,
+                    dfeta_InductionStatus = finalInductionStatus
+                }
+            });
+        }
+        else
+        {
+            await _organizationService.CreateAsync(new dfeta_induction()
+            {
+                dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacherId),
+                dfeta_InductionStatus = finalInductionStatus
+            });
+        }
+
+        return teacherId;
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/BatchSendInductionCompletedEmailsJobTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/BatchSendInductionCompletedEmailsJobTests.cs
@@ -1,0 +1,281 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Moq;
+using QualifiedTeachersApi.DataStore.Crm;
+using QualifiedTeachersApi.DataStore.Crm.Models;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Jobs;
+using QualifiedTeachersApi.Jobs.Scheduling;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+public class BatchSendInductionCompletedEmailsJobTests : InductionCompletedEmailJobTestBase
+{
+    public BatchSendInductionCompletedEmailsJobTests(DbFixture dbFixture)
+        : base(dbFixture)
+    {
+    }
+
+    public static TheoryData<DateTime, DateTime?, DateTime, DateTime, DateTime> DateRangeEvaluationTestData { get; } = new()
+    {
+        // Last awarded to date and today minus email delay (3 days) are both within GMT
+        {
+            new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc),
+            null,
+            new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 02, 03, 0, 0, 0, DateTimeKind.Utc)
+        },
+        // Last awarded to date is within GMT and today minus email delay (3 days) is when it switches from GMT to BST
+        {
+            new DateTime(2023, 03, 26, 0, 0, 0, DateTimeKind.Utc),
+            null,
+            new DateTime(2023, 03, 30, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 03, 26, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 03, 27, 0, 0, 0, DateTimeKind.Utc)
+        },
+        // Last awarded to date and today minus email delay (3 days) are both within BST
+        {
+            new DateTime(2023, 04, 01, 0, 0, 0, DateTimeKind.Utc),
+            null,
+            new DateTime(2023, 04, 05, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 04, 01, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 04, 02, 0, 0, 0, DateTimeKind.Utc)
+        },
+        // Last awarded to date is within BST and today minus email delay (3 days) is when it switches from BST to GMT
+        {
+            new DateTime(2023, 10, 29, 0, 0, 0, DateTimeKind.Utc),
+            null,
+            new DateTime(2023, 11, 02, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 10, 29, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 10, 30, 0, 0, 0, DateTimeKind.Utc)
+        },
+        // Last awarded to date from previous job is used if available (rather than initial last awarded to date from config)
+        {
+            new DateTime(2022, 05, 23, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc),
+            new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2023, 02, 03, 0, 0, 0, DateTimeKind.Utc)
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(DateRangeEvaluationTestData))]
+    public async Task Execute_ForMultipleScenarios_EvaluatesDateRangeCorrectly(
+        DateTime initialLastAwardedToUtc,
+        DateTime? previousJobLastAwardedToUtc,
+        DateTime utcNow,
+        DateTime startExpected,
+        DateTime endExpected)
+    {
+        // Arrange
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var dataverseAdapter = new Mock<IDataverseAdapter>();
+        if (previousJobLastAwardedToUtc.HasValue)
+        {
+            var previousJob = new InductionCompletedEmailsJob
+            {
+                InductionCompletedEmailsJobId = Guid.NewGuid(),
+                AwardedToUtc = previousJobLastAwardedToUtc.Value,
+                ExecutedUtc = utcNow.AddDays(-1)
+            };
+            await dbContext.InductionCompletedEmailsJobs.AddAsync(previousJob);
+            await dbContext.SaveChangesAsync();
+        }
+
+        var jobOptions = Options.Create(
+            new BatchSendInductionCompletedEmailsJobOptions
+            {
+                EmailDelayDays = 3,
+                InitialLastAwardedToUtc = initialLastAwardedToUtc,
+                JobSchedule = "0 8 * * *"
+            });
+
+        clock.UtcNow = utcNow;
+
+        DateTime startActual = DateTime.MinValue;
+        DateTime endActual = DateTime.MaxValue;
+        dataverseAdapter
+            .Setup(d => d.GetInductionCompleteesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(new InductionCompletee[] { })
+            .Callback<DateTime, DateTime>(
+                (start, end) =>
+                {
+                    startActual = start;
+                    endActual = end;
+                });
+
+        var job = new BatchSendInductionCompletedEmailsJob(
+            jobOptions,
+            dbContext,
+            dataverseAdapter.Object,
+            backgroundJobScheduler.Object,
+            clock);
+
+        // Act
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(startExpected, startActual);
+        Assert.Equal(endExpected, endActual);
+    }
+
+    [Fact]
+    public async Task Execute_WhenHasCompleteesForDateRange_UpdatesDatabaseAndEnqueuesJobToSendEmail()
+    {
+        // Arrange
+        var initialLastAwardedToUtc = new DateTime(2023, 02, 03, 0, 0, 0, DateTimeKind.Utc);
+        var today = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var dataverseAdapter = new Mock<IDataverseAdapter>();
+        var jobOptions = Options.Create(
+            new BatchSendInductionCompletedEmailsJobOptions
+            {
+                EmailDelayDays = 3,
+                InitialLastAwardedToUtc = initialLastAwardedToUtc,
+                JobSchedule = "0 8 * * *"
+            });
+
+        clock.UtcNow = today;
+
+        var inductionCompletee1 = new InductionCompletee
+        {
+            TeacherId = Guid.NewGuid(),
+            Trn = "1234567",
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            EmailAddress = Faker.Internet.Email()
+        };
+
+        var inductionCompletees = new[] { inductionCompletee1 };
+
+        dataverseAdapter
+            .Setup(d => d.GetInductionCompleteesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(inductionCompletees);
+
+        var job = new BatchSendInductionCompletedEmailsJob(
+            jobOptions,
+            dbContext,
+            dataverseAdapter.Object,
+            backgroundJobScheduler.Object,
+            clock);
+
+        // Act
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        var jobItem = await dbContext.InductionCompletedEmailsJobItems.SingleOrDefaultAsync(i => i.PersonId == inductionCompletee1.TeacherId);
+        Assert.NotNull(jobItem);
+        Assert.Equal(inductionCompletee1.Trn, jobItem.Trn);
+        Assert.Equal(inductionCompletee1.EmailAddress, jobItem.EmailAddress);
+        Assert.Equal(inductionCompletee1.FirstName, jobItem.Personalization["first name"]);
+        Assert.Equal(inductionCompletee1.LastName, jobItem.Personalization["last name"]);
+
+        backgroundJobScheduler
+            .Verify(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<InductionCompletedEmailJobDispatcher, Task>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_WhenDoesNotHaveCompleteesForDateRange_UpdatesDatabaseOnly()
+    {
+        // Arrange
+        var initialLastAwardedToUtc = new DateTime(2023, 02, 03, 0, 0, 0, DateTimeKind.Utc);
+        var today = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var dataverseAdapter = new Mock<IDataverseAdapter>();
+        var jobOptions = Options.Create(
+            new BatchSendInductionCompletedEmailsJobOptions
+            {
+                EmailDelayDays = 3,
+                InitialLastAwardedToUtc = initialLastAwardedToUtc,
+                JobSchedule = "0 8 * * *"
+            });
+
+        clock.UtcNow = today;
+
+        dataverseAdapter
+            .Setup(d => d.GetInductionCompleteesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(new InductionCompletee[] { });
+
+        var job = new BatchSendInductionCompletedEmailsJob(
+            jobOptions,
+            dbContext,
+            dataverseAdapter.Object,
+            backgroundJobScheduler.Object,
+            clock);
+
+        // Act
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        var jobInfo = await dbContext.InductionCompletedEmailsJobs.SingleOrDefaultAsync(j => j.ExecutedUtc == today);
+        Assert.NotNull(jobInfo);
+
+        backgroundJobScheduler
+            .Verify(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<InductionCompletedEmailJobDispatcher, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_WhenEnqueueFails_DoesNotUpdateDatabase()
+    {
+        // Arrange
+        var initialLastAwardedToUtc = new DateTime(2023, 02, 02, 0, 0, 0, DateTimeKind.Utc);
+        var today = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var dataverseAdapter = new Mock<IDataverseAdapter>();
+        var jobOptions = Options.Create(
+            new BatchSendInductionCompletedEmailsJobOptions
+            {
+                EmailDelayDays = 3,
+                InitialLastAwardedToUtc = initialLastAwardedToUtc,
+                JobSchedule = "0 8 * * *"
+            });
+
+        clock.UtcNow = today;
+
+        var inductionCompletee1 = new InductionCompletee
+        {
+            TeacherId = Guid.NewGuid(),
+            Trn = "1234567",
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            EmailAddress = Faker.Internet.Email()
+        };
+
+        var inductionCompletees = new[] { inductionCompletee1 };
+
+        dataverseAdapter
+            .Setup(d => d.GetInductionCompleteesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(inductionCompletees);
+
+        backgroundJobScheduler
+            .Setup(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<InductionCompletedEmailJobDispatcher, Task>>>()))
+            .Throws<Exception>();
+
+        var job = new BatchSendInductionCompletedEmailsJob(
+            jobOptions,
+            dbContext,
+            dataverseAdapter.Object,
+            backgroundJobScheduler.Object,
+            clock);
+
+        // Act
+        await Assert.ThrowsAsync<Exception>(() => job.Execute(CancellationToken.None));
+
+        // Assert
+        var jobInfo = await dbContext.InductionCompletedEmailsJobs.SingleOrDefaultAsync(j => j.ExecutedUtc == today);
+        Assert.Null(jobInfo);
+        var jobItem = await dbContext.InductionCompletedEmailsJobItems.SingleOrDefaultAsync(i => i.PersonId == inductionCompletee1.TeacherId);
+        Assert.Null(jobItem);
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/InductionCompletedEmailJobCollection.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/InductionCompletedEmailJobCollection.cs
@@ -1,0 +1,8 @@
+﻿using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+[CollectionDefinition("InductionCompletedEmailJob")]
+public class InductionCompletedEmailJobCollection
+{
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/InductionCompletedEmailJobDispatcherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/InductionCompletedEmailJobDispatcherTests.cs
@@ -1,0 +1,106 @@
+﻿using Moq;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Jobs;
+using QualifiedTeachersApi.Jobs.Scheduling;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+public class InductionCompletedEmailJobDispatcherTests : InductionCompletedEmailJobTestBase
+{
+    public InductionCompletedEmailJobDispatcherTests(DbFixture dbFixture)
+        : base(dbFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Execute_WhenCalled_EnqueuesSendEmailJobForAllUnsentItems()
+    {
+        // Arrange
+        var utcNow = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
+        var inductionCompletedEmailsJobId = Guid.NewGuid();
+        var teacher1PersonId = Guid.NewGuid();
+        var teacher1Trn = "1234567";
+        var teacher1EmailAddress = Faker.Internet.Email();
+        var teacher1FirstName = Faker.Name.First();
+        var teacher1LastName = Faker.Name.Last();
+        var teacher1Personalisation = new Dictionary<string, string>()
+        {
+            { "first name", teacher1FirstName },
+            { "last name", teacher1LastName },
+        };
+        var teacher2PersonId = Guid.NewGuid();
+        var teacher2Trn = "1234567";
+        var teacher2EmailAddress = Faker.Internet.Email();
+        var teacher2FirstName = Faker.Name.First();
+        var teacher2LastName = Faker.Name.Last();
+        var teacher2Personalisation = new Dictionary<string, string>()
+        {
+            { "first name", teacher1FirstName },
+            { "last name", teacher1LastName },
+        };
+        var teacher3PersonId = Guid.NewGuid();
+        var teacher3Trn = "1234567";
+        var teacher3EmailAddress = Faker.Internet.Email();
+        var teacher3FirstName = Faker.Name.First();
+        var teacher3LastName = Faker.Name.Last();
+        var teacher3Personalisation = new Dictionary<string, string>()
+        {
+            { "first name", teacher1FirstName },
+            { "last name", teacher1LastName },
+        };
+
+        var batchJob = new InductionCompletedEmailsJob
+        {
+            InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+            AwardedToUtc = utcNow.AddDays(-1),
+            ExecutedUtc = utcNow
+        };
+        dbContext.InductionCompletedEmailsJobs.Add(batchJob);
+
+        var jobItem1 = new InductionCompletedEmailsJobItem
+        {
+            InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+            PersonId = teacher1PersonId,
+            Trn = teacher1Trn,
+            EmailAddress = teacher1EmailAddress,
+            Personalization = teacher1Personalisation,
+            EmailSent = false
+        };
+        dbContext.InductionCompletedEmailsJobItems.Add(jobItem1);
+        var jobItem2 = new InductionCompletedEmailsJobItem
+        {
+            InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+            PersonId = teacher2PersonId,
+            Trn = teacher2Trn,
+            EmailAddress = teacher2EmailAddress,
+            Personalization = teacher2Personalisation,
+            EmailSent = true
+        };
+        dbContext.InductionCompletedEmailsJobItems.Add(jobItem2);
+        var jobItem3 = new InductionCompletedEmailsJobItem
+        {
+            InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+            PersonId = teacher3PersonId,
+            Trn = teacher3Trn,
+            EmailAddress = teacher3EmailAddress,
+            Personalization = teacher3Personalisation,
+            EmailSent = false
+        };
+        dbContext.InductionCompletedEmailsJobItems.Add(jobItem3);
+        await dbContext.SaveChangesAsync();
+
+        var dispatcher = new InductionCompletedEmailJobDispatcher(
+            dbContext,
+            backgroundJobScheduler.Object);
+
+        // Act
+        await dispatcher.Execute(inductionCompletedEmailsJobId);
+
+        // Assert
+        backgroundJobScheduler
+            .Verify(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<SendInductionCompletedEmailJob, Task>>>()), Times.Exactly(2));
+    }
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/InductionCompletedEmailJobTestBase.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/InductionCompletedEmailJobTestBase.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+[Collection("InductionCompletedEmailJob")]
+public abstract class InductionCompletedEmailJobTestBase : IAsyncLifetime
+{
+    public InductionCompletedEmailJobTestBase(DbFixture dbFixture)
+    {
+        DbFixture = dbFixture;
+    }
+
+    public DbFixture DbFixture { get; }
+
+    public async Task InitializeAsync()
+    {
+        using var dbContext = DbFixture.GetDbContext();
+        await dbContext.Database.ExecuteSqlAsync($"delete from induction_completed_emails_jobs");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/SendInductionCompletedEmailJobTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/Jobs/SendInductionCompletedEmailJobTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Moq;
+using QualifiedTeachersApi.DataStore.Sql.Models;
+using QualifiedTeachersApi.Events;
+using QualifiedTeachersApi.Jobs;
+using QualifiedTeachersApi.Services.AccessYourQualifications;
+using QualifiedTeachersApi.Services.GetAnIdentity.Api.Models;
+using QualifiedTeachersApi.Services.GetAnIdentityApi;
+using QualifiedTeachersApi.Services.Notify;
+using Xunit;
+
+namespace QualifiedTeachersApi.Tests.Jobs;
+
+public class SendInductionCompletedEmailJobTests : InductionCompletedEmailJobTestBase
+{
+    public SendInductionCompletedEmailJobTests(DbFixture dbFixture)
+        : base(dbFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Execute_WhenCalled_GetsTrnTokenSendsEmailAddsEventAndUpdatesDatabase()
+    {
+        // Arrange
+        var utcNow = new DateTime(2023, 02, 06, 08, 00, 00, DateTimeKind.Utc);
+        using var dbContext = DbFixture.GetDbContext();
+        var clock = new TestableClock();
+        var notificationSender = new Mock<INotificationSender>();
+        var getAnIdentityApiClient = new Mock<IGetAnIdentityApiClient>();
+        var accessYourQualificationOptions = Options.Create(
+            new AccessYourQualificationsOptions
+            {
+                BaseAddress = "https://aytq.com"
+            });
+        clock.UtcNow = utcNow;
+        var inductionCompletedEmailsJobId = Guid.NewGuid();
+        var personId = Guid.NewGuid();
+        var trn = "1234567";
+        var emailAddress = Faker.Internet.Email();
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+        var personalisation = new Dictionary<string, string>()
+        {
+            { "first name", firstName },
+            { "last name", lastName },
+        };
+
+        var batchJob = new InductionCompletedEmailsJob
+        {
+            InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+            AwardedToUtc = utcNow.AddDays(-1),
+            ExecutedUtc = utcNow
+        };
+        dbContext.InductionCompletedEmailsJobs.Add(batchJob);
+
+        var jobItem = new InductionCompletedEmailsJobItem
+        {
+            InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
+            PersonId = personId,
+            Trn = trn,
+            EmailAddress = emailAddress,
+            Personalization = personalisation
+        };
+        dbContext.InductionCompletedEmailsJobItems.Add(jobItem);
+        await dbContext.SaveChangesAsync();
+
+        var tokenResponse = new CreateTrnTokenResponse
+        {
+            Email = emailAddress,
+            Trn = trn,
+            TrnToken = "Thisismytrntoken",
+            ExpiresUtc = utcNow.AddDays(60)
+        };
+
+        getAnIdentityApiClient
+            .Setup(i => i.CreateTrnToken(It.Is<CreateTrnTokenRequest>(r => r.Trn == trn && r.Email == emailAddress)))
+            .ReturnsAsync(tokenResponse);
+
+        var job = new SendInductionCompletedEmailJob(
+            notificationSender.Object,
+            dbContext,
+            getAnIdentityApiClient.Object,
+            accessYourQualificationOptions,
+            clock);
+
+        // Act
+        await job.Execute(inductionCompletedEmailsJobId, personId);
+
+        // Assert
+        notificationSender
+            .Verify(n => n.SendEmail(It.IsAny<string>(), It.Is<string>(s => s == emailAddress), It.IsAny<IReadOnlyDictionary<string, string>>()), Times.Once);
+
+        var updatedJobItem = await dbContext.InductionCompletedEmailsJobItems.SingleOrDefaultAsync(i => i.InductionCompletedEmailsJobId == inductionCompletedEmailsJobId && i.PersonId == personId);
+        Assert.NotNull(updatedJobItem);
+        Assert.True(updatedJobItem.EmailSent);
+
+        var events = await dbContext.Events
+                                .Where(e => e.EventName == "InductionCompletedEmailSentEvent")
+                                .ToListAsync();
+        var emailSentEvent = events
+                .Select(e => JsonSerializer.Deserialize<InductionCompletedEmailSentEvent>(e.Payload))
+                .Where(e => e!.InductionCompletedEmailsJobId == inductionCompletedEmailsJobId && e.PersonId == personId)
+                .SingleOrDefault();
+        Assert.NotNull(emailSentEvent);
+    }
+}


### PR DESCRIPTION
### Context

We have a process for sending emails to QTS awardees and we want something similar for those who have passed induction.

### Changes proposed in this pull request

Create a new job similar to that for QTS recipients but for those people who have passed induction.

### Guidance to review

DB changes + background jobs + tests

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
