### PR TITLE
Amended to make format of dates on certificates independent of current culture

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetEytsCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetEytsCertificateHandler.cs
@@ -56,7 +56,7 @@ public class GetEytsCertificateHandler : IRequestHandler<GetEytsCertificateReque
         {
             { FullNameFormField, fullName.ToString() },
             { TrnFormField, teacher.dfeta_TRN },
-            { EytsDateFormField, teacher.dfeta_EYTSDate!.Value.ToString("dd MMMM yyyy") }
+            { EytsDateFormField, teacher.dfeta_EYTSDate!.Value.ToString("d MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate("EYTS certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetEytsCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetEytsCertificateHandler.cs
@@ -56,7 +56,7 @@ public class GetEytsCertificateHandler : IRequestHandler<GetEytsCertificateReque
         {
             { FullNameFormField, fullName.ToString() },
             { TrnFormField, teacher.dfeta_TRN },
-            { EytsDateFormField, teacher.dfeta_EYTSDate!.Value.ToLongDateString() }
+            { EytsDateFormField, teacher.dfeta_EYTSDate!.Value.ToString("dd MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate("EYTS certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetNpqCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetNpqCertificateHandler.cs
@@ -70,7 +70,7 @@ public class GetNpqCertificateHandler : IRequestHandler<GetNpqCertificateRequest
         var fieldValues = new Dictionary<string, string>()
         {
             { FullNameFormField, fullName.ToString() },
-            { PassDateFormField, qualification.dfeta_CompletionorAwardDate.Value.ToLongDateString() }
+            { PassDateFormField, qualification.dfeta_CompletionorAwardDate.Value.ToString("dd MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate($"{qualification.dfeta_Type} Certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetNpqCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetNpqCertificateHandler.cs
@@ -70,7 +70,7 @@ public class GetNpqCertificateHandler : IRequestHandler<GetNpqCertificateRequest
         var fieldValues = new Dictionary<string, string>()
         {
             { FullNameFormField, fullName.ToString() },
-            { PassDateFormField, qualification.dfeta_CompletionorAwardDate.Value.ToString("dd MMMM yyyy") }
+            { PassDateFormField, qualification.dfeta_CompletionorAwardDate.Value.ToString("d MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate($"{qualification.dfeta_Type} Certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetQtsCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetQtsCertificateHandler.cs
@@ -56,7 +56,7 @@ public class GetQtsCertificateHandler : IRequestHandler<GetQtsCertificateRequest
         {
             { QtsFormNameField, fullName.ToString() },
             { QtsFormTrnField, teacher.dfeta_TRN },
-            { QtsFormDateField, teacher.dfeta_QTSDate!.Value.ToString("dd MMMM yyyy") }
+            { QtsFormDateField, teacher.dfeta_QTSDate!.Value.ToString("d MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate("QTS certificate.pdf", fieldValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetQtsCertificateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetQtsCertificateHandler.cs
@@ -56,7 +56,7 @@ public class GetQtsCertificateHandler : IRequestHandler<GetQtsCertificateRequest
         {
             { QtsFormNameField, fullName.ToString() },
             { QtsFormTrnField, teacher.dfeta_TRN },
-            { QtsFormDateField, teacher.dfeta_QTSDate!.Value.ToLongDateString() }
+            { QtsFormDateField, teacher.dfeta_QTSDate!.Value.ToString("dd MMMM yyyy") }
         };
 
         var pdfStream = await _certificateGenerator.GenerateCertificate("QTS certificate.pdf", fieldValues);


### PR DESCRIPTION
### Context

When executing in different environments date on certificates is in different (longer format).

### Changes proposed in this pull request

Amend so that date is always in the same format independent of current culture.

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
