### PR TITLE
Add ReadOnlyMode config value for AKS and PAAS environments

### DIFF
--- a/terraform/aks/app.tf
+++ b/terraform/aks/app.tf
@@ -28,6 +28,7 @@ module "api_application_configuration" {
     DqtReporting__RunService                       = "false"
     GetAnIdentity__RunLinkTrnToIdentityUserService = "false"
     RecurringJobs__Enabled                         = "false"
+    ReadOnlyMode                                   = "true"
   }
 
   secret_variables = {

--- a/terraform/paas/app.tf
+++ b/terraform/paas/app.tf
@@ -19,7 +19,8 @@ locals {
         "DistributedLockContainerName"         = local.distributed_lock_container_name,
         "PlatformEnvironment"                  = var.environment_name,
         "StorageConnectionString"              = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.app-storage.name};AccountKey=${azurerm_storage_account.app-storage.primary_access_key}",
-        "Platform"                             = "PAAS"
+        "Platform"                             = "PAAS",
+        "ReadOnlyMode"                         = "false"
       }
     ))
   }


### PR DESCRIPTION
`ReadOnlyMode` is a mode the API can run in where the endpoints that require a local database are disabled. This is done so that we can migrate from PAAS to AKS with only partial unavailability. This change sets the flag for AKS environments to `true` in preparation for that move. I've also set it explicitly for PAAS environments to `false` so it's easy to see where to flip the values when the time comes.