### PR TITLE
Added check to get NPQ certificate that the qualification Id is associated with the authenticated user

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/OpenApi/OpenApiEndpointsStartupFilter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/Infrastructure/OpenApi/OpenApiEndpointsStartupFilter.cs
@@ -53,7 +53,15 @@ public class OpenApiEndpointsStartupFilter : IStartupFilter
                     ClientSecret = _identityOptionsAccessor.Value.ClientSecret,
                     UsePkceWithAuthorizationCodeGrant = true
                 };
+
+                settings.CustomJavaScriptPath = "/docs/swagger-custom.js";
             }
         });
+
+        if (_environment.IsDevelopment())
+        {
+            // Needed to use custom Javascript for Swagger UI
+            app.UseStaticFiles();
+        }
     };
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/CertificatesController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/CertificatesController.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using System.ComponentModel;
+using System.Security.Claims;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -129,7 +130,7 @@ public class CertificatesController : Controller
         description: "Returns a PDF of the NPQ Certificate associated with the provided qualification ID.")]
     [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK, "application/pdf")]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetNpq([FromRoute] Guid qualificationId)
+    public async Task<IActionResult> GetNpq([FromRoute][Description("The ID of the qualification record associated with the certificate.")] Guid qualificationId)
     {
         var trn = User.FindFirstValue("trn");
         if (trn is null)

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/CertificatesController.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Controllers/CertificatesController.cs
@@ -129,8 +129,20 @@ public class CertificatesController : Controller
         description: "Returns a PDF of the NPQ Certificate associated with the provided qualification ID.")]
     [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK, "application/pdf")]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetNpq(GetNpqCertificateRequest request)
+    public async Task<IActionResult> GetNpq([FromRoute] Guid qualificationId)
     {
+        var trn = User.FindFirstValue("trn");
+        if (trn is null)
+        {
+            return NotFound();
+        }
+
+        var request = new GetNpqCertificateRequest()
+        {
+            QualificationId = qualificationId,
+            Trn = trn
+        };
+
         var response = await _mediator.Send(request);
         if (response is null)
         {

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetNpqCertificateHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Handlers/GetNpqCertificateHandler.cs
@@ -39,7 +39,8 @@ public class GetNpqCertificateHandler : IRequestHandler<GetNpqCertificateRequest
                 Contact.PrimaryIdAttribute,
                 Contact.Fields.FirstName,
                 Contact.Fields.MiddleName,
-                Contact.Fields.LastName
+                Contact.Fields.LastName,
+                Contact.Fields.dfeta_TRN
             });
 
         if (qualification == null
@@ -51,7 +52,8 @@ public class GetNpqCertificateHandler : IRequestHandler<GetNpqCertificateRequest
         }
 
         var teacher = qualification.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute);
-        if (teacher == null)
+        if (teacher == null
+            || teacher.dfeta_TRN != request.Trn)
         {
             return null;
         }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetNpqCertificateRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetNpqCertificateRequest.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using MediatR;
 using QualifiedTeachersApi.V3.Responses;
 
@@ -6,7 +5,6 @@ namespace QualifiedTeachersApi.V3.Requests;
 
 public record GetNpqCertificateRequest : IRequest<GetCertificateResponse?>
 {
-    [Description("The ID of the qualification record associated with the certificate.")]
     public required Guid QualificationId { get; set; }
 
     public required string Trn { get; init; }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetNpqCertificateRequest.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V3/Requests/GetNpqCertificateRequest.cs
@@ -1,13 +1,13 @@
 using System.ComponentModel;
 using MediatR;
-using Microsoft.AspNetCore.Mvc;
 using QualifiedTeachersApi.V3.Responses;
 
 namespace QualifiedTeachersApi.V3.Requests;
 
 public record GetNpqCertificateRequest : IRequest<GetCertificateResponse?>
 {
-    [FromRoute(Name = "qualificationId")]
     [Description("The ID of the qualification record associated with the certificate.")]
     public required Guid QualificationId { get; set; }
+
+    public required string Trn { get; init; }
 }

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/wwwroot/docs/swagger-custom.js
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/wwwroot/docs/swagger-custom.js
@@ -1,0 +1,9 @@
+﻿window.fetch = function (fetch) {
+  return function () {
+    var req = arguments[1];
+    if (req.headers["X-Requested-With"]) {
+      delete req.headers["X-Requested-With"];
+    }
+    return fetch.apply(window, arguments);
+  };
+}(window.fetch);


### PR DESCRIPTION
### Context

The endpoint that returns a NPQ certificate takes a qualification ID parameter (since a teacher can have multiple). We don’t currently check that the current user owns the qualification specified which could allow a teacher to get a certificate for a qualification that isn’t their own.

### Changes proposed in this pull request

Add an additional check to the GetNpqCertificateHandler that the qualification specified belongs to the currently authenticated teacher. If it does not, return null from the handler.

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
