### PR TITLE
Initial changes to support running on AKS

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Logging/WebApplicationBuilderExtensions.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/Logging/WebApplicationBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace QualifiedTeachersApi.Infrastructure.Logging;
 
 public static class WebApplicationBuilderExtensions
 {
-    public static WebApplicationBuilder ConfigureLogging(this WebApplicationBuilder builder, string? paasEnvironmentName)
+    public static WebApplicationBuilder ConfigureLogging(this WebApplicationBuilder builder, string? platformEnvironmentName)
     {
         if (builder.Environment.IsProduction())
         {
@@ -19,9 +19,9 @@ public static class WebApplicationBuilderExtensions
 
             builder.Services.Configure<SentryAspNetCoreOptions>(options =>
             {
-                if (!string.IsNullOrEmpty(paasEnvironmentName))
+                if (!string.IsNullOrEmpty(platformEnvironmentName))
                 {
-                    options.Environment = paasEnvironmentName;
+                    options.Environment = platformEnvironmentName;
                 }
 
                 var gitSha = builder.Configuration["GitSha"];

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.Development.json
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "DetailedErrors": true,
+  "Platform": "Local",
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.Testing.json
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/appsettings.Testing.json
@@ -1,4 +1,5 @@
 {
+  "Platform": "Local",
   "ApiClients": {
     "tests": {
       "ApiKey": [ "tests" ]

--- a/terraform/api-app.tf
+++ b/terraform/api-app.tf
@@ -18,8 +18,9 @@ locals {
         "ConnectionStrings:DefaultConnection"  = local.pg_connection_string,
         "ConnectionStrings:Redis"              = local.redis_connection_string,
         "DistributedLockContainerName"         = local.distributed_lock_container_name,
-        "PaasEnvironment"                      = var.environment_name,
+        "PlatformEnvironment"                  = var.environment_name,
         "StorageConnectionString"              = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.app-storage.name};AccountKey=${azurerm_storage_account.app-storage.primary_access_key}",
+        "Platform"                             = "PAAS"
       }
     ))
   }


### PR DESCRIPTION
- Rename `paasEnvironmentName` to `platformEnvironmentName`.
- Don't host a metrics endpoint unless we're running on PAAS.