### PR TITLE
Add middle name to V2 find teachers response

### DIFF
--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/DataStore/Crm/DataverseAdapter.cs
@@ -1135,6 +1135,7 @@ public partial class DataverseAdapter : IDataverseAdapter
                 Contact.Fields.dfeta_TRN,
                 Contact.Fields.EMailAddress1,
                 Contact.Fields.FirstName,
+                Contact.Fields.MiddleName,
                 Contact.Fields.LastName,
                 Contact.Fields.BirthDate,
                 Contact.Fields.dfeta_NINumber,

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/FindTeachersHandler.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Handlers/FindTeachersHandler.cs
@@ -68,6 +68,7 @@ public class FindTeachersHandler : IRequestHandler<FindTeachersRequest, FindTeac
                 Trn = a.dfeta_TRN,
                 EmailAddresses = !string.IsNullOrEmpty(a.EMailAddress1) ? new[] { a.EMailAddress1 } : Array.Empty<string>(),
                 FirstName = a.FirstName,
+                MiddleName = a.MiddleName,
                 LastName = a.LastName,
                 DateOfBirth = a.BirthDate.HasValue ? DateOnly.FromDateTime(a.BirthDate.Value) : null,
                 NationalInsuranceNumber = a.dfeta_NINumber,

--- a/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/FindTeacherResult.cs
+++ b/QualifiedTeachersApi/src/QualifiedTeachersApi/V2/Responses/FindTeacherResult.cs
@@ -5,6 +5,7 @@ public record FindTeacherResult
     public required string Trn { get; set; }
     public required string[] EmailAddresses { get; set; }
     public required string FirstName { get; set; }
+    public required string MiddleName { get; set; }
     public required string LastName { get; set; }
     public required DateOnly? DateOfBirth { get; set; }
     public required string? NationalInsuranceNumber { get; set; }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetTeachersByInitialTeacherTrainingSlugIdTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/DataverseIntegration/GetTeachersByInitialTeacherTrainingSlugIdTests.cs
@@ -53,15 +53,7 @@ public class GetTeachersByInitialTeacherTrainingSlugIdTests : IAsyncLifetime
 
         // Assert
         Assert.NotEmpty(result);
-        Assert.Collection(result,
-            item1 =>
-            {
-                Assert.Equal(teacher1Id, item1.Id);
-            },
-            item2 =>
-            {
-                Assert.Equal(teacher2Id, item2.Id);
-            }
-        );
+        Assert.Contains(result, item => item.Id == teacher1Id);
+        Assert.Contains(result, item => item.Id == teacher2Id);
     }
 }

--- a/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/FindTeachersTests.cs
+++ b/QualifiedTeachersApi/tests/QualifiedTeachersApi.Tests/V2/Operations/FindTeachersTests.cs
@@ -44,6 +44,7 @@ public class FindTeachersTests : ApiTestBase
         var contact1 = new Contact()
         {
             FirstName = "test",
+            MiddleName = "tester",
             LastName = "testing",
             Id = Guid.NewGuid(),
             dfeta_NINumber = "1111",
@@ -72,6 +73,7 @@ public class FindTeachersTests : ApiTestBase
                          trn = contact1.dfeta_TRN,
                          emailAddresses = Array.Empty<string>(),
                          firstName = contact1.FirstName,
+                         middleName = contact1.MiddleName,
                          lastName = contact1.LastName,
                          dateOfBirth = DateOnly.FromDateTime(contact1.BirthDate.Value).ToString("yyyy-MM-dd"),
                          nationalInsuranceNumber = contact1.dfeta_NINumber,
@@ -117,6 +119,7 @@ public class FindTeachersTests : ApiTestBase
         var contact1 = new Contact()
         {
             FirstName = "test",
+            MiddleName = "tester",
             LastName = "testing",
             Id = Guid.NewGuid(),
             dfeta_NINumber = "1111",
@@ -155,6 +158,7 @@ public class FindTeachersTests : ApiTestBase
                          trn = contact1.dfeta_TRN,
                          emailAddresses = Array.Empty<string>(),
                          firstName = contact1.FirstName,
+                         middleName = contact1.MiddleName,
                          lastName = contact1.LastName,
                          dateOfBirth = DateOnly.FromDateTime(contact1.BirthDate.Value).ToString("yyyy-MM-dd"),
                          nationalInsuranceNumber = contact1.dfeta_NINumber,
@@ -173,6 +177,7 @@ public class FindTeachersTests : ApiTestBase
         var contact1 = new Contact()
         {
             FirstName = "test",
+            MiddleName = "tester",
             LastName = "testing",
             Id = Guid.NewGuid(),
             dfeta_NINumber = "1111",
@@ -199,7 +204,7 @@ public class FindTeachersTests : ApiTestBase
     public async Task Given_search_returns_a_result_with_no_active_sanctions_returns_expected_response()
     {
         // Arrange
-        var contact1 = new Contact() { FirstName = "test", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 2, 1), dfeta_TRN = "someReference", dfeta_ActiveSanctions = null };
+        var contact1 = new Contact() { FirstName = "test", MiddleName = "tester", LastName = "testing", Id = Guid.NewGuid(), dfeta_NINumber = "1111", BirthDate = new DateTime(1988, 2, 1), dfeta_TRN = "someReference", dfeta_ActiveSanctions = null };
         ApiFixture.DataverseAdapter
             .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersQuery>()))
             .ReturnsAsync(new[] { contact1 });
@@ -221,6 +226,7 @@ public class FindTeachersTests : ApiTestBase
                          trn = contact1.dfeta_TRN,
                          emailAddresses = Array.Empty<string>(),
                          firstName = contact1.FirstName,
+                         middleName = contact1.MiddleName,
                          lastName = contact1.LastName,
                          dateOfBirth = DateOnly.FromDateTime(contact1.BirthDate.Value).ToString("yyyy-MM-dd"),
                          nationalInsuranceNumber = contact1.dfeta_NINumber,
@@ -241,6 +247,7 @@ public class FindTeachersTests : ApiTestBase
         var contact1 = new Contact()
         {
             FirstName = "test",
+            MiddleName = "tester",
             LastName = "testing",
             Id = Guid.NewGuid(),
             dfeta_NINumber = "1111",
@@ -270,6 +277,7 @@ public class FindTeachersTests : ApiTestBase
                          trn = contact1.dfeta_TRN,
                          emailAddresses = Array.Empty<string>(),
                          firstName = contact1.FirstName,
+                         middleName = contact1.MiddleName,
                          lastName = contact1.LastName,
                          dateOfBirth = DateOnly.FromDateTime(contact1.BirthDate.Value).ToString("yyyy-MM-dd"),
                          nationalInsuranceNumber = contact1.dfeta_NINumber,


### PR DESCRIPTION
### Context

ID needs a teacher’s middle name to be able to use it for the created ID account without an additional API call.

### Changes proposed in this pull request

Add MiddleName to each result on the V2 find endpoint’s response.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
