### PR TITLE
Fix DQT dates for BST

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/DataverseAdapter.SetIttResultForTeacher.cs
@@ -101,21 +101,25 @@ public partial class DataverseAdapter
             lookupData.EarlyYearsTeacherStatusId,
             lookupData.QualifiedTeacherTrainedStatusId,
             lookupData.QualifiedTeacherAssessmentOnlyRouteId,
-            lookupData.QualifiedTeacherInternationalTeacherStatusId
-            );
+            lookupData.QualifiedTeacherInternationalTeacherStatusId);
 
         if (qtsLookupFailed.HasValue)
         {
             return (SetIttResultForTeacherResult.Failed(qtsLookupFailed.Value), null);
         }
 
-        if (isEarlyYears && lookupData.Teacher.dfeta_EYTSDate.HasValue && lookupData.Teacher.dfeta_EYTSDate.Value.ToDateOnly() != (assessmentDate.HasValue ? assessmentDate.Value : null))
+        if (assessmentDate.HasValue)
         {
-            return (SetIttResultForTeacherResult.Failed(SetIttResultForTeacherFailedReason.EytsDateMismatch), null);
-        }
-        else if (!isEarlyYears && lookupData.Teacher.dfeta_QTSDate.HasValue && lookupData.Teacher.dfeta_QTSDate.Value.ToDateOnly() != (assessmentDate.HasValue ? assessmentDate.Value : null))
-        {
-            return (SetIttResultForTeacherResult.Failed(SetIttResultForTeacherFailedReason.QtsDateMismatch), null);
+            if (isEarlyYears && lookupData.Teacher.dfeta_EYTSDate.HasValue &&
+                lookupData.Teacher.dfeta_EYTSDate.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true) != assessmentDate.Value)
+            {
+                return (SetIttResultForTeacherResult.Failed(SetIttResultForTeacherFailedReason.EytsDateMismatch), null);
+            }
+            else if (!isEarlyYears && lookupData.Teacher.dfeta_QTSDate.HasValue &&
+                lookupData.Teacher.dfeta_QTSDate.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true) != assessmentDate.Value)
+            {
+                return (SetIttResultForTeacherResult.Failed(SetIttResultForTeacherFailedReason.QtsDateMismatch), null);
+            }
         }
 
         var qtsUpdate = new dfeta_qtsregistration()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/DateTimeExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/DateTimeExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace TeachingRecordSystem.Api.DataStore.Crm;
+
+public static class DateTimeExtensions
+{
+    private static readonly TimeZoneInfo _gmt = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+
+    public static DateOnly ToDateOnlyWithDqtBstFix(this DateTime dateTime, bool isLocalTime) =>
+        DateOnly.FromDateTime(isLocalTime ? TimeZoneInfo.ConvertTimeFromUtc(dateTime, _gmt) : dateTime);
+
+    public static DateOnly? ToDateOnlyWithDqtBstFix(this DateTime? dateTime, bool isLocalTime) =>
+        dateTime.HasValue ? ToDateOnlyWithDqtBstFix(dateTime.Value, isLocalTime) : null;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/DateOnlyExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/DateOnlyExtensions.cs
@@ -6,9 +6,4 @@ public static class DateOnlyExtensions
 
     public static DateTime? ToDateTime(this DateOnly? dateOnly) =>
         dateOnly.HasValue ? dateOnly.Value.ToDateTime(new(), DateTimeKind.Utc) : null;
-
-    public static DateOnly ToDateOnly(this DateTime dateTime) => DateOnly.FromDateTime(dateTime);
-
-    public static DateOnly? ToDateOnly(this DateTime? dateTime) =>
-        dateTime.HasValue ? DateOnly.FromDateTime(dateTime.Value) : null;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -66,7 +66,7 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
 
             wasCreated = false;
             trn = teacher?.dfeta_TRN;
-            qtsDate = teacher?.dfeta_QTSDate?.ToDateOnly();
+            qtsDate = teacher?.dfeta_QTSDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true);
         }
         else
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetTeacherHandler.cs
@@ -80,15 +80,15 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
 
         return new GetTeacherResponse()
         {
-            DateOfBirth = teacher.BirthDate.ToDateOnly(),
+            DateOfBirth = teacher.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false),
             FirstName = teacher.FirstName,
             HasActiveSanctions = teacher.dfeta_ActiveSanctions == true,
             LastName = teacher.LastName,
             MiddleName = teacher.MiddleName,
             NationalInsuranceNumber = teacher.dfeta_NINumber,
             Trn = teacher.dfeta_TRN,
