### PR TITLE
Handle a removed TRN in ID webhook

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/DataverseAdapter.CreateTeacher.cs
@@ -57,7 +57,7 @@ public partial class DataverseAdapter
 
         if (allocateTrn)
         {
-            trn = await _trnGenerationApiClient.GenerateTrn();
+            trn = await GenerateTrn();
             newContact.dfeta_TRN = trn;
         }
         else

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/IDataverseAdapter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/IDataverseAdapter.cs
@@ -103,4 +103,6 @@ public interface IDataverseAdapter
     Task<EytsAwardee[]> GetEytsAwardeesForDateRange(DateTime startDate, DateTime endDate);
 
     Task<InductionCompletee[]> GetInductionCompleteesForDateRange(DateTime startDate, DateTime endDate);
+
+    Task ClearTeacherIdentityInfo(Guid identityUserId, DateTime updateTimeUtc);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Json/JsonSerializerOptionsExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Json/JsonSerializerOptionsExtensions.cs
@@ -9,7 +9,6 @@ public static class JsonSerializerOptionsExtensions
     public static JsonSerializerOptions AddConverters(this JsonSerializerOptions options)
     {
         options.Converters.Add(new JsonStringEnumConverter());
-        options.Converters.Add(new NotificationEnvelopeConverter());
 
         return options;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Services/GetAnIdentity/WebHooks/UserUpdatedHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Services/GetAnIdentity/WebHooks/UserUpdatedHandler.cs
@@ -27,6 +27,12 @@ public class UserUpdatedHandler : IRequestHandler<UserUpdatedRequest>
     {
         if (request.Trn is null)
         {
+            if (request.ChangedTrn.HasValue)
+            {
+                // TRN has been removed
+                await _dataverseAdapter.ClearTeacherIdentityInfo(request.UserId, request.UpdateTimeUtc);
+            }
+
             return;
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Services/GetAnIdentity/WebHooks/UserUpdatedMessage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Services/GetAnIdentity/WebHooks/UserUpdatedMessage.cs
@@ -1,8 +1,16 @@
-﻿namespace TeachingRecordSystem.Api.Services.GetAnIdentity.WebHooks;
+﻿using Optional;
+
+namespace TeachingRecordSystem.Api.Services.GetAnIdentity.WebHooks;
 
 public record UserUpdatedMessage : INotificationMessage
 {
     public const string MessageTypeName = "UserUpdated";
 
     public required User User { get; init; }
+    public required UserUpdatedMessageChanges Changes { get; init; }
+}
+
+public record UserUpdatedMessageChanges
+{
+    public required Option<string?> Trn { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Services/GetAnIdentity/WebHooks/UserUpdatedRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Services/GetAnIdentity/WebHooks/UserUpdatedRequest.cs
@@ -1,12 +1,14 @@
 ﻿using MediatR;
+using Optional;
 
 namespace TeachingRecordSystem.Api.Services.GetAnIdentity.WebHooks;
 
 public class UserUpdatedRequest : IRequest
 {
-    public required Guid UserId { get; set; }
+    public required Guid UserId { get; init; }
     public required string? Trn { get; init; }
-    public required string EmailAddress { get; set; }
-    public required string? MobileNumber { get; set; }
-    public required DateTime UpdateTimeUtc { get; set; }
+    public required string EmailAddress { get; init; }
+    public required string? MobileNumber { get; init; }
+    public required DateTime UpdateTimeUtc { get; init; }
+    public required Option<string?> ChangedTrn { get; init; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/DataverseIntegration/ClearTeacherIdentityInfoTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/DataverseIntegration/ClearTeacherIdentityInfoTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Api.DataStore.Crm;
+using TeachingRecordSystem.Api.DataStore.Crm.Models;
+using Xunit;
+
+namespace TeachingRecordSystem.Api.Tests.DataverseIntegration;
+
+public class ClearTeacherIdentityInfoTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly DataverseAdapter _dataverseAdapter;
+    private readonly IOrganizationServiceAsync _organizationService;
+
+    public ClearTeacherIdentityInfoTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _dataverseAdapter = _dataScope.CreateDataverseAdapter();
+        _organizationService = _dataScope.OrganizationService;
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task ContactExistsWithIdentityUserId_ClearsTsPersonId()
+    {
+        // Arrange
+        var identityUserId = Guid.NewGuid();
+        var trn = await _dataverseAdapter.GenerateTrn();
+        var updateTimeUtc = DateTime.UtcNow;
+
+        var contactId = await _organizationService.CreateAsync(new Contact()
+        {
+            dfeta_TSPersonID = identityUserId.ToString(),
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            dfeta_TRN = trn
+        });
+
+        // Act
+        await _dataverseAdapter.ClearTeacherIdentityInfo(identityUserId, updateTimeUtc);
+
+        // Assert
+        var contact = (await _organizationService.RetrieveAsync(
+            Contact.EntityLogicalName,
+            contactId,
+            new ColumnSet(Contact.Fields.dfeta_TSPersonID, Contact.Fields.dfeta_LastIdentityUpdate))).ToEntity<Contact>();
+
+        Assert.Null(contact.dfeta_TSPersonID);
+        Assert.Equal(updateTimeUtc, contact.dfeta_LastIdentityUpdate!.Value, precision: TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task NoContactWithTsPersonId_Succeeds()
+    {
+        // Arrange
+        var identityUserId = Guid.NewGuid();
+        var updateTimeUtc = DateTime.UtcNow;
+
+        // Act
+        await _dataverseAdapter.ClearTeacherIdentityInfo(identityUserId, updateTimeUtc);
+
+        // Assert
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TeachingRecordSystem.TestCommon.csproj
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TeachingRecordSystem.TestCommon.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectCapability Remove="TestContainer" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>


### PR DESCRIPTION
If a TRN is unlinked from an ID account then remove the link in DQT too. The fields that were synchronised are left untouched.

Also separated webhook-specific serializer configuration out from the main API serializer settings as they may well need to vary. Amended tests to avoid double serialization too.