### PR TITLE
Treat SQL timeout exceptions as transient

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Services/DqtReporting/DqtReportingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Services/DqtReporting/DqtReportingService.cs
@@ -65,7 +65,8 @@ public partial class DqtReportingService : BackgroundService
             }
             catch (Exception ex)
             {
-                if (ex is SqlException sqlException && sqlException.IsTransient)
+                if (ex is SqlException sqlException &&
+                    (sqlException.IsTransient || sqlException.Message.StartsWith("Execution Timeout Expired.")))
                 {
                     _logger.LogWarning(ex, "Transient SQL exception thrown.");
                     continue;


### PR DESCRIPTION
We see SQL timeout exceptions from time to time from the reporting service and they're not currently treated as transient (meaning they're logged as errors and the service shuts down). This change is to treat those errors as transient. There doesn't seem to be a nicer way of checking these other than matching on the exception's `Message`.