-            QtsDate = teacher.dfeta_QTSDate.ToDateOnly(),
-            EytsDate = teacher.dfeta_EYTSDate.ToDateOnly(),
+            QtsDate = teacher.dfeta_QTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+            EytsDate = teacher.dfeta_EYTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             HusId = teacher.dfeta_HUSID,
             EarlyYearsStatus = earlyYearsStatus is not null ?
                 new GetTeacherResponseEarlyYearsStatus()
@@ -99,8 +99,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 null,
             InitialTeacherTraining = itt.Select(i => new GetTeacherResponseInitialTeacherTraining()
             {
-                ProgrammeEndDate = i.dfeta_ProgrammeEndDate.ToDateOnly(),
-                ProgrammeStartDate = i.dfeta_ProgrammeStartDate.ToDateOnly(),
+                ProgrammeEndDate = i.dfeta_ProgrammeEndDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+                ProgrammeStartDate = i.dfeta_ProgrammeStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                 ProgrammeType = i.dfeta_ProgrammeType?.ConvertToEnum<dfeta_ITTProgrammeType, IttProgrammeType>(),
                 Result = i.dfeta_Result.HasValue ? i.dfeta_Result.Value.ConvertFromITTResult() : null,
                 Provider = new()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetTrnRequestHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetTrnRequestHandler.cs
@@ -52,7 +52,7 @@ public class GetTrnRequestHandler : IRequestHandler<GetTrnRequest, TrnRequestInf
         }
 
         var trn = teacher.dfeta_TRN;
-        var qtsDate = teacher.dfeta_QTSDate.ToDateOnly();
+        var qtsDate = teacher.dfeta_QTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true);
         var status = trn != null ? TrnRequestStatus.Completed : TrnRequestStatus.Pending;
 
         return new TrnRequestInfo()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Validators/SetNpqQualificationValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Validators/SetNpqQualificationValidator.cs
@@ -23,7 +23,7 @@ public class SetNpqQualificationValidator : AbstractValidator<SetNpqQualificatio
                     return;
                 }
 
-                if (ctx.InstanceToValidate.CompletionDate.Value > clock.UtcNow.Date.ToDateOnly())
+                if (ctx.InstanceToValidate.CompletionDate.Value > clock.Today)
                 {
                     ctx.AddFailure(ctx.PropertyName, StringResources.Errors_10019_Title);
                 }
@@ -31,7 +31,6 @@ public class SetNpqQualificationValidator : AbstractValidator<SetNpqQualificatio
                 {
                     ctx.AddFailure(ctx.PropertyName, StringResources.Errors_10022_Title);
                 }
-
             });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Endpoints/FindTeachersEndpoint.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Endpoints/FindTeachersEndpoint.cs
@@ -59,7 +59,7 @@ public class FindTeachersEndpoint : Endpoint<FindTeachersRequest, FindTeachersRe
             Results = results.Select(r => new FindTeachersResponseResult()
             {
                 Trn = r.dfeta_TRN,
-                DateOfBirth = r.BirthDate!.Value.ToDateOnly(),
+                DateOfBirth = r.BirthDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false),
                 FirstName = r.ResolveFirstName(),
                 MiddleName = r.ResolveMiddleName(),
                 LastName = r.ResolveLastName()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetEytsCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetEytsCertificateHandler.cs
@@ -56,7 +56,7 @@ public class GetEytsCertificateHandler : IRequestHandler<GetEytsCertificateReque
         {
             { FullNameFormField, fullName.ToString() },
             { TrnFormField, teacher.dfeta_TRN },
-            { EytsDateFormField, teacher.dfeta_EYTSDate!.Value.ToString("d MMMM yyyy") }
+            { EytsDateFormField, teacher.dfeta_EYTSDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true).ToString("d MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate("EYTS certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetInductionCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetInductionCertificateHandler.cs
@@ -78,7 +78,12 @@ public class GetInductionCertificateHandler : IRequestHandler<GetInductionCertif
         {
             { FullNameFormField, fullName.ToString() },
             { TrnFormField, request.Trn },
-            { InductionDateFormField, induction.dfeta_CompletionDate.HasValue ? induction.dfeta_CompletionDate.Value.ToString("d MMMM yyyy") : string.Empty }
+            {
+                InductionDateFormField,
+                induction.dfeta_CompletionDate.HasValue ?
+                    induction.dfeta_CompletionDate.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true).ToString("d MMMM yyyy") :
+                    string.Empty
+            }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate("Induction certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetNpqCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetNpqCertificateHandler.cs
@@ -70,7 +70,7 @@ public class GetNpqCertificateHandler : IRequestHandler<GetNpqCertificateRequest
         var fieldValues = new Dictionary<string, string>()
         {
             { FullNameFormField, fullName.ToString() },
-            { PassDateFormField, qualification.dfeta_CompletionorAwardDate.Value.ToString("d MMMM yyyy") }
+            { PassDateFormField, qualification.dfeta_CompletionorAwardDate.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true).ToString("d MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate($"{qualification.dfeta_Type} Certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetQtsCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetQtsCertificateHandler.cs
@@ -56,7 +56,7 @@ public class GetQtsCertificateHandler : IRequestHandler<GetQtsCertificateRequest
         {
             { QtsFormNameField, fullName.ToString() },
             { QtsFormTrnField, teacher.dfeta_TRN },
-            { QtsFormDateField, teacher.dfeta_QTSDate!.Value.ToString("d MMMM yyyy") }
+            { QtsFormDateField, teacher.dfeta_QTSDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true).ToString("d MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate("QTS certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
@@ -197,12 +197,12 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             FirstName = firstName,
             MiddleName = middleName,
             LastName = lastName,
-            DateOfBirth = teacher.BirthDate!.Value.ToDateOnly(),
+            DateOfBirth = teacher.BirthDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false),
             NationalInsuranceNumber = teacher.dfeta_NINumber,
             PendingNameChange = request.Include.HasFlag(GetTeacherRequestIncludes.PendingDetailChanges) ? Option.Some(pendingNameChange) : default,
             PendingDateOfBirthChange = request.Include.HasFlag(GetTeacherRequestIncludes.PendingDetailChanges) ? Option.Some(pendingDateOfBirthChange) : default,
-            Qts = MapQts(teacher.dfeta_QTSDate?.ToDateOnly(), request.AccessMode),
-            Eyts = MapEyts(teacher.dfeta_EYTSDate?.ToDateOnly(), request.AccessMode),
+            Qts = MapQts(teacher.dfeta_QTSDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), request.AccessMode),
+            Eyts = MapEyts(teacher.dfeta_EYTSDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), request.AccessMode),
             Induction = request.Include.HasFlag(GetTeacherRequestIncludes.Induction) ?
                 Option.Some(MapInduction(induction!, inductionPeriods!, request.AccessMode)) :
                 default,
@@ -211,8 +211,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 {
                     Qualification = MapIttQualification(i),
                     ProgrammeType = i.dfeta_ProgrammeType?.ConvertToEnum<dfeta_ITTProgrammeType, IttProgrammeType>(),
-                    StartDate = i.dfeta_ProgrammeStartDate.ToDateOnly(),
-                    EndDate = i.dfeta_ProgrammeEndDate.ToDateOnly(),
+                    StartDate = i.dfeta_ProgrammeStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+                    EndDate = i.dfeta_ProgrammeEndDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                     Result = i.dfeta_Result.HasValue ? i.dfeta_Result.Value.ConvertFromITTResult() : null,
                     AgeRange = MapAgeRange(i.dfeta_AgeRangeFrom, i.dfeta_AgeRangeTo),
                     Provider = MapIttProvider(i),
@@ -253,8 +253,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
         induction != null ?
             new GetTeacherResponseInduction()
             {
-                StartDate = induction.dfeta_StartDate.ToDateOnly(),
-                EndDate = induction.dfeta_CompletionDate.ToDateOnly(),
+                StartDate = induction.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+                EndDate = induction.dfeta_CompletionDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                 Status = MapInductionStatus(induction.dfeta_InductionStatus),
                 CertificateUrl =
                     (induction.dfeta_InductionStatus == dfeta_InductionStatus.Pass || induction.dfeta_InductionStatus == dfeta_InductionStatus.PassedinWales) &&
@@ -271,8 +271,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
 
         return new GetTeacherResponseInductionPeriod()
         {
-            StartDate = inductionPeriod.dfeta_StartDate.ToDateOnly(),
-            EndDate = inductionPeriod.dfeta_EndDate.ToDateOnly(),
+            StartDate = inductionPeriod.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+            EndDate = inductionPeriod.dfeta_EndDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             Terms = inductionPeriod.dfeta_Numberofterms,
             AppropriateBody = new GetTeacherResponseInductionPeriodAppropriateBody()
             {
@@ -379,7 +379,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 && q.dfeta_CompletionorAwardDate.HasValue)
             .Select(q => new GetTeacherResponseNpqQualificationsQualification()
             {
-                Awarded = q.dfeta_CompletionorAwardDate!.Value.ToDateOnly(),
+                Awarded = q.dfeta_CompletionorAwardDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                 Type = new GetTeacherResponseNpqQualificationsQualificationType()
                 {
                     Code = MapNpqQualificationType(q.dfeta_Type!.Value),
@@ -412,7 +412,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 && q.dfeta_MQ_Date.HasValue)
             .Select(mq => new
             {
-                Awarded = mq.dfeta_MQ_Date!.Value.ToDateOnly(),
+                Awarded = mq.dfeta_MQ_Date!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                 Specialism = mq.Extract<dfeta_specialism>(dfeta_specialism.EntityLogicalName, dfeta_specialism.PrimaryIdAttribute)
             })
             .Where(mq => mq.Specialism != null)
@@ -465,7 +465,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             return new GetTeacherResponseHigherEducationQualificationsQualification
             {
                 Name = heQualification.dfeta_name,
-                Awarded = q.dfeta_CompletionorAwardDate.ToDateOnly(),
+                Awarded = q.dfeta_CompletionorAwardDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                 Subjects = heSubjects.ToArray()
             };
         })

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/DataverseIntegration/CreateDateOfBirthChangeIncidentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/DataverseIntegration/CreateDateOfBirthChangeIncidentTests.cs
@@ -26,7 +26,7 @@ public class CreateDateOfBirthChangeIncidentTests : IAsyncLifetime
         // Arrange
         var createPersonResult = await _dataScope.CreateTestDataHelper().CreatePerson();
 
-        var newDateOfBirth = Faker.Identification.DateOfBirth().ToDateOnly();
+        var newDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
         var evidenceFileName = "evidence.txt";
         var evidenceFileContent = new MemoryStream(Encoding.UTF8.GetBytes("Test file"));
         var evidenceFileMimeType = "text/plain";
@@ -52,7 +52,7 @@ public class CreateDateOfBirthChangeIncidentTests : IAsyncLifetime
         Assert.NotNull(createdIncident);
         Assert.Equal(createPersonResult.TeacherId, createdIncident.CustomerId.Id);
         Assert.Equal("Request to change date of birth", createdIncident.Title);
-        Assert.Equal(newDateOfBirth, createdIncident.dfeta_NewDateofBirth?.ToDateOnly());
+        Assert.Equal(newDateOfBirth, DateOnly.FromDateTime(createdIncident.dfeta_NewDateofBirth!.Value));
         Assert.Equal(command.FromIdentity, createdIncident.dfeta_FromIdentity);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/CreateDateOfBirthChangeTests.cs
@@ -54,7 +54,7 @@ public class CreateDateOfBirthChangeTests : ApiTestBase
         // Arrange
         var trn = "1234567";
         var contactId = Guid.NewGuid();
-        var newDateOfBirth = Faker.Identification.DateOfBirth().ToDateOnly();
+        var newDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
 
         var evidenceFileName = "evidence.txt";
         var evidenceFileUrl = Faker.Internet.SecureUrl();
@@ -88,7 +88,7 @@ public class CreateDateOfBirthChangeTests : ApiTestBase
         // Arrange
         var trn = "1234567";
         var contactId = Guid.NewGuid();
-        var newDateOfBirth = Faker.Identification.DateOfBirth().ToDateOnly();
+        var newDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
 
         var evidenceFileName = "evidence.txt";
         var evidenceFileUrl = Faker.Internet.SecureUrl();
@@ -126,7 +126,7 @@ public class CreateDateOfBirthChangeTests : ApiTestBase
         // Arrange
         var trn = "1234567";
         var contactId = Guid.NewGuid();
-        var newDateOfBirth = Faker.Identification.DateOfBirth().ToDateOnly();
+        var newDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
 
         var evidenceFileName = "evidence.txt";
         var evidenceFileUrl = Faker.Internet.SecureUrl();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
@@ -586,7 +586,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
         var firstName2 = Faker.Name.First();
         var lastName = Faker.Name.Last();
         var middleName = Faker.Name.Middle();
-        var dateOfBirth = Faker.Identification.DateOfBirth().ToDateOnly();
+        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
         var nino = Faker.Identification.UkNationalInsuranceNumber();
 
         var qtsDate = new DateOnly(1997, 4, 23);


### PR DESCRIPTION
Most custom fields in DQT have incorrectly been set up as local instead of UTC. This change applies a correction before we truncate the `DateTime` to a `DateOnly`.