### PR TITLE
Added HigherEducationQualifications section to V3 endpoints

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetTeacherRequest.cs
@@ -22,6 +22,7 @@ public enum GetTeacherRequestIncludes
     NpqQualifications = 1 << 2,
     MandatoryQualifications = 1 << 3,
     PendingDetailChanges = 1 << 4,
+    HigherEducationQualifications = 1 << 5,
 
-    All = Induction | InitialTeacherTraining | NpqQualifications | MandatoryQualifications | PendingDetailChanges
+    All = Induction | InitialTeacherTraining | NpqQualifications | MandatoryQualifications | PendingDetailChanges | HigherEducationQualifications
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Responses/GetTeacherResponse.cs
@@ -20,6 +20,7 @@ public record GetTeacherResponse
     public required Option<IEnumerable<GetTeacherResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
     public required Option<IEnumerable<GetTeacherResponseNpqQualificationsQualification>> NpqQualifications { get; init; }
     public required Option<IEnumerable<GetTeacherResponseMandatoryQualificationsQualification>> MandatoryQualifications { get; init; }
+    public required Option<IEnumerable<GetTeacherResponseHigherEducationQualificationsQualification>> HigherEducationQualifications { get; init; }
 }
 
 public record GetTeacherResponseQts
@@ -111,4 +112,17 @@ public record GetTeacherResponseMandatoryQualificationsQualification
 {
     public required DateOnly Awarded { get; init; }
     public required string Specialism { get; init; }
+}
+
+public record GetTeacherResponseHigherEducationQualificationsQualification
+{
+    public required string Name { get; init; }
+    public required DateOnly? Awarded { get; init; }
+    public required IEnumerable<GetTeacherResponseHigherEducationQualificationsQualificationSubject> Subjects { get; init; }
+}
+
+public record GetTeacherResponseHigherEducationQualificationsQualificationSubject
+{
+    public required string Code { get; init; }
+    public required string Name { get; init; }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherByTrnTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherByTrnTests.cs
@@ -67,30 +67,39 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
     }
 
     [Fact]
-    public Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInductionContent()
+    public Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent()
     {
         var trn = "1234567";
         var baseUrl = $"/v3/teachers/{trn}";
 
-        return ValidRequestWithInitialTeacherTraining_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, trn);
+        return ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(HttpClientWithApiKey, baseUrl, trn);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedInductionContent()
+    public Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent()
     {
         var trn = "1234567";
         var baseUrl = $"/v3/teachers/{trn}";
 
-        return ValidRequestWithNpqQualifications_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, trn, expectCertificateUrls: false);
+        return ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(HttpClientWithApiKey, baseUrl, trn, expectCertificateUrls: false);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedInductionContent()
+    public Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
     {
         var trn = "1234567";
         var baseUrl = $"/v3/teachers/{trn}";
 
-        return ValidRequestWithMandatoryQualifications_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, trn);
+        return ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent(HttpClientWithApiKey, baseUrl, trn);
+    }
+
+    [Fact]
+    public Task Get_ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent()
+    {
+        var trn = "1234567";
+        var baseUrl = $"/v3/teachers/{trn}";
+
+        return ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(HttpClientWithApiKey, baseUrl, trn);
     }
 
     [Fact]

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V3/GetTeacherTests.cs
@@ -56,33 +56,43 @@ public class GetTeacherTests : GetTeacherTestBase
     }
 
     [Fact]
-    public Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInductionContent()
+    public Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent()
     {
         var trn = "1234567";
         var httpClient = GetHttpClientWithIdentityAccessToken(trn);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithInitialTeacherTraining_ReturnsExpectedInductionContent(httpClient, baseUrl, trn);
+        return ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(httpClient, baseUrl, trn);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedInductionContent()
+    public Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent()
     {
         var trn = "1234567";
         var httpClient = GetHttpClientWithIdentityAccessToken(trn);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithNpqQualifications_ReturnsExpectedInductionContent(httpClient, baseUrl, trn, expectCertificateUrls: true);
+        return ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(httpClient, baseUrl, trn, expectCertificateUrls: true);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedInductionContent()
+    public Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
     {
         var trn = "1234567";
         var httpClient = GetHttpClientWithIdentityAccessToken(trn);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithMandatoryQualifications_ReturnsExpectedInductionContent(httpClient, baseUrl, trn);
+        return ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent(httpClient, baseUrl, trn);
+    }
+
+    [Fact]
+    public Task Get_ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent()
+    {
+        var trn = "1234567";
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var baseUrl = "/v3/teacher";
+
+        return ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(httpClient, baseUrl, trn);
     }
 
     [Fact]


### PR DESCRIPTION
### Context

To be able to move to the v3 endpoints, Claim need HE qualifications to be returned.

### Changes proposed in this pull request

Amend the `/v3/teacher` and `/v3/teachers/{trn}` endpoints to accept an additional `Includes` parameter - `HigherEducationQualifications`. When this is specified in the request, include an additional block in the response with the following schema:

```json
{
  "higherEducationQualifications": [
    {
      "name": "",
      "awarded": "YYYY-MM-DD",
      "subjects": [
        {
          "code": "",
          "name": ""
        }
      ]
    }
  ]
}
```

N.B. We don’t always have an awarded date, so the `awarded` property will have to be nullable.

### Guidance to review

Change to V3 endpoint + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
