### PR TITLE
Deploy DB migrations to k8s environments

### DIFF
--- a/.github/workflows/actions/deploy-aks-environment/action.yml
+++ b/.github/workflows/actions/deploy-aks-environment/action.yml
@@ -7,6 +7,9 @@ inputs:
   api_docker_image:
     description: 'The API Docker image to deploy to the environment'
     required: true
+  cli_docker_image:
+    description: 'The CLI Docker image to deploy to the environment'
+    required: true
   ui_docker_image:
     description: 'The Support UI Docker image to deploy to the environment'
     required: true
@@ -34,5 +37,6 @@ runs:
       env:
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
         TF_VAR_api_docker_image: ${{ inputs.api_docker_image }}
+        TF_VAR_cli_docker_image: ${{ inputs.cli_docker_image }}
         TF_VAR_ui_docker_image: ${{ inputs.ui_docker_image }}
       shell: bash

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,6 +6,9 @@ on:
       api_docker_image:
         type: string
         required: true
+      cli_docker_image:
+        type: string
+        required: true
       ui_docker_image:
         type: string
         required: true
@@ -52,6 +55,7 @@ jobs:
       with:
         environment_name: dev
         api_docker_image: ${{ inputs.api_docker_image }}
+        cli_docker_image: ${{ inputs.cli_docker_image }}
         ui_docker_image: ${{ inputs.ui_docker_image }}
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,6 +5,8 @@ on:
     outputs:
       api_docker_image:
         value: ${{ jobs.package.outputs.api_image_tag }}
+      cli_docker_image:
+        value: ${{ jobs.package.outputs.cli_image_tag }}
       ui_docker_image:
         value: ${{ jobs.package.outputs.ui_image_tag }}
 
@@ -17,6 +19,7 @@ jobs:
 
     outputs:
       api_image_tag: ${{ steps.image_tags.outputs.api_tag }}
+      cli_image_tag: ${{ steps.image_tags.outputs.cli_tag }}
       ui_image_tag: ${{ steps.image_tags.outputs.ui_tag }}
 
     steps:
@@ -28,6 +31,7 @@ jobs:
         id: image_tags
         run: |
           echo "api_tag=$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):api-$GITHUB_SHA" >> $GITHUB_OUTPUT
+          echo "cli_tag=$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):cli-$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo "ui_tag=$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):ui-$GITHUB_SHA" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
@@ -42,8 +46,12 @@ jobs:
           just docker-build-api --build-arg GIT_SHA=$GITHUB_SHA --tag $API_TAG
           docker push $API_TAG
 
+          just docker-build-cli --tag $CLI_TAG
+          docker push $CLI_TAG
+
           just docker-build-ui --build-arg GIT_SHA=$GITHUB_SHA --tag $UI_TAG
           docker push $UI_TAG
         env:
           API_TAG: ${{ steps.image_tags.outputs.api_tag }}
+          CLI_TAG: ${{ steps.image_tags.outputs.cli_tag }}
           UI_TAG: ${{ steps.image_tags.outputs.ui_tag }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,5 +194,6 @@ jobs:
     uses: ./.github/workflows/deploy-dev.yml
     with:
       api_docker_image: ${{ needs.package.outputs.api_docker_image }}
+      cli_docker_image: ${{ needs.package.outputs.cli_docker_image }}
       ui_docker_image: ${{ needs.package.outputs.ui_docker_image }}
     secrets: inherit

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Dockerfile
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Dockerfile
@@ -1,0 +1,5 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/dotnet/sdk:7.0
+COPY src/TeachingRecordSystem.Cli/bin/Release/net7.0/publish/ TrsCli/
+WORKDIR /TrsCli
+ENV PATH="${PATH}:/TrsCli"

--- a/justfile
+++ b/justfile
@@ -63,6 +63,11 @@ docker-build-api *ARGS:
   @cd {{solution-root / "src" / "TeachingRecordSystem.Cli"}} && dotnet publish -c Release
   @cd {{solution-root}} && docker build . -f {{"src" / "TeachingRecordSystem.Api" / "Dockerfile"}} {{ARGS}}
 
+# Build the CLI Docker image
+docker-build-cli *ARGS:
+  @cd {{solution-root / "src" / "TeachingRecordSystem.Cli"}} && dotnet publish -c Release
+  @cd {{solution-root}} && docker build . -f {{"src" / "TeachingRecordSystem.Cli" / "Dockerfile"}} {{ARGS}}
+
 # Build the Support UI Docker image
 docker-build-ui *ARGS:
   @cd {{solution-root / "src" / "TeachingRecordSystem.SupportUi"}} && dotnet publish -c Release

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -54,6 +54,10 @@ variable "api_docker_image" {
   type = string
 }
 
+variable "cli_docker_image" {
+  type = string
+}
+
 variable "ui_docker_image" {
   type = string
 }


### PR DESCRIPTION
This uses a kubernetes job that invokes the `trscli`. The API and UI deployments are made dependent on this job so that they're not deployed until the job completes successfully